### PR TITLE
fix: 修复 Windows 环境下设置页 API Config 读取和 git-bash 路径检测问题 (closes #22, closes #23)

### DIFF
--- a/src/app/api/settings/app/route.ts
+++ b/src/app/api/settings/app/route.ts
@@ -11,21 +11,41 @@ const ALLOWED_KEYS = [
   'anthropic_base_url',
 ];
 
+const ENV_VAR_MAP: Record<string, string[]> = {
+  anthropic_auth_token: ['ANTHROPIC_AUTH_TOKEN', 'ANTHROPIC_API_KEY'],
+  anthropic_base_url: ['ANTHROPIC_BASE_URL'],
+};
+
 export async function GET() {
   try {
     const result: Record<string, string> = {};
+    const sources: Record<string, 'db' | 'env'> = {};
     for (const key of ALLOWED_KEYS) {
-      const value = getSetting(key);
-      if (value !== undefined) {
-        // Mask token for security (only return last 8 chars)
+      let value = getSetting(key);
+      let source: 'db' | 'env' = 'db';
+
+      if (value === undefined || value === '') {
+        const envVarNames = ENV_VAR_MAP[key] ?? [];
+        for (const envName of envVarNames) {
+          const envValue = process.env[envName];
+          if (envValue) {
+            value = envValue;
+            source = 'env';
+            break;
+          }
+        }
+      }
+
+      if (value !== undefined && value !== '') {
         if (key === 'anthropic_auth_token' && value.length > 8) {
           result[key] = '***' + value.slice(-8);
         } else {
           result[key] = value;
         }
+        sources[key] = source;
       }
     }
-    return NextResponse.json({ settings: result });
+    return NextResponse.json({ settings: result, sources });
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Failed to read app settings';
     return NextResponse.json({ error: message }, { status: 500 });

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -67,6 +67,7 @@ function ApiConfigSection() {
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [status, setStatus] = useState<"idle" | "saved" | "error">("idle");
+  const [sources, setSources] = useState<Record<string, string>>({});
 
   useEffect(() => {
     fetch("/api/settings/app")
@@ -75,6 +76,7 @@ function ApiConfigSection() {
         const s = data.settings || {};
         setToken(s.anthropic_auth_token || "");
         setBaseUrl(s.anthropic_base_url || "");
+        setSources(data.sources || {});
       })
       .catch(() => {})
       .finally(() => setLoading(false));
@@ -97,6 +99,15 @@ function ApiConfigSection() {
       if (res.ok) {
         setStatus("saved");
         setTimeout(() => setStatus("idle"), 2000);
+        // Re-fetch to update sources
+        const refetch = await fetch("/api/settings/app");
+        if (refetch.ok) {
+          const data = await refetch.json();
+          const s = data.settings || {};
+          setToken(s.anthropic_auth_token || "");
+          setBaseUrl(s.anthropic_base_url || "");
+          setSources(data.sources || {});
+        }
       } else {
         setStatus("error");
       }
@@ -122,6 +133,9 @@ function ApiConfigSection() {
         <div>
           <Label htmlFor="api-base-url" className="text-xs text-muted-foreground">
             API Base URL
+            {sources.anthropic_base_url === "env" && (
+              <span className="ml-2 rounded bg-blue-100 px-1.5 py-0.5 text-[10px] font-medium text-blue-700 dark:bg-blue-900/30 dark:text-blue-400">from env</span>
+            )}
           </Label>
           <Input
             id="api-base-url"
@@ -133,7 +147,10 @@ function ApiConfigSection() {
         </div>
         <div>
           <Label htmlFor="api-token" className="text-xs text-muted-foreground">
-            API Token (ANTHROPIC_AUTH_TOKEN)
+            API Token (ANTHROPIC_AUTH_TOKEN / ANTHROPIC_API_KEY)
+            {sources.anthropic_auth_token === "env" && (
+              <span className="ml-2 rounded bg-blue-100 px-1.5 py-0.5 text-[10px] font-medium text-blue-700 dark:bg-blue-900/30 dark:text-blue-400">from env</span>
+            )}
           </Label>
           <Input
             id="api-token"
@@ -143,6 +160,9 @@ function ApiConfigSection() {
             onChange={(e) => setToken(e.target.value)}
             className="mt-1 font-mono text-sm"
           />
+          {sources.anthropic_auth_token === "env" && (
+            <p className="mt-1 text-[11px] text-muted-foreground">Currently using value from environment variable. Save to override with a custom value.</p>
+          )}
         </div>
       </div>
       <div className="flex items-center gap-3">

--- a/src/lib/claude-client.ts
+++ b/src/lib/claude-client.ts
@@ -15,7 +15,7 @@ import type {
 import type { ClaudeStreamOptions, SSEEvent, TokenUsage, MCPServerConfig, PermissionRequestEvent } from '@/types';
 import { registerPendingPermission } from './permission-registry';
 import { getSetting } from './db';
-import { findClaudeBinary, getExpandedPath } from './platform';
+import { findClaudeBinary, getExpandedPath, isWindows, findGitBash } from './platform';
 import os from 'os';
 
 let cachedClaudePath: string | null | undefined;
@@ -107,6 +107,14 @@ export function streamClaude(options: ClaudeStreamOptions): ReadableStream<strin
         if (!sdkEnv.USERPROFILE) sdkEnv.USERPROFILE = os.homedir();
         // Ensure SDK subprocess has expanded PATH (consistent with Electron mode)
         sdkEnv.PATH = getExpandedPath();
+
+        // Auto-detect git-bash on Windows (required by Claude Code)
+        if (isWindows && !sdkEnv.CLAUDE_CODE_GIT_BASH_PATH) {
+          const gitBashPath = findGitBash();
+          if (gitBashPath) {
+            sdkEnv.CLAUDE_CODE_GIT_BASH_PATH = gitBashPath;
+          }
+        }
 
         const appToken = getSetting('anthropic_auth_token');
         const appBaseUrl = getSetting('anthropic_base_url');

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -1,5 +1,6 @@
 import { execFileSync, execFile } from 'child_process';
 import { promisify } from 'util';
+import fs from 'fs';
 import os from 'os';
 import path from 'path';
 
@@ -161,4 +162,51 @@ export async function getClaudeVersion(claudePath: string): Promise<string | nul
   } catch {
     return null;
   }
+}
+
+/**
+ * Find git-bash (bash.exe) on Windows.
+ * Required by Claude Code on Windows for shell execution.
+ * Returns the path to bash.exe, or undefined if not found.
+ */
+export function findGitBash(): string | undefined {
+  if (!isWindows) return undefined;
+
+  // 1. Already set by user
+  if (process.env.CLAUDE_CODE_GIT_BASH_PATH) {
+    const envPath = process.env.CLAUDE_CODE_GIT_BASH_PATH;
+    if (fs.existsSync(envPath)) return envPath;
+  }
+
+  // 2. Common installation paths
+  const commonPaths = [
+    'C:\\Program Files\\Git\\bin\\bash.exe',
+    'C:\\Program Files (x86)\\Git\\bin\\bash.exe',
+  ];
+  for (const p of commonPaths) {
+    if (fs.existsSync(p)) return p;
+  }
+
+  // 3. Derive from `where git` output
+  try {
+    const result = execFileSync('where', ['git'], {
+      timeout: 3000,
+      stdio: 'pipe',
+      shell: true,
+    });
+    const lines = result.toString().trim().split(/\r?\n/);
+    for (const line of lines) {
+      const gitExe = line.trim();
+      if (!gitExe) continue;
+      // git.exe is typically at <GitRoot>/cmd/git.exe or <GitRoot>/bin/git.exe
+      const gitDir = path.dirname(gitExe);
+      const gitRoot = path.dirname(gitDir);
+      const bashPath = path.join(gitRoot, 'bin', 'bash.exe');
+      if (fs.existsSync(bashPath)) return bashPath;
+    }
+  } catch {
+    // where git failed, skip
+  }
+
+  return undefined;
 }


### PR DESCRIPTION
## 概述

修复 Windows 环境下的两个 Bug，对应 Issue #22 和 #23。

---

## Bug 1: 设置页 API Config 无法读取环境变量 (#22)

### 问题
设置页 "Save API Config" 无法捕获本地 CLI 已配置的中转 URL 和 API Key。用户通过环境变量（如 `ANTHROPIC_AUTH_TOKEN`、`ANTHROPIC_BASE_URL`）配置的值不会显示在设置页中。

### 修复
- **`src/app/api/settings/app/route.ts`**：GET 接口增加环境变量回退逻辑，当数据库中无值时依次检查 `ANTHROPIC_AUTH_TOKEN`、`ANTHROPIC_API_KEY`、`ANTHROPIC_BASE_URL` 环境变量，并返回值来源（`db` 或 `env`）
- **`src/app/settings/page.tsx`**：前端显示 `from env` 标签提示用户当前值来自环境变量；保存后自动刷新状态

---

## Bug 2: Windows 上 Git 安装在非标准路径时 Claude CLI 退出码 1 (#23)

### 问题
Git 安装在非默认路径（如 `D:\APP\Git`）时，Claude CLI 无法找到 `bash.exe`，进程以退出码 1 退出，报错：
> Claude Code on Windows requires git-bash.

### 修复
- **`src/lib/platform.ts`**：新增 `findGitBash()` 函数，按优先级自动检测 git-bash 路径：
  1. 环境变量 `CLAUDE_CODE_GIT_BASH_PATH`（用户手动设置）
  2. 常见安装路径（`C:\Program Files\Git\bin\bash.exe` 等）
  3. 通过 `where git` 命令推导 Git 安装目录
- **`src/lib/claude-client.ts`**：在构建 SDK 子进程环境变量时，仅在 Windows 平台且未设置 `CLAUDE_CODE_GIT_BASH_PATH` 时调用自动检测

---

## 修改文件

| 文件 | 说明 |
|---|---|
| `src/app/api/settings/app/route.ts` | API Config GET 接口增加环境变量回退读取 |
| `src/app/settings/page.tsx` | 前端显示值来源标签，保存后刷新 |
| `src/lib/platform.ts` | 新增 `findGitBash()` 自动检测函数 |
| `src/lib/claude-client.ts` | SDK 环境变量构建时自动设置 git-bash 路径 |