### PR TITLE
fix: auto-detect git-bash path on Windows for Claude CLI (closes #23)

### DIFF
--- a/src/lib/claude-client.ts
+++ b/src/lib/claude-client.ts
@@ -15,7 +15,7 @@ import type {
 import type { ClaudeStreamOptions, SSEEvent, TokenUsage, MCPServerConfig, PermissionRequestEvent } from '@/types';
 import { registerPendingPermission } from './permission-registry';
 import { getSetting } from './db';
-import { findClaudeBinary, getExpandedPath } from './platform';
+import { findClaudeBinary, getExpandedPath, isWindows, findGitBash } from './platform';
 import os from 'os';
 
 let cachedClaudePath: string | null | undefined;
@@ -107,6 +107,14 @@ export function streamClaude(options: ClaudeStreamOptions): ReadableStream<strin
         if (!sdkEnv.USERPROFILE) sdkEnv.USERPROFILE = os.homedir();
         // Ensure SDK subprocess has expanded PATH (consistent with Electron mode)
         sdkEnv.PATH = getExpandedPath();
+
+        // Auto-detect git-bash on Windows (required by Claude Code)
+        if (isWindows && !sdkEnv.CLAUDE_CODE_GIT_BASH_PATH) {
+          const gitBashPath = findGitBash();
+          if (gitBashPath) {
+            sdkEnv.CLAUDE_CODE_GIT_BASH_PATH = gitBashPath;
+          }
+        }
 
         const appToken = getSetting('anthropic_auth_token');
         const appBaseUrl = getSetting('anthropic_base_url');

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -1,5 +1,6 @@
 import { execFileSync, execFile } from 'child_process';
 import { promisify } from 'util';
+import fs from 'fs';
 import os from 'os';
 import path from 'path';
 
@@ -161,4 +162,51 @@ export async function getClaudeVersion(claudePath: string): Promise<string | nul
   } catch {
     return null;
   }
+}
+
+/**
+ * Find git-bash (bash.exe) on Windows.
+ * Required by Claude Code on Windows for shell execution.
+ * Returns the path to bash.exe, or undefined if not found.
+ */
+export function findGitBash(): string | undefined {
+  if (!isWindows) return undefined;
+
+  // 1. Already set by user
+  if (process.env.CLAUDE_CODE_GIT_BASH_PATH) {
+    const envPath = process.env.CLAUDE_CODE_GIT_BASH_PATH;
+    if (fs.existsSync(envPath)) return envPath;
+  }
+
+  // 2. Common installation paths
+  const commonPaths = [
+    'C:\\Program Files\\Git\\bin\\bash.exe',
+    'C:\\Program Files (x86)\\Git\\bin\\bash.exe',
+  ];
+  for (const p of commonPaths) {
+    if (fs.existsSync(p)) return p;
+  }
+
+  // 3. Derive from `where git` output
+  try {
+    const result = execFileSync('where', ['git'], {
+      timeout: 3000,
+      stdio: 'pipe',
+      shell: true,
+    });
+    const lines = result.toString().trim().split(/\r?\n/);
+    for (const line of lines) {
+      const gitExe = line.trim();
+      if (!gitExe) continue;
+      // git.exe is typically at <GitRoot>/cmd/git.exe or <GitRoot>/bin/git.exe
+      const gitDir = path.dirname(gitExe);
+      const gitRoot = path.dirname(gitDir);
+      const bashPath = path.join(gitRoot, 'bin', 'bash.exe');
+      if (fs.existsSync(bashPath)) return bashPath;
+    }
+  } catch {
+    // where git failed, skip
+  }
+
+  return undefined;
 }


### PR DESCRIPTION
## 问题

Windows 上 Git 安装在非标准路径（如 `D:\APP\Git`）时，Claude CLI 无法找到 `bash.exe`，进程以退出码 1 退出：

> Claude Code on Windows requires git-bash. If installed but not in PATH, set environment variable pointing to your bash.exe, similar to: CLAUDE_CODE_GIT_BASH_PATH=C:\Program Files\Git\bin\bash.exe

## 修复

在 `src/lib/platform.ts` 新增 `findGitBash()` 函数，按优先级自动检测 git-bash 路径：

1. **环境变量** `CLAUDE_CODE_GIT_BASH_PATH`（用户手动设置）
2. **常见安装路径**（`C:\Program Files\Git\bin\bash.exe`、`C:\Program Files (x86)\Git\bin\bash.exe`）
3. **`where git` 推导** — 定位 `git.exe`，从其路径推导 Git 安装目录，拼接 `bin\bash.exe`

在 `src/lib/claude-client.ts` 构建 SDK 子进程环境变量时，仅在 Windows 平台且 `CLAUDE_CODE_GIT_BASH_PATH` 未设置时调用该函数，将检测结果写入环境变量。

## 修改文件

| 文件 | 说明 |
|---|---|
| `src/lib/platform.ts` | 新增 `findGitBash()` 导出函数 |
| `src/lib/claude-client.ts` | 构建 `sdkEnv` 时调用自动检测 |

## 从 #24 拆分

按作者建议，从 PR #24 中拆分出此独立修复。Bug 1（#22）因 main 分支已移除 `ApiConfigSection` 组件需另行处理。