### PR TITLE
fix: 修复构建脚本中 rmSync 无法删除目录符号链接的问题

### DIFF
--- a/scripts/build-electron.mjs
+++ b/scripts/build-electron.mjs
@@ -15,7 +15,7 @@ function resolveStandaloneSymlinks() {
       const target = fs.readlinkSync(fullPath);
       const resolved = path.resolve(standaloneModules, target);
       if (fs.existsSync(resolved)) {
-        fs.rmSync(fullPath);
+        fs.rmSync(fullPath, { recursive: true, force: true });
         fs.cpSync(resolved, fullPath, { recursive: true });
         console.log(`Resolved symlink: ${entry} -> ${target}`);
       }


### PR DESCRIPTION
## 问题

执行 `npm run electron:build` 时，`scripts/build-electron.mjs` 在解析 `.next/standalone/.next/node_modules/` 中的符号链接时报错：

```
Error: Path is a directory: .next/standalone/.next/node_modules/better-sqlite3-90e2652d1716b047
    at Object.rmSync (node:fs:1236:18)
    at resolveStandaloneSymlinks (file:///...CodePilot/scripts/build-electron.mjs:18:12)
```

部分条目（如 `better-sqlite3-90e2652d1716b047`）是指向目录的符号链接，`fs.rmSync()` 在未传入 `{ recursive: true }` 时会抛出 `ERR_FS_EISDIR` 错误。

## 修复

为 `fs.rmSync()` 添加 `{ recursive: true, force: true }` 参数。