### PR TITLE
fix: add missing popoverFilter to handleKeyDown dependency array

### DIFF
--- a/src/components/chat/MessageInput.tsx
+++ b/src/components/chat/MessageInput.tsx
@@ -280,7 +280,7 @@ export function MessageInput({
         }
       }
     },
-    [popoverMode, popoverItems, selectedIndex, insertItem, closePopover]
+    [popoverMode, popoverItems, popoverFilter, selectedIndex, insertItem, closePopover]
   );
 
   // Click outside to close popover


### PR DESCRIPTION
## Summary

`handleKeyDown` in `MessageInput.tsx` uses `filteredItems` (derived from `popoverItems` filtered by `popoverFilter`), but `popoverFilter` was missing from the `useCallback` dependency array. This caused a stale closure bug.

## Problem

```typescript
const filteredItems = popoverItems.filter((item) =>
  item.label.toLowerCase().includes(popoverFilter.toLowerCase())
);

const handleKeyDown = useCallback((e) => {
  // Uses filteredItems.length for arrow key wrapping
  setSelectedIndex((prev) => (prev + 1) % filteredItems.length);
  // Uses filteredItems[selectedIndex] for Enter/Tab selection
  if (filteredItems[selectedIndex]) {
    insertItem(filteredItems[selectedIndex]);
  }
}, [popoverMode, popoverItems, selectedIndex, insertItem, closePopover]);
//    ^^^ popoverFilter is missing — filteredItems becomes stale
```

## Symptoms

- Arrow Up/Down could wrap at the wrong count after the user types to filter
- Enter/Tab could select the wrong item (from the unfiltered list)
- Intermittent, depending on React render batching timing

## Fix

Added `popoverFilter` to the dependency array:

```typescript
[popoverMode, popoverItems, popoverFilter, selectedIndex, insertItem, closePopover]
```

One-line change, minimal risk.