### PR TITLE
fix: 文件 API 路径范围 — 允许非 home 目录的项目，使用路径深度检查保障安全

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ yarn-error.log*
 
 # vercel
 .vercel
+.claude
 
 # local database
 /data/

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "electron:dev": "concurrently -k \"next dev\" \"wait-on http://localhost:3000 && electron .\"",
+    "electron:dev": "node scripts/build-electron.mjs && concurrently -k \"next dev\" \"wait-on http://localhost:3000 && electron .\"",
     "electron:build": "next build && node scripts/build-electron.mjs",
     "electron:pack": "npm run electron:build && electron-builder --config electron-builder.yml",
     "electron:pack:mac": "npm run electron:build && electron-builder --mac --config electron-builder.yml",

--- a/src/__tests__/unit/files-security.test.ts
+++ b/src/__tests__/unit/files-security.test.ts
@@ -8,6 +8,9 @@
  * 2. Paths outside the base directory are rejected
  * 3. Symlink-based escapes are caught
  * 4. Edge cases (root, same path, trailing separators) are handled
+ * 5. isRootPath correctly identifies filesystem roots
+ * 6. getPathDepth returns correct depth values
+ * 7. isBaseDirUnsafe blocks shallow/system directories
  */
 
 import { describe, it, after } from 'node:test';
@@ -16,8 +19,8 @@ import path from 'path';
 import os from 'os';
 import fs from 'fs';
 
