### PR TITLE
feat: add OpenRouter as alternative API provider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "shiki": "^3.22.0",
         "streamdown": "^2.1.0",
         "tailwind-merge": "^3.4.0",
+        "undici": "^7.21.0",
         "use-stick-to-bottom": "^1.1.2",
         "uuid": "^13.0.0"
       },
@@ -471,6 +472,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1139,7 +1141,6 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -1161,7 +1162,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -1178,7 +1178,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -1193,7 +1192,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -3009,6 +3007,7 @@
       "integrity": "sha512-6LdVIUERWxQMmUSSQi0I53GgCBYgM2RpGngCPY7hSeju+VrKjq3lvs7HpJoPbDiY5QM5EYRtRX5fvrinnMAz3w==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "playwright": "1.58.1"
       },
@@ -5333,6 +5332,7 @@
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
       "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/unist": "*"
       }
@@ -5376,6 +5376,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.13.tgz",
       "integrity": "sha512-KkiJeU6VbYbUOp5ITMIc7kBfqlYkKA5KhEHVrGMmUUMt7NeaZg65ojdPk+FtNrBAOXNVM5QM72jnADjM+XVRAQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -5386,6 +5387,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -5494,6 +5496,7 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -6034,6 +6037,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6085,6 +6089,7 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -6811,6 +6816,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -7551,8 +7557,7 @@
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -7580,6 +7585,7 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
       "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -7989,6 +7995,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -8351,6 +8358,7 @@
       "integrity": "sha512-uOOBA3f+kW3o4KpSoMQ6SNpdXU7WtxlJRb9vCZgOvqhTz4b3GjcoWKstdisizNZLsylhTMv8TLHFPFW0Uxsj/g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.7.0",
         "builder-util": "26.4.1",
@@ -8681,7 +8689,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -8702,7 +8709,6 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -9061,6 +9067,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -9246,6 +9253,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -12525,6 +12533,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/debug": "^4.0.0",
         "debug": "^4.0.0",
@@ -13161,7 +13170,8 @@
           "url": "https://opencollective.com/unified"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -13416,7 +13426,6 @@
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -14406,7 +14415,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -14424,7 +14432,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -14709,6 +14716,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14718,6 +14726,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -15277,7 +15286,6 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -16422,7 +16430,6 @@
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -16550,6 +16557,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -16817,6 +16825,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -16880,6 +16889,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici": {
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.21.0.tgz",
+      "integrity": "sha512-Hn2tCQpoDt1wv23a68Ctc8Cr/BHpUSfaPYrkajTXOS9IKpxVRx/X5m1K2YkbK2ipgZgxXSgsUinl3x+2YdSSfg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -16892,6 +16910,7 @@
       "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
       "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "bail": "^2.0.0",
@@ -17591,6 +17610,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "shiki": "^3.22.0",
     "streamdown": "^2.1.0",
     "tailwind-merge": "^3.4.0",
+    "undici": "^7.21.0",
     "use-stick-to-bottom": "^1.1.2",
     "uuid": "^13.0.0"
   },

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1,7 +1,8 @@
 import { NextRequest } from 'next/server';
 import { streamClaude } from '@/lib/claude-client';
+import { streamOpenRouter } from '@/lib/openrouter-client';
 import { addMessage, getSession, updateSessionTitle, updateSdkSessionId, getSetting } from '@/lib/db';
-import type { SendMessageRequest, SSEEvent, TokenUsage } from '@/types';
+import type { SendMessageRequest, SSEEvent, TokenUsage, ApiProvider } from '@/types';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -63,17 +64,33 @@ export async function POST(request: NextRequest) {
       abortController.abort();
     });
 
