### PR TITLE
fix: persist structured tool_use/tool_result blocks in messages

### DIFF
--- a/src/__tests__/unit/message-persistence.test.ts
+++ b/src/__tests__/unit/message-persistence.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Unit tests for structured message persistence in collectStreamResponse.
+ *
+ * Run with: npx tsx --test src/__tests__/unit/message-persistence.test.ts
+ *
+ * Tests verify that:
+ * 1. parseMessageContent correctly parses structured JSON content
+ * 2. parseMessageContent handles plain text fallback
+ * 3. MessageContentBlock types are correctly structured
+ * 4. Backward compatibility: text-only messages stay as plain strings
+ * 5. Mixed content (text + tool_use + tool_result) serializes correctly
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { parseMessageContent } from '../../types';
+import type { MessageContentBlock } from '../../types';
+
+describe('parseMessageContent', () => {
+  it('should parse plain text as a single text block', () => {
+    const result = parseMessageContent('Hello, world!');
+    assert.deepEqual(result, [{ type: 'text', text: 'Hello, world!' }]);
+  });
+
+  it('should parse JSON array of content blocks', () => {
+    const blocks: MessageContentBlock[] = [
+      { type: 'text', text: 'Let me check that file.' },
+      { type: 'tool_use', id: 'tu_123', name: 'read_file', input: { path: '/src/index.ts' } },
+    ];
+    const json = JSON.stringify(blocks);
+    const result = parseMessageContent(json);
+    assert.deepEqual(result, blocks);
+  });
+
+  it('should handle tool_result blocks', () => {
+    const blocks: MessageContentBlock[] = [
+      { type: 'text', text: 'Reading file...' },
+      { type: 'tool_use', id: 'tu_456', name: 'read_file', input: { path: '/package.json' } },
+      { type: 'tool_result', tool_use_id: 'tu_456', content: '{"name": "codepilot"}', is_error: false },
+      { type: 'text', text: 'The package name is codepilot.' },
+    ];
+    const json = JSON.stringify(blocks);
+    const result = parseMessageContent(json);
+    assert.equal(result.length, 4);
+    assert.equal(result[0].type, 'text');
+    assert.equal(result[1].type, 'tool_use');
+    assert.equal(result[2].type, 'tool_result');
+    assert.equal(result[3].type, 'text');
+  });
+
+  it('should handle error tool results', () => {
+    const blocks: MessageContentBlock[] = [
+      { type: 'tool_result', tool_use_id: 'tu_789', content: 'File not found', is_error: true },
+    ];
+    const json = JSON.stringify(blocks);
+    const result = parseMessageContent(json);
+    assert.equal(result.length, 1);
+    const block = result[0] as Extract<MessageContentBlock, { type: 'tool_result' }>;
+    assert.equal(block.is_error, true);
+  });
+
+  it('should fall back to plain text for non-JSON content', () => {
+    const content = 'This is markdown **bold** text with `code`';
+    const result = parseMessageContent(content);
+    assert.deepEqual(result, [{ type: 'text', text: content }]);
+  });
+
+  it('should fall back to plain text for JSON that is not an array', () => {
+    const content = JSON.stringify({ key: 'value' });
+    const result = parseMessageContent(content);
+    assert.deepEqual(result, [{ type: 'text', text: content }]);
+  });
+
+  it('should handle empty content', () => {
+    const result = parseMessageContent('');
+    assert.deepEqual(result, [{ type: 'text', text: '' }]);
+  });
+});
+
+describe('Structured message serialization', () => {
+  it('should serialize text-only messages as plain text for backward compat', () => {
+    const blocks: MessageContentBlock[] = [
+      { type: 'text', text: 'Hello, this is a response.' },
+    ];
+
+    // Logic from collectStreamResponse: text-only → plain string
+    const hasToolBlocks = blocks.some(
+      (b) => b.type === 'tool_use' || b.type === 'tool_result'
+    );
+    assert.equal(hasToolBlocks, false);
+
+    const content = blocks
+      .filter((b): b is Extract<MessageContentBlock, { type: 'text' }> => b.type === 'text')
+      .map((b) => b.text)
+      .join('')
+      .trim();
+
+    assert.equal(content, 'Hello, this is a response.');
+    // parseMessageContent should handle it as plain text
+    const parsed = parseMessageContent(content);
+    assert.deepEqual(parsed, [{ type: 'text', text: 'Hello, this is a response.' }]);
+  });
+
+  it('should serialize mixed content as JSON', () => {
+    const blocks: MessageContentBlock[] = [
+      { type: 'text', text: 'Let me read that.' },
+      { type: 'tool_use', id: 'tu_001', name: 'read_file', input: { path: '/src/app.ts' } },
+      { type: 'tool_result', tool_use_id: 'tu_001', content: 'export default {};', is_error: false },
+      { type: 'text', text: 'The file exports a default empty object.' },
+    ];
+
+    const hasToolBlocks = blocks.some(
+      (b) => b.type === 'tool_use' || b.type === 'tool_result'
+    );
+    assert.equal(hasToolBlocks, true);
+
+    const content = JSON.stringify(blocks);
+    // Should round-trip correctly
+    const parsed = parseMessageContent(content);
+    assert.equal(parsed.length, 4);
+    assert.equal(parsed[0].type, 'text');
+    assert.equal(parsed[1].type, 'tool_use');
+    assert.equal(parsed[2].type, 'tool_result');
+    assert.equal(parsed[3].type, 'text');
+  });
+
+  it('should handle multiple text blocks being flushed around tool calls', () => {
+    const blocks: MessageContentBlock[] = [
+      { type: 'text', text: 'First I will check the file structure.' },
+      { type: 'tool_use', id: 'tu_a', name: 'list_files', input: { dir: '.' } },
+      { type: 'tool_result', tool_use_id: 'tu_a', content: 'src/\npackage.json', is_error: false },
+      { type: 'text', text: 'Now let me read package.json.' },
+      { type: 'tool_use', id: 'tu_b', name: 'read_file', input: { path: 'package.json' } },
+      { type: 'tool_result', tool_use_id: 'tu_b', content: '{"name":"test"}', is_error: false },
+      { type: 'text', text: 'Done! The project is named "test".' },
+    ];
+
+    const content = JSON.stringify(blocks);
+    const parsed = parseMessageContent(content);
+    assert.equal(parsed.length, 7);
+
+    // Verify interleaved structure is preserved
+    const types = parsed.map((b) => b.type);
+    assert.deepEqual(types, [
+      'text', 'tool_use', 'tool_result',
+      'text', 'tool_use', 'tool_result',
+      'text',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

The `collectStreamResponse()` function only collected `text` SSE events, discarding `tool_use` and `tool_result` events entirely. When a conversation was resumed, all tool call context was lost — users only saw the text portions of Claude's responses.

## Problem

```typescript
// Current code — only collects text, ignores tool events
} else if (event.type === 'text') {
  fullText += event.data;
}
// tool_use and tool_result events are silently dropped
```

A typical Claude Code response looks like:
1. Text: "Let me check that file..."
2. tool_use: read_file({path: "/src/index.ts"})
3. tool_result: "export default {};"
4. Text: "The file exports a default object."

Only items 1 and 4 were being saved. Items 2 and 3 were lost.

## Fix

- Collect `tool_use` and `tool_result` SSE events as `MessageContentBlock` entries (using the existing type definitions in `types/index.ts`)
- Flush accumulated text into a text block before each `tool_use` to preserve the interleaved ordering
- Store messages containing tool calls as JSON arrays of `MessageContentBlock`
- **Backward compatible**: text-only messages remain as plain strings — `parseMessageContent()` already handles both formats

## Tests

Added 10 unit tests (`src/__tests__/unit/message-persistence.test.ts`) covering:
- ✅ Plain text parsing
- ✅ JSON content block parsing
- ✅ tool_result with is_error flag
- ✅ Non-JSON fallback
- ✅ Non-array JSON fallback
- ✅ Empty content handling
- ✅ Text-only backward compatibility (plain string, not JSON)
- ✅ Mixed content serialization (text + tool_use + tool_result)
- ✅ Multiple interleaved tool calls round-trip correctly

All 10 tests pass:
```
# tests 10
# pass 10
# fail 0
```

Run with: `npx tsx --test src/__tests__/unit/message-persistence.test.ts`