### PR TITLE
feat: support x64/arm64 macOS builds and fix build script errors

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -43,7 +43,7 @@ mac:
   category: public.app-category.developer-tools
   target:
     - target: dmg
-      arch: [arm64]
+      arch: [arm64, x64]
 win:
   icon: build/icon.ico
   target:

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,6 +11,8 @@ const eslintConfig = defineConfig([
     ".next/**",
     "out/**",
     "build/**",
+    "release/**",
+    "dist-electron/**",
     "next-env.d.ts",
   ]),
 ]);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "opus-4.6-test",
-  "version": "0.1.0",
+  "name": "codepilot",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "opus-4.6-test",
-      "version": "0.1.0",
+      "name": "codepilot",
+      "version": "0.2.2",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.33",
         "@hugeicons/core-free-icons": "^3.1.1",

--- a/scripts/build-electron.mjs
+++ b/scripts/build-electron.mjs
@@ -15,7 +15,7 @@ function resolveStandaloneSymlinks() {
       const target = fs.readlinkSync(fullPath);
       const resolved = path.resolve(standaloneModules, target);
       if (fs.existsSync(resolved)) {
-        fs.rmSync(fullPath);
+        fs.rmSync(fullPath, { recursive: true, force: true });
         fs.cpSync(resolved, fullPath, { recursive: true });
         console.log(`Resolved symlink: ${entry} -> ${target}`);
       }


### PR DESCRIPTION
This PR introduces several improvements to the build process to support both Intel (x64) and Apple Silicon (arm64) macOS users.

**Changes:**
- **Build Configuration**: Updated electron-builder.yml to include x64 in the macOS target architectures.
- **Build Script Fix**: Modified build-electron.mjs to use fs.rmSync with { recursive: true, force: true }. This fixes an ERR_FS_EISDIR error when handling directory symlinks during the standalone build process.
- **Lint Configuration**: Added release/ and dist-electron/ to eslint.config.mjs to prevent ESLint from scanning minified build artifacts.
- **Lockfile Cleanup**: Standardized the project name in package-lock.json to codepilot.

**Verification:**
- Successfully built .dmg packages for both x64 and arm64 architectures.
- Verified binary architectures using the file command.