-    // Stream Claude response, using SDK session ID for resume if available
-    const stream = streamClaude({
-      prompt: content,
-      sessionId: session_id,
-      sdkSessionId: session.sdk_session_id || undefined,
-      model: effectiveModel,
-      systemPrompt: systemPromptOverride || session.system_prompt || undefined,
-      workingDirectory: session.working_directory || undefined,
-      abortController,
-      permissionMode,
-    });
+    // Determine which provider to use
+    const provider: ApiProvider = (getSetting('api_provider') as ApiProvider) || 'claude_code';
+
+    let stream: ReadableStream<string>;
+
+    if (provider === 'openrouter') {
+      // Use OpenRouter (OpenAI-compatible API)
+      stream = streamOpenRouter({
+        prompt: content,
+        sessionId: session_id,
+        model: effectiveModel,
+        systemPrompt: systemPromptOverride || session.system_prompt || undefined,
+        abortController,
+      });
+    } else {
+      // Use Claude Code Agent SDK (default)
+      stream = streamClaude({
+        prompt: content,
+        sessionId: session_id,
+        sdkSessionId: session.sdk_session_id || undefined,
+        model: effectiveModel,
+        systemPrompt: systemPromptOverride || session.system_prompt || undefined,
+        workingDirectory: session.working_directory || undefined,
+        abortController,
+        permissionMode,
+      });
+    }
 
     // Tee the stream: one for client, one for collecting the response
     const [streamForClient, streamForCollect] = stream.tee();

