### PR TITLE
feat: add Linux build support (AppImage, deb, rpm)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,7 @@ Pre-built releases are available on the [**Releases**](https://github.com/op7418
 
 - **macOS**: Universal binary (arm64 + x64) distributed as `.dmg`
 - **Windows**: x64 distributed as `.zip`
-
-> Linux builds are planned. Contributions welcome.
+- **Linux**: x64 and arm64 distributed as `.AppImage`, `.deb`, and `.rpm`
 
 ---
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -74,8 +74,7 @@ npm run electron:dev
 
 - **macOS** -- 支持 arm64（Apple Silicon）和 x64（Intel）架构的 `.dmg` 安装包
 - **Windows** -- 提供 `.zip` 压缩包，解压即用
-
-> **Linux** 版本正在计划中，欢迎贡献。
+- **Linux** -- 支持 x64 和 arm64 架构，提供 `.AppImage`、`.deb` 和 `.rpm` 格式
 
 ---
 

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -56,3 +56,19 @@ nsis:
   allowToChangeInstallationDirectory: true
   createDesktopShortcut: true
   createStartMenuShortcut: true
+linux:
+  icon: build/icon.png
+  category: Development
+  artifactName: "${productName}-${version}-${arch}.${ext}"
+  desktop:
+    Name: CodePilot
+    Comment: A native desktop GUI for Claude Code
+    Categories: Development;IDE;
+    StartupWMClass: codepilot
+  target:
+    - target: AppImage
+      arch: [x64, arm64]
+    - target: deb
+      arch: [x64, arm64]
+    - target: rpm
+      arch: [x64, arm64]

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -71,12 +71,13 @@ function checkNativeModuleABI(): void {
 
 /**
  * Read the user's full shell environment by running a login shell.
- * When Electron is launched from Dock/Finder, process.env is very limited
- * and won't include vars from .zshrc/.bashrc (e.g. API keys).
+ * When Electron is launched from Dock/Finder (macOS) or desktop launcher
+ * (Linux), process.env is very limited and won't include vars from
+ * .zshrc/.bashrc (e.g. API keys, nvm PATH).
  */
 function loadUserShellEnv(): Record<string, string> {
-  // Only macOS needs login-shell env loading; Windows/Linux GUI apps inherit full env
-  if (process.platform !== 'darwin') {
+  // Windows GUI apps inherit the full user environment
+  if (process.platform === 'win32') {
     return {};
   }
   try {
@@ -249,6 +250,9 @@ function getIconPath(): string {
   }
   if (process.platform === 'win32') {
     return path.join(process.resourcesPath, 'icon.ico');
+  }
+  if (process.platform === 'linux') {
+    return path.join(process.resourcesPath, 'icon.png');
   }
   return path.join(process.resourcesPath, 'icon.icns');
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "electron:build": "next build && node scripts/build-electron.mjs",
     "electron:pack": "npm run electron:build && electron-builder --config electron-builder.yml",
     "electron:pack:mac": "npm run electron:build && electron-builder --mac --config electron-builder.yml",
-    "electron:pack:win": "npm run electron:build && electron-builder --win --config electron-builder.yml"
+    "electron:pack:win": "npm run electron:build && electron-builder --win --config electron-builder.yml",
+    "electron:pack:linux": "npm run electron:build && electron-builder --linux --config electron-builder.yml"
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.33",


### PR DESCRIPTION
## Summary

Add Linux as a supported platform, delivering on the README's note: *"Linux builds are planned. Contributions welcome."*

## Changes

### `electron-builder.yml`
- Added `linux` section with:
  - **AppImage**, **deb**, and **rpm** targets
  - Both **x64** and **arm64** architectures
  - Proper `icon.png` reference
  - Desktop entry with category `Development`, comment, and `StartupWMClass`

### `package.json`
- Added `electron:pack:linux` script: `npm run electron:build && electron-builder --linux --config electron-builder.yml`

### `electron/main.ts`
- **`getIconPath()`**: Fixed to return `.png` on Linux instead of falling through to `.icns` (macOS format)
- **`loadUserShellEnv()`**: Enabled on Linux — GUI apps launched from desktop launchers (GNOME, KDE, etc.) also have limited `process.env` and need login shell env loading for API keys, nvm PATH, etc.

### `README.md` + `README_CN.md`
- Updated supported platforms section to include Linux

## Build Commands

```bash
# Build Linux packages (AppImage + deb + rpm)
npm run electron:pack:linux
```

## Notes

- The existing `afterPack` script and `asarUnpack` config for `better-sqlite3` should work on Linux without changes
- The server spawn logic already handles Linux correctly (uses `/bin/sh` like macOS)
- Tested that the electron-builder config is valid YAML and all referenced paths exist