-// Import the function under test
-import { isPathSafe } from '../../lib/files';
+// Import the functions under test
+import { isPathSafe, isRootPath, getPathDepth, isBaseDirUnsafe } from '../../lib/files';
 
 describe('isPathSafe', () => {
   it('should allow paths within the base directory', () => {
@@ -118,18 +121,120 @@ describe('File API path traversal scenarios', () => {
   });
 });
 
-describe('baseDir validation', () => {
-  it('should reject baseDir set to root (bypass attempt)', () => {
-    // If baseDir=/, every path would pass isPathSafe — must be blocked
-    const homeDir = os.homedir();
-    assert.equal(isPathSafe(homeDir, '/'), false);
+describe('isRootPath', () => {
+  it('should detect Unix root as a root path', () => {
+    assert.equal(isRootPath('/'), true);
   });
 
-  it('should reject baseDir outside home directory', () => {
-    const homeDir = os.homedir();
-    assert.equal(isPathSafe(homeDir, '/tmp'), false);
-    assert.equal(isPathSafe(homeDir, '/etc'), false);
-    assert.equal(isPathSafe(homeDir, '/var/log'), false);
+  it('should detect Windows drive roots as root paths', () => {
+    if (process.platform === 'win32') {
+      assert.equal(isRootPath('C:\\'), true);
+      assert.equal(isRootPath('D:\\'), true);
+    }
+  });
+
+  it('should not treat regular directories as root paths', () => {
+    assert.equal(isRootPath('/home/user/project'), false);
+    assert.equal(isRootPath('/tmp'), false);
+    assert.equal(isRootPath('/etc'), false);
+    if (process.platform === 'win32') {
+      assert.equal(isRootPath('C:\\Users\\user\\project'), false);
+      assert.equal(isRootPath('D:\\projects'), false);
+    }
+  });
+});
+
+describe('getPathDepth', () => {
+  it('should return 0 for filesystem roots', () => {
+    assert.equal(getPathDepth('/'), 0);
+    if (process.platform === 'win32') {
+      assert.equal(getPathDepth('C:\\'), 0);
+      assert.equal(getPathDepth('D:\\'), 0);
+    }
+  });
+
+  it('should return 1 for top-level directories', () => {
+    if (process.platform === 'win32') {
+      assert.equal(getPathDepth('C:\\Users'), 1);
+      assert.equal(getPathDepth('D:\\projects'), 1);
+    } else {
+      assert.equal(getPathDepth('/etc'), 1);
+      assert.equal(getPathDepth('/tmp'), 1);
+      assert.equal(getPathDepth('/var'), 1);
+    }
+  });
+
+  it('should return 2 for two-level paths', () => {
+    if (process.platform === 'win32') {
+      assert.equal(getPathDepth('C:\\Users\\user'), 2);
+      assert.equal(getPathDepth('D:\\projects\\myapp'), 2);
+    } else {
+      assert.equal(getPathDepth('/opt/projects'), 2);
+      assert.equal(getPathDepth('/home/user'), 2);
+    }
+  });
+
+  it('should return correct depth for deep paths', () => {
+    if (process.platform === 'win32') {
+      assert.equal(getPathDepth('C:\\Users\\user\\projects\\myapp'), 4);
+    } else {
+      assert.equal(getPathDepth('/home/user/projects/myapp'), 4);
+    }
+  });
+});
+
+describe('isBaseDirUnsafe', () => {
+  it('should reject filesystem roots', () => {
+    assert.equal(isBaseDirUnsafe('/'), true);
+    if (process.platform === 'win32') {
+      assert.equal(isBaseDirUnsafe('C:\\'), true);
+      assert.equal(isBaseDirUnsafe('D:\\'), true);
+    }
+  });
+
+  it('should reject shallow system directories (depth 1)', () => {
+    if (process.platform === 'win32') {
+      assert.equal(isBaseDirUnsafe('D:\\projects'), true);
+    } else {
+      assert.equal(isBaseDirUnsafe('/etc'), true);
+      assert.equal(isBaseDirUnsafe('/tmp'), true);
+      assert.equal(isBaseDirUnsafe('/var'), true);
+    }
+  });
+
+  it('should allow directories with depth >= 2', () => {
+    if (process.platform === 'win32') {
+      assert.equal(isBaseDirUnsafe('D:\\projects\\myapp'), false);
+      assert.equal(isBaseDirUnsafe('C:\\Users\\user'), false);
+    } else {
+      assert.equal(isBaseDirUnsafe('/opt/projects'), false);
+      assert.equal(isBaseDirUnsafe('/home/user'), false);
+      assert.equal(isBaseDirUnsafe('/home/user/projects/myapp'), false);
+    }
+  });
+});
+
+describe('baseDir validation', () => {
+  it('should reject baseDir set to root (bypass attempt)', () => {
+    assert.equal(isBaseDirUnsafe('/'), true);
+  });
+
+  it('should reject shallow system dirs as baseDir', () => {
+    // /etc, /tmp etc. have depth 1 — too shallow for baseDir
+    if (process.platform === 'win32') {
+      assert.equal(isBaseDirUnsafe('D:\\projects'), true);
+    } else {
+      assert.equal(isBaseDirUnsafe('/etc'), true);
+      assert.equal(isBaseDirUnsafe('/tmp'), true);
+    }
+  });
+
+  it('should allow baseDir with sufficient depth outside home', () => {
+    if (process.platform === 'win32') {
+      assert.equal(isBaseDirUnsafe('D:\\projects\\myapp'), false);
+    } else {
+      assert.equal(isBaseDirUnsafe('/opt/projects'), false);
+    }
   });
 
   it('should allow baseDir inside home directory', () => {
@@ -153,5 +258,18 @@ describe('baseDir validation', () => {
     const homeDir = os.homedir();
     const filePath = path.join(homeDir, 'documents', 'file.txt');
     assert.equal(isPathSafe(homeDir, filePath), true);
+  });
+
+  it('should allow dir within a non-home baseDir', () => {
+    // This is the key fix: D:\\projects\\myapp should work as baseDir
+    const baseDir = path.resolve('/opt/projects/myapp');
+    const targetDir = path.join(baseDir, 'src', 'components');
+    assert.equal(isPathSafe(baseDir, targetDir), true);
+  });
+
+  it('should block dir outside a non-home baseDir', () => {
+    const baseDir = path.resolve('/opt/projects/myapp');
+    const targetDir = path.resolve('/etc/passwd');
+    assert.equal(isPathSafe(baseDir, targetDir), false);
   });
 });

--- a/src/app/api/files/preview/route.ts
+++ b/src/app/api/files/preview/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { readFilePreview, isPathSafe } from '@/lib/files';
+import { readFilePreview, isPathSafe, isBaseDirUnsafe } from '@/lib/files';
 import type { FilePreviewResponse, ErrorResponse } from '@/types';
 
 export async function GET(request: NextRequest) {
@@ -22,15 +22,15 @@ export async function GET(request: NextRequest) {
   // Validate that the file is within the session's working directory.
   // The baseDir parameter should be the session's working directory,
   // which acts as the trust boundary for file access.
-  // The baseDir itself must be under the user's home directory to prevent
+  // The baseDir must not be a filesystem root (e.g. / or C:\) to prevent
   // attackers from setting baseDir=/ to bypass all restrictions.
   const baseDir = searchParams.get('baseDir');
   if (baseDir) {
     const resolvedBase = path.resolve(baseDir);
-    // Ensure baseDir is within the home directory (prevent baseDir=/ bypass)
-    if (!isPathSafe(homeDir, resolvedBase)) {
+    // Prevent overly broad baseDir (root paths or shallow system dirs like /etc)
+    if (isBaseDirUnsafe(resolvedBase)) {
       return NextResponse.json<ErrorResponse>(
-        { error: 'Base directory is outside the allowed scope' },
+        { error: 'Base directory is too broad (must be at least 2 levels deep)' },
         { status: 403 }
       );
     }

--- a/src/app/api/files/route.ts
+++ b/src/app/api/files/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { scanDirectory, isPathSafe } from '@/lib/files';
+import { scanDirectory, isPathSafe, isBaseDirUnsafe } from '@/lib/files';
 import type { FileTreeResponse, ErrorResponse } from '@/types';
 
 export async function GET(request: NextRequest) {
@@ -20,17 +20,17 @@ export async function GET(request: NextRequest) {
   const homeDir = os.homedir();
 
   // Use baseDir (the session's working directory) as the trust boundary.
-  // The baseDir itself must be under the user's home directory to prevent
+  // The baseDir must not be a filesystem root (e.g. / or C:\) to prevent
   // attackers from setting baseDir=/ to bypass all restrictions.
   // If no baseDir is provided, fall back to the user's home directory
   // to prevent scanning arbitrary system directories.
   const baseDir = searchParams.get('baseDir');
   if (baseDir) {
     const resolvedBase = path.resolve(baseDir);
-    // Ensure baseDir is within the home directory (prevent baseDir=/ bypass)
-    if (!isPathSafe(homeDir, resolvedBase)) {
+    // Prevent overly broad baseDir (root paths or shallow system dirs like /etc)
+    if (isBaseDirUnsafe(resolvedBase)) {
       return NextResponse.json<ErrorResponse>(
-        { error: 'Base directory is outside the allowed scope' },
+        { error: 'Base directory is too broad (must be at least 2 levels deep)' },
         { status: 403 }
       );
     }

--- a/src/components/chat/MessageInput.tsx
+++ b/src/components/chat/MessageInput.tsx
@@ -353,9 +353,11 @@ export function MessageInput({
 
   // Fetch files for @ mention
   const fetchFiles = useCallback(async (filter: string) => {
+    if (!workingDirectory) return [];
     try {
       const params = new URLSearchParams();
-      if (sessionId) params.set('session_id', sessionId);
+      params.set('dir', workingDirectory);
+      params.set('baseDir', workingDirectory);
       if (filter) params.set('q', filter);
       const res = await fetch(`/api/files?${params.toString()}`);
       if (!res.ok) return [];
@@ -373,7 +375,7 @@ export function MessageInput({
     } catch {
       return [];
     }
-  }, [sessionId]);
+  }, [workingDirectory]);
 
   // Fetch skills for / command (built-in + API)
   // Returns all items unfiltered — filtering is done by filteredItems

--- a/src/components/layout/RightPanel.tsx
+++ b/src/components/layout/RightPanel.tsx
@@ -154,7 +154,7 @@ export function RightPanel() {
           <span className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground/70 mb-1.5 block">Files</span>
           <div className="overflow-hidden">
             {previewPath ? (
-              <FilePreview filePath={previewPath} onBack={handleBackToTree} />
+              <FilePreview filePath={previewPath} onBack={handleBackToTree} workingDirectory={workingDirectory} />
             ) : (
               <FileTree
                 workingDirectory={workingDirectory}

--- a/src/components/project/FilePreview.tsx
+++ b/src/components/project/FilePreview.tsx
@@ -13,9 +13,10 @@ import type { FilePreview as FilePreviewType } from "@/types";
 interface FilePreviewProps {
   filePath: string;
   onBack: () => void;
+  workingDirectory?: string;
 }
 
-export function FilePreview({ filePath, onBack }: FilePreviewProps) {
+export function FilePreview({ filePath, onBack, workingDirectory }: FilePreviewProps) {
   const [preview, setPreview] = useState<FilePreviewType | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -26,8 +27,10 @@ export function FilePreview({ filePath, onBack }: FilePreviewProps) {
       setLoading(true);
       setError(null);
       try {
+        const params = new URLSearchParams({ path: filePath });
+        if (workingDirectory) params.set('baseDir', workingDirectory);
         const res = await fetch(
-          `/api/files/preview?path=${encodeURIComponent(filePath)}`
+          `/api/files/preview?${params.toString()}`
         );
         if (!res.ok) {
           const data = await res.json();
@@ -43,7 +46,7 @@ export function FilePreview({ filePath, onBack }: FilePreviewProps) {
     }
 
     loadPreview();
-  }, [filePath]);
+  }, [filePath, workingDirectory]);
 
   const handleCopyPath = async () => {
     await navigator.clipboard.writeText(filePath);

--- a/src/components/project/FileTree.tsx
+++ b/src/components/project/FileTree.tsx
@@ -117,7 +117,7 @@ export function FileTree({ workingDirectory, onFileSelect }: FileTreeProps) {
     setLoading(true);
     try {
       const res = await fetch(
-        `/api/files?dir=${encodeURIComponent(workingDirectory)}&depth=4`
+        `/api/files?dir=${encodeURIComponent(workingDirectory)}&baseDir=${encodeURIComponent(workingDirectory)}&depth=4`
       );
       if (res.ok) {
         const data = await res.json();

--- a/src/lib/files.ts
+++ b/src/lib/files.ts
@@ -74,6 +74,50 @@ export function isPathSafe(basePath: string, targetPath: string): boolean {
   return resolvedTarget.startsWith(resolvedBase + path.sep) || resolvedTarget === resolvedBase;
 }
 
+/**
+ * Check if the given path is a filesystem root (e.g. `/` on Unix, `C:\` on Windows).
+ */
+export function isRootPath(p: string): boolean {
+  const resolved = path.resolve(p);
+  return resolved === path.parse(resolved).root;
+}
+
+/**
+ * Get the depth of a path relative to its filesystem root.
+ * Examples:
+ *   `/`            → 0
+ *   `/etc`         → 1
+ *   `/opt/projects`→ 2
+ *   `C:\`          → 0
+ *   `D:\projects`  → 1
+ *   `D:\projects\myapp` → 2
+ */
+export function getPathDepth(p: string): number {
+  const resolved = path.resolve(p);
+  const root = path.parse(resolved).root;
+  if (resolved === root) return 0;
+  // Remove the root prefix and split by separator
+  const relative = resolved.slice(root.length);
+  return relative.split(path.sep).filter(Boolean).length;
+}
+
+/**
+ * Minimum required directory depth for baseDir.
+ * Depth ≥ 2 prevents shallow system directories like /etc, /tmp, /var
+ * from being used as base directories while allowing real project paths
+ * like /opt/projects/myapp or D:\projects\myapp.
+ */
+const MIN_BASE_DIR_DEPTH = 2;
+
+/**
+ * Check if a path is too broad to be used as a baseDir.
+ * Rejects filesystem roots and shallow paths (depth < 2) that could
+ * expose sensitive system directories.
+ */
+export function isBaseDirUnsafe(p: string): boolean {
+  return getPathDepth(p) < MIN_BASE_DIR_DEPTH;
+}
+
 export function scanDirectory(dir: string, depth: number = 3): FileTreeNode[] {
   const resolvedDir = path.resolve(dir);
 


### PR DESCRIPTION
## 问题

文件树和预览 API（`/api/files`、`/api/files/preview`）要求 `baseDir` 必须位于 `os.homedir()` 下，导致 Windows 非系统盘项目（如 `D:\projects\myapp`）以及 Unix 上 `~` 之外的项目无法正常工作，返回 403 `\"Directory is outside the allowed scope\"`。

## 根因

1. 前端调用方（FileTree、MessageInput、FilePreview）**从未传递 `baseDir` 参数**，API 回退到 `homeDir` 限制
2. `homeDir` 限制对桌面应用过于严格 — 项目可以在文件系统任意位置

## 修改内容

### 后端（安全策略）

- **`src/lib/files.ts`** — 新增 `getPathDepth()` 计算目录相对根的深度，新增 `isBaseDirUnsafe()` 拒绝深度 < 2 的 `baseDir`（阻止 `/`、`/etc`、`/tmp` 等）
- **`src/app/api/files/route.ts`** — 用 `isBaseDirUnsafe(baseDir)` 替换 `isPathSafe(homeDir, baseDir)`
- **`src/app/api/files/preview/route.ts`** — 同步修改

### 前端（参数修复）

- **`src/components/project/FileTree.tsx`** — 传递 `baseDir=workingDirectory`
- **`src/components/chat/MessageInput.tsx`** — 修复缺失的 `dir` 参数（原来会 400），添加 `baseDir`
- **`src/components/project/FilePreview.tsx`** — 新增 `workingDirectory` prop，传递为 `baseDir`
- **`src/components/layout/RightPanel.tsx`** — 透传 `workingDirectory` 给 FilePreview

## 安全性考量

此修改在尽可能放宽限制的同时，最大程度保障了安全性：

| 安全层 | 措施 | 说明 |
|--------|------|------|
| **路径深度检查** | `baseDir` 深度必须 ≥ 2 | 阻止 `/etc`（深度 1）、`/tmp`（深度 1）等系统目录被用作 `baseDir`，防止 DNS rebinding 攻击暴露系统文件 |
| **根路径阻止** | 深度 0 被拒绝 | `/`、`C:\` 等根路径仍然被阻止 |
| **目录范围限制** | `isPathSafe(baseDir, dir)` 不变 | `dir` 必须在 `baseDir` 范围内，防止路径穿越 |
| **无 baseDir 回退** | 仍限制到 `homeDir` | 纵深防御：如果前端未传递 `baseDir`，保持原有的严格限制 |
| **网络绑定** | 服务器仅绑定 `127.0.0.1` | Electron main.ts 中硬编码 |

### 攻击场景分析

- ✅ `?dir=/etc/passwd&baseDir=/etc` → 拒绝（`/etc` 深度为 1，< 2）
- ✅ `?dir=/&baseDir=/` → 拒绝（`/` 深度为 0，< 2）
- ✅ `?dir=/tmp/evil&baseDir=/tmp` → 拒绝（`/tmp` 深度为 1，< 2）
- ✅ `?dir=/home/user/../etc&baseDir=/home/user` → 拒绝（resolve 后 dir 不在 baseDir 内）
- ✅ `?dir=D:\projects\myapp` （无 baseDir）→ 拒绝（回退到 homeDir 检查）
- ✅ `?dir=D:\projects\myapp&baseDir=D:\projects\myapp` → 允许（深度 ≥ 2）

## 测试

6 个测试套件，30 个测试全部通过，覆盖：
- `isPathSafe` 路径安全检查
- `isRootPath` 根路径检测
- `getPathDepth` 路径深度计算
- `isBaseDirUnsafe` baseDir 安全性验证
- 文件 API 路径穿越场景
- baseDir 验证端到端场景"