--- a/src/app/api/settings/app/route.ts
+++ b/src/app/api/settings/app/route.ts
@@ -9,6 +9,10 @@ import { getSetting, setSetting } from '@/lib/db';
 const ALLOWED_KEYS = [
   'anthropic_auth_token',
   'anthropic_base_url',
+  'api_provider',           // 'claude_code' | 'openrouter'
+  'openrouter_api_key',
+  'openrouter_base_url',
+  'openrouter_model',       // default OpenRouter model ID
 ];
 
 export async function GET() {
@@ -17,8 +21,8 @@ export async function GET() {
     for (const key of ALLOWED_KEYS) {
       const value = getSetting(key);
       if (value !== undefined) {
-        // Mask token for security (only return last 8 chars)
-        if (key === 'anthropic_auth_token' && value.length > 8) {
+        // Mask tokens for security (only return last 8 chars)
+        if ((key === 'anthropic_auth_token' || key === 'openrouter_api_key') && value.length > 8) {
           result[key] = '***' + value.slice(-8);
         } else {
           result[key] = value;
@@ -46,7 +50,7 @@ export async function PUT(request: NextRequest) {
       const strValue = String(value ?? '').trim();
       if (strValue) {
         // Don't overwrite token if user sent the masked version back
-        if (key === 'anthropic_auth_token' && strValue.startsWith('***')) {
+        if ((key === 'anthropic_auth_token' || key === 'openrouter_api_key') && strValue.startsWith('***')) {
           continue;
         }
         setSetting(key, strValue);

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -62,8 +62,15 @@ export default function SettingsPage() {
 
 // --- API Configuration Section (CodePilot app settings, stored in SQLite) ---
 function ApiConfigSection() {
+  const [provider, setProvider] = useState<"claude_code" | "openrouter">("claude_code");
+  // Claude Code settings
   const [token, setToken] = useState("");
   const [baseUrl, setBaseUrl] = useState("");
+  // OpenRouter settings
+  const [orApiKey, setOrApiKey] = useState("");
+  const [orBaseUrl, setOrBaseUrl] = useState("");
+  const [orModel, setOrModel] = useState("");
+
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [status, setStatus] = useState<"idle" | "saved" | "error">("idle");
@@ -73,8 +80,12 @@ function ApiConfigSection() {
       .then((r) => r.json())
       .then((data) => {
         const s = data.settings || {};
+        setProvider((s.api_provider as "claude_code" | "openrouter") || "claude_code");
         setToken(s.anthropic_auth_token || "");
         setBaseUrl(s.anthropic_base_url || "");
+        setOrApiKey(s.openrouter_api_key || "");
+        setOrBaseUrl(s.openrouter_base_url || "");
+        setOrModel(s.openrouter_model || "");
       })
       .catch(() => {})
       .finally(() => setLoading(false));
@@ -89,13 +100,19 @@ function ApiConfigSection() {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           settings: {
+            api_provider: provider,
             anthropic_auth_token: token,
             anthropic_base_url: baseUrl,
+            openrouter_api_key: orApiKey,
+            openrouter_base_url: orBaseUrl,
+            openrouter_model: orModel,
           },
         }),
       });
       if (res.ok) {
         setStatus("saved");
+        // Dispatch event so other components (e.g. MessageInput) can react
+        window.dispatchEvent(new CustomEvent("provider-changed", { detail: { provider } }));
         setTimeout(() => setStatus("idle"), 2000);
       } else {
         setStatus("error");
@@ -114,37 +131,142 @@ function ApiConfigSection() {
       <div>
         <Label className="text-sm font-medium">API Configuration</Label>
         <p className="text-xs text-muted-foreground">
-          Optional. Configure a custom Anthropic-compatible API for Claude Code.
-          Leave empty to use the default authentication (claude login / shell environment).
+          Choose your API provider and configure the connection settings.
         </p>
       </div>
-      <div className="space-y-3">
-        <div>
-          <Label htmlFor="api-base-url" className="text-xs text-muted-foreground">
-            API Base URL
-          </Label>
-          <Input
-            id="api-base-url"
-            placeholder="https://api.anthropic.com"
-            value={baseUrl}
-            onChange={(e) => setBaseUrl(e.target.value)}
-            className="mt-1 font-mono text-sm"
-          />
-        </div>
-        <div>
-          <Label htmlFor="api-token" className="text-xs text-muted-foreground">
-            API Token (ANTHROPIC_AUTH_TOKEN)
-          </Label>
-          <Input
-            id="api-token"
-            type="password"
-            placeholder="sk-ant-..."
-            value={token}
-            onChange={(e) => setToken(e.target.value)}
-            className="mt-1 font-mono text-sm"
-          />
+
+      {/* Provider selector */}
+      <div className="space-y-2">
+        <Label className="text-xs text-muted-foreground">Provider</Label>
+        <div className="flex gap-2">
+          <button
+            onClick={() => setProvider("claude_code")}
+            className={`flex-1 rounded-lg border px-3 py-2 text-sm transition-colors ${
+              provider === "claude_code"
+                ? "border-primary bg-primary/10 text-primary font-medium"
+                : "border-border hover:border-primary/50"
+            }`}
+          >
+            <div className="font-medium">Claude Code</div>
+            <div className="text-xs text-muted-foreground mt-0.5">
+              Uses Claude CLI (requires claude login)
+            </div>
+          </button>
+          <button
+            onClick={() => setProvider("openrouter")}
+            className={`flex-1 rounded-lg border px-3 py-2 text-sm transition-colors ${
+              provider === "openrouter"
+                ? "border-primary bg-primary/10 text-primary font-medium"
+                : "border-border hover:border-primary/50"
+            }`}
+          >
+            <div className="font-medium">OpenRouter</div>
+            <div className="text-xs text-muted-foreground mt-0.5">
+              OpenAI-compatible API, supports many models
+            </div>
+          </button>
         </div>
       </div>
+
+      {/* Claude Code settings */}
+      {provider === "claude_code" && (
+        <div className="space-y-3 rounded-lg border border-border/30 p-3">
+          <p className="text-xs text-muted-foreground">
+            Optional. Leave empty to use default authentication (claude login).
+          </p>
+          <div>
+            <Label htmlFor="api-base-url" className="text-xs text-muted-foreground">
+              API Base URL
+            </Label>
+            <Input
+              id="api-base-url"
+              placeholder="https://api.anthropic.com"
+              value={baseUrl}
+              onChange={(e) => setBaseUrl(e.target.value)}
+              className="mt-1 font-mono text-sm"
+            />
+          </div>
+          <div>
+            <Label htmlFor="api-token" className="text-xs text-muted-foreground">
+              API Token (ANTHROPIC_AUTH_TOKEN)
+            </Label>
+            <Input
+              id="api-token"
+              type="password"
+              placeholder="sk-ant-..."
+              value={token}
+              onChange={(e) => setToken(e.target.value)}
+              className="mt-1 font-mono text-sm"
+            />
+          </div>
+        </div>
+      )}
+
+      {/* OpenRouter settings */}
+      {provider === "openrouter" && (
+        <div className="space-y-3 rounded-lg border border-border/30 p-3">
+          <p className="text-xs text-muted-foreground">
+            Configure your OpenRouter API key. Get one at{" "}
+            <a
+              href="https://openrouter.ai/keys"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary underline"
+            >
+              openrouter.ai/keys
+            </a>
+          </p>
+          <div>
+            <Label htmlFor="or-api-key" className="text-xs text-muted-foreground">
+              API Key
+            </Label>
+            <Input
+              id="or-api-key"
+              type="password"
+              placeholder="sk-or-v1-..."
+              value={orApiKey}
+              onChange={(e) => setOrApiKey(e.target.value)}
+              className="mt-1 font-mono text-sm"
+            />
+          </div>
+          <div>
+            <Label htmlFor="or-base-url" className="text-xs text-muted-foreground">
+              Base URL (optional)
+            </Label>
+            <Input
+              id="or-base-url"
+              placeholder="https://openrouter.ai/api/v1"
+              value={orBaseUrl}
+              onChange={(e) => setOrBaseUrl(e.target.value)}
+              className="mt-1 font-mono text-sm"
+            />
+          </div>
+          <div>
+            <Label htmlFor="or-model" className="text-xs text-muted-foreground">
+              Default Model
+            </Label>
+            <Input
+              id="or-model"
+              placeholder="anthropic/claude-sonnet-4"
+              value={orModel}
+              onChange={(e) => setOrModel(e.target.value)}
+              className="mt-1 font-mono text-sm"
+            />
+            <p className="text-xs text-muted-foreground mt-1">
+              Browse models at{" "}
+              <a
+                href="https://openrouter.ai/models"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-primary underline"
+              >
+                openrouter.ai/models
+              </a>
+            </p>
+          </div>
+        </div>
+      )}
+
       <div className="flex items-center gap-3">
         <Button onClick={handleSave} disabled={saving} size="sm" className="gap-2">
           {saving ? (

--- a/src/components/chat/MessageInput.tsx
+++ b/src/components/chat/MessageInput.tsx
@@ -72,10 +72,24 @@ const MODE_OPTIONS: ModeOption[] = [
   { value: 'ask', label: 'Ask', icon: HelpCircleIcon, description: 'Answer questions only' },
 ];
 
-const MODEL_OPTIONS = [
+const CLAUDE_MODEL_OPTIONS = [
   { value: 'sonnet', label: 'Sonnet 4.5' },
   { value: 'opus', label: 'Opus 4.6' },
   { value: 'haiku', label: 'Haiku 4.5' },
+];
+
+const OPENROUTER_MODEL_OPTIONS = [
+  { value: 'anthropic/claude-sonnet-4', label: 'Claude Sonnet 4' },
+  { value: 'anthropic/claude-sonnet-4.5', label: 'Claude Sonnet 4.5' },
+  { value: 'anthropic/claude-opus-4', label: 'Claude Opus 4' },
+  { value: 'anthropic/claude-opus-4.6', label: 'Claude Opus 4.6' },
+  { value: 'anthropic/claude-haiku-3.5', label: 'Claude Haiku 3.5' },
+  { value: 'openai/gpt-4.1', label: 'GPT-4.1' },
+  { value: 'openai/o3', label: 'o3' },
+  { value: 'google/gemini-2.5-pro', label: 'Gemini 2.5 Pro' },
+  { value: 'google/gemini-2.5-flash', label: 'Gemini 2.5 Flash' },
+  { value: 'deepseek/deepseek-chat-v3-0324', label: 'DeepSeek V3' },
+  { value: 'deepseek/deepseek-r1', label: 'DeepSeek R1' },
 ];
 
 export function MessageInput({
@@ -106,6 +120,51 @@ export function MessageInput({
   const [modeMenuOpen, setModeMenuOpen] = useState(false);
   const [modelMenuOpen, setModelMenuOpen] = useState(false);
   const [inputValue, setInputValue] = useState('');
+  const [apiProvider, setApiProvider] = useState<'claude_code' | 'openrouter'>('claude_code');
+  const [customDefaultModel, setCustomDefaultModel] = useState<string>('');
+  const prevProviderRef = useRef(apiProvider);
+
+  // Fetch current provider setting on mount, on focus, and listen for changes
+  useEffect(() => {
+    const fetchProvider = () => {
+      fetch('/api/settings/app', { cache: 'no-store' })
+        .then((r) => r.json())
+        .then((data) => {
+          const p = data.settings?.api_provider;
+          if (p === 'openrouter') setApiProvider('openrouter');
+          else setApiProvider('claude_code');
+          // Also read the custom default model from settings
+          const orModel = data.settings?.openrouter_model;
+          if (orModel) setCustomDefaultModel(orModel);
+        })
+        .catch(() => {});
+    };
+    fetchProvider();
+    const handler = () => fetchProvider();
+    // Re-fetch when settings saved, window focused, or page becomes visible
+    window.addEventListener('provider-changed', handler);
+    window.addEventListener('focus', handler);
+    document.addEventListener('visibilitychange', () => {
+      if (document.visibilityState === 'visible') handler();
+    });
+    return () => {
+      window.removeEventListener('provider-changed', handler);
+      window.removeEventListener('focus', handler);
+    };
+  }, []);
+
+  // When provider changes, auto-switch model to the default of the new provider
+  useEffect(() => {
+    if (prevProviderRef.current !== apiProvider) {
+      prevProviderRef.current = apiProvider;
+      if (apiProvider === 'openrouter' && customDefaultModel) {
+        onModelChange?.(customDefaultModel);
+      } else {
+        const newOptions = apiProvider === 'openrouter' ? OPENROUTER_MODEL_OPTIONS : CLAUDE_MODEL_OPTIONS;
+        onModelChange?.(newOptions[0].value);
+      }
+    }
+  }, [apiProvider, onModelChange, customDefaultModel]);
 
   // Fetch files for @ mention
   const fetchFiles = useCallback(async (filter: string) => {
@@ -234,6 +293,10 @@ export function MessageInput({
     }
   }, [fetchFiles, fetchSkills, popoverMode, closePopover]);
 
+  const filteredItems = popoverItems.filter((item) =>
+    item.label.toLowerCase().includes(popoverFilter.toLowerCase())
+  );
+
   const handleSubmit = useCallback((_msg: { text: string; files: unknown[] }, e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     const content = inputValue.trim();
@@ -280,7 +343,7 @@ export function MessageInput({
         }
       }
     },
-    [popoverMode, popoverItems, selectedIndex, insertItem, closePopover]
+    [popoverMode, popoverItems, filteredItems, selectedIndex, insertItem, closePopover]
   );
 
   // Click outside to close popover
@@ -319,11 +382,21 @@ export function MessageInput({
     return () => document.removeEventListener('mousedown', handler);
   }, [modelMenuOpen]);
 
-  const filteredItems = popoverItems.filter((item) =>
-    item.label.toLowerCase().includes(popoverFilter.toLowerCase())
-  );
-
-  const currentModelValue = modelName || 'sonnet';
+  // Build model options: preset list + custom default model if not already included
+  const baseModelOptions = apiProvider === 'openrouter' ? OPENROUTER_MODEL_OPTIONS : CLAUDE_MODEL_OPTIONS;
+  const MODEL_OPTIONS = (() => {
+    if (apiProvider !== 'openrouter' || !customDefaultModel) return baseModelOptions;
+    // If the custom model from settings is not in the preset list, add it at the top
+    if (!baseModelOptions.some((m) => m.value === customDefaultModel)) {
+      // Generate a friendly label from the model ID (e.g. "anthropic/claude-opus-4.6" → "claude-opus-4.6")
+      const shortLabel = customDefaultModel.includes('/')
+        ? customDefaultModel.split('/').pop() || customDefaultModel
+        : customDefaultModel;
+      return [{ value: customDefaultModel, label: shortLabel }, ...baseModelOptions];
+    }
+    return baseModelOptions;
+  })();
+  const currentModelValue = modelName || MODEL_OPTIONS[0].value;
   const currentModelOption = MODEL_OPTIONS.find((m) => m.value === currentModelValue) || MODEL_OPTIONS[0];
   const currentMode = MODE_OPTIONS.find((m) => m.value === mode) || MODE_OPTIONS[0];
 

--- a/src/lib/openrouter-client.ts
+++ b/src/lib/openrouter-client.ts
@@ -1,0 +1,228 @@
+/**
+ * OpenRouter-compatible streaming client.
+ * Uses undici fetch with proxy support + OpenAI-compatible chat completions API.
+ * Outputs the same SSE event format as claude-client.ts so the frontend works unchanged.
+ */
+import type { SSEEvent, TokenUsage } from '@/types';
+import { getSetting } from './db';
+import { getMessages } from './db';
+import { fetch as undiciFetch, ProxyAgent, type Dispatcher } from 'undici';
+
+export interface OpenRouterStreamOptions {
+  prompt: string;
+  sessionId: string;
+  model?: string;
+  systemPrompt?: string;
+  abortController?: AbortController;
+}
+
+function formatSSE(event: SSEEvent): string {
+  return `data: ${JSON.stringify(event)}\n\n`;
+}
+
+/**
+ * Get proxy dispatcher if http_proxy / https_proxy is set
+ */
+function getProxyDispatcher(): Dispatcher | undefined {
+  const proxyUrl =
+    process.env.https_proxy ||
+    process.env.HTTPS_PROXY ||
+    process.env.http_proxy ||
+    process.env.HTTP_PROXY;
+  if (proxyUrl) {
+    return new ProxyAgent(proxyUrl);
+  }
+  return undefined;
+}
+
+/**
+ * Stream chat responses via OpenRouter (OpenAI-compatible API).
+ * Returns a ReadableStream of SSE-formatted strings matching the existing protocol.
+ */
+export function streamOpenRouter(options: OpenRouterStreamOptions): ReadableStream<string> {
+  const { sessionId, model, systemPrompt, abortController } = options;
+
+  return new ReadableStream<string>({
+    async start(controller) {
+      try {
+        // Resolve API key: app setting > env var
+        const apiKey =
+          getSetting('openrouter_api_key') ||
+          process.env.OPENROUTER_API_KEY ||
+          '';
+        // Resolve base URL: app setting > env var > default
+        const baseURL =
+          getSetting('openrouter_base_url') ||
+          process.env.OPENROUTER_BASE_URL ||
+          'https://openrouter.ai/api/v1';
+        // Resolve default model: app setting > env var > fallback
+        const defaultModel =
+          getSetting('openrouter_model') ||
+          process.env.ANTHROPIC_MODEL ||
+          'anthropic/claude-sonnet-4';
+
+        if (!apiKey) {
+          controller.enqueue(formatSSE({
+            type: 'error',
+            data: 'OpenRouter API key not configured. Please set it in Settings → API Configuration.',
+          }));
+          controller.enqueue(formatSSE({ type: 'done', data: '' }));
+          controller.close();
+          return;
+        }
+
+        const effectiveModel = model || defaultModel;
+
+        // Build conversation history from database
+        const previousMessages = getMessages(sessionId);
+        const messages: Array<{ role: string; content: string }> = [];
+
+        if (systemPrompt) {
+          messages.push({ role: 'system', content: systemPrompt });
+        }
+
+        for (const msg of previousMessages) {
+          messages.push({
+            role: msg.role,
+            content: msg.content,
+          });
+        }
+
+        // The current user message is already saved to DB before streaming,
+        // so it's included in previousMessages. No need to add again.
+
+        // Send init status event
+        controller.enqueue(formatSSE({
+          type: 'status',
+          data: JSON.stringify({
+            model: effectiveModel,
+            provider: 'openrouter',
+          }),
+        }));
+
+        // Make streaming request to OpenRouter (with proxy support)
+        const apiURL = baseURL.replace(/\/+$/, '') + '/chat/completions';
+        const dispatcher = getProxyDispatcher();
+
+        const fetchOptions: Parameters<typeof undiciFetch>[1] = {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${apiKey}`,
+            'HTTP-Referer': 'https://github.com/op7418/CodePilot',
+            'X-Title': 'CodePilot',
+          },
+          body: JSON.stringify({
+            model: effectiveModel,
+            messages,
+            stream: true,
+          }),
+          signal: abortController?.signal as never,
+        };
+
+        if (dispatcher) {
+          fetchOptions.dispatcher = dispatcher;
+        }
+
+        const response = await undiciFetch(apiURL, fetchOptions);
+
+        if (!response.ok) {
+          const errorBody = await response.text();
+          let errorMessage: string;
+          try {
+            const parsed = JSON.parse(errorBody);
+            errorMessage = parsed.error?.message || parsed.error || errorBody;
+          } catch {
+            errorMessage = errorBody;
+          }
+          controller.enqueue(formatSSE({
+            type: 'error',
+            data: `OpenRouter API error (${response.status}): ${errorMessage}`,
+          }));
+          controller.enqueue(formatSSE({ type: 'done', data: '' }));
+          controller.close();
+          return;
+        }
+
+        if (!response.body) {
+          controller.enqueue(formatSSE({ type: 'error', data: 'No response body from OpenRouter' }));
+          controller.enqueue(formatSSE({ type: 'done', data: '' }));
+          controller.close();
+          return;
+        }
+
+        // Parse the SSE stream from OpenRouter
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = '';
+        let totalInputTokens = 0;
+        let totalOutputTokens = 0;
+
+        while (true) {
+          if (abortController?.signal.aborted) break;
+
+          const { done, value } = await reader.read();
+          if (done) break;
+
+          buffer += decoder.decode(value, { stream: true });
+          const lines = buffer.split('\n');
+          // Keep the last potentially incomplete line
+          buffer = lines.pop() || '';
+
+          for (const line of lines) {
+            const trimmed = line.trim();
+            if (!trimmed || !trimmed.startsWith('data: ')) continue;
+
+            const data = trimmed.slice(6);
+            if (data === '[DONE]') continue;
+
+            try {
+              const chunk = JSON.parse(data);
+
+              // Extract text delta
+              const delta = chunk.choices?.[0]?.delta;
+              if (delta?.content) {
+                controller.enqueue(formatSSE({ type: 'text', data: delta.content }));
+              }
+
+              // Extract usage info (some providers include it in the final chunk)
+              if (chunk.usage) {
+                totalInputTokens = chunk.usage.prompt_tokens || 0;
+                totalOutputTokens = chunk.usage.completion_tokens || 0;
+              }
+            } catch {
+              // Skip malformed chunks
+            }
+          }
+        }
+
+        // Send result with token usage
+        const tokenUsage: TokenUsage = {
+          input_tokens: totalInputTokens,
+          output_tokens: totalOutputTokens,
+        };
+
+        controller.enqueue(formatSSE({
+          type: 'result',
+          data: JSON.stringify({
+            subtype: 'success',
+            is_error: false,
+            usage: tokenUsage,
+          }),
+        }));
+
+        controller.enqueue(formatSSE({ type: 'done', data: '' }));
+        controller.close();
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+        controller.enqueue(formatSSE({ type: 'error', data: errorMessage }));
+        controller.enqueue(formatSSE({ type: 'done', data: '' }));
+        controller.close();
+      }
+    },
+
+    cancel() {
+      abortController?.abort();
+    },
+  });
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -348,6 +348,12 @@ export const SETTING_KEYS = {
 } as const;
 
 // ==========================================
+// Provider Types
+// ==========================================
+
+export type ApiProvider = 'claude_code' | 'openrouter';
+
+// ==========================================
 // Claude Client Types
 // ==========================================
 
@@ -361,4 +367,16 @@ export interface ClaudeStreamOptions {
   mcpServers?: Record<string, MCPServerConfig>;
   abortController?: AbortController;
   permissionMode?: string;
+}
+
+// ==========================================
+// OpenRouter Client Types
+// ==========================================
+
+export interface OpenRouterStreamOptions {
+  prompt: string;
+  sessionId: string;
+  model?: string;
+  systemPrompt?: string;
+  abortController?: AbortController;
 }


### PR DESCRIPTION
## 概述

添加 OpenRouter（OpenAI 兼容 API）作为替代 API 提供商，允许用户通过统一接口访问更多 LLM 模型（Claude、GPT-4o、Gemini、DeepSeek 等）。

## 变更内容

### 新增文件
- **`src/lib/openrouter-client.ts`** — OpenRouter 流式客户端，使用 `undici` fetch 并支持 HTTP 代理。输出与现有 Claude SDK 客户端相同的 SSE 事件格式，确保前端完全兼容。

### 修改文件
- **`src/app/api/chat/route.ts`** — 根据用户设置动态选择 API 提供商（`claude_code` 或 `openrouter`）。
- **`src/app/api/settings/app/route.ts`** — 新增设置项（`api_provider`、`openrouter_api_key`、`openrouter_base_url`、`openrouter_model`），API Key 返回时自动脱敏。
- **`src/app/settings/page.tsx`** — 新增提供商选择器 UI 和 OpenRouter 专属配置表单（API Key、Base URL、默认模型）。
- **`src/components/chat/MessageInput.tsx`** — 模型列表根据所选提供商动态切换，支持自动检测提供商变更，并动态包含用户自定义的默认模型。
- **`src/types/index.ts`** — 新增 `ApiProvider` 类型和 `OpenRouterStreamOptions` 接口。
- **`package.json`** — 新增 `undici` 依赖，用于支持代理的 HTTP 请求。

## 功能特性

- **提供商选择**：用户可在设置中切换 Claude Code SDK 和 OpenRouter。
- **动态模型列表**：模型下拉菜单根据所选提供商自动更新，内置 Claude、GPT-4o、Gemini、DeepSeek 等模型预设。
- **自定义默认模型**：若用户配置的默认模型不在预设列表中，会自动添加到模型选择器顶部。
- **HTTP 代理支持**：OpenRouter 客户端通过 `undici` ProxyAgent 自动读取 `http_proxy` / `https_proxy` 环境变量。
- **API Key 安全**：OpenRouter API Key 在设置 API 返回时自动脱敏，与现有 Anthropic Token 处理方式一致。
- **零破坏性变更**：现有 Claude Code SDK 工作流保持默认且完全不受影响。

## 测试方式

1. 进入 **设置 → API 配置**
2. 选择 **OpenRouter** 作为提供商
3. 输入 OpenRouter API Key，可选设置默认模型
4. 保存后返回聊天页面 — 模型列表应显示 OpenRouter 模型
5. 发送消息验证流式响应是否正常工作