### PR TITLE
ci: multi-platform build (macOS + Windows, arm64 + x64)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,9 @@
-name: Build & Package
+name: Build & Release
 
 on:
+  push:
+    tags:
+      - "v*"
   workflow_dispatch:
     inputs:
       platform:
@@ -12,44 +15,11 @@ on:
           - all
           - windows
           - macos
-          - linux
-  push:
-    tags:
-      - "v*"
 
 permissions:
   contents: write
 
 jobs:
-  build-windows:
-    if: ${{ github.event_name == 'push' || inputs.platform == 'all' || inputs.platform == 'windows' }}
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: npm
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build Electron app
-        run: npm run electron:build
-
-      - name: Package for Windows
-        run: npx electron-builder --win --config electron-builder.yml --publish never
-
-      - name: Upload Windows artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: windows
-          path: |
-            release/*.exe
-            release/*.zip
-          if-no-files-found: warn
-
   build-macos:
     if: ${{ github.event_name == 'push' || inputs.platform == 'all' || inputs.platform == 'macos' }}
     runs-on: macos-latest
@@ -67,11 +37,16 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build Electron app
-        run: npm run electron:build
+      - name: Build Next.js
+        run: npm run build
 
-      - name: Package for macOS (${{ matrix.arch }})
+      - name: Build Electron
+        run: node scripts/build-electron.mjs
+
+      - name: Package macOS (${{ matrix.arch }})
         run: npx electron-builder --mac --${{ matrix.arch }} --config electron-builder.yml --publish never
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload macOS artifacts
         uses: actions/upload-artifact@v4
@@ -80,9 +55,9 @@ jobs:
           path: release/*.dmg
           if-no-files-found: warn
 
-  build-linux:
-    if: ${{ github.event_name == 'push' || inputs.platform == 'all' || inputs.platform == 'linux' }}
-    runs-on: ubuntu-latest
+  build-windows:
+    if: ${{ github.event_name == 'push' || inputs.platform == 'all' || inputs.platform == 'windows' }}
+    runs-on: windows-latest
     strategy:
       matrix:
         arch: [x64, arm64]
@@ -97,25 +72,27 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build Electron app
-        run: npm run electron:build
+      - name: Build Next.js
+        run: npm run build
 
-      - name: Package for Linux (${{ matrix.arch }})
-        run: npx electron-builder --linux --${{ matrix.arch }} --config electron-builder.yml --publish never
+      - name: Build Electron
+        run: node scripts/build-electron.mjs
 
-      - name: Upload Linux artifacts
+      - name: Package Windows (${{ matrix.arch }})
+        run: npx electron-builder --win --${{ matrix.arch }} --config electron-builder.yml --publish never
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload Windows artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: linux-${{ matrix.arch }}
-          path: |
-            release/*.AppImage
-            release/*.deb
-            release/*.rpm
+          name: windows-${{ matrix.arch }}
+          path: release/*.exe
           if-no-files-found: warn
 
   release:
     if: ${{ always() && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && !contains(needs.*.result, 'cancelled') }}
-    needs: [build-windows, build-macos, build-linux]
+    needs: [build-macos, build-windows]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -154,7 +131,7 @@ jobs:
       - name: Collect release files
         run: |
           mkdir -p release-files
-          find artifacts -type f \( -name '*.exe' -o -name '*.dmg' -o -name '*.AppImage' -o -name '*.deb' -o -name '*.rpm' -o -name '*.zip' \) -exec cp {} release-files/ \;
+          find artifacts -type f \( -name '*.exe' -o -name '*.dmg' \) ! -name '*.blockmap' -exec cp {} release-files/ \;
           ls -lh release-files/
 
       - name: Create GitHub Release
@@ -167,19 +144,15 @@ jobs:
           cat > release-notes.md << 'NOTES_EOF'
           ## Downloads
 
-          **Windows**
-          - **CodePilot Setup ${{ steps.meta.outputs.version }}.exe** — Windows installer (x64 + arm64)
-
           **macOS**
           - **CodePilot-${{ steps.meta.outputs.version }}-arm64.dmg** — macOS Apple Silicon (M1/M2/M3/M4)
           - **CodePilot-${{ steps.meta.outputs.version }}-x64.dmg** — macOS Intel
 
-          **Linux**
-          - **AppImage / deb / rpm** — x64 and arm64
+          **Windows**
+          - **CodePilot-${{ steps.meta.outputs.version }}-x64.exe** — Windows x64
+          - **CodePilot-${{ steps.meta.outputs.version }}-arm64.exe** — Windows ARM64
 
           ## Installation
-
-          **Windows**: 下载 exe 安装包，双击安装，按提示完成即可。
 
           **macOS**:
           1. 下载对应芯片架构的 DMG 文件
@@ -187,11 +160,15 @@ jobs:
           3. 首次打开时如遇安全提示，前往 **系统设置 → 隐私与安全性** 点击"仍要打开"
           4. 在 Settings 页面配置 Anthropic API Key 或环境变量
 
-          **Linux**: 使用 AppImage 直接运行，或通过 deb/rpm 包安装。
+          **Windows**:
+          1. 下载对应架构的 EXE 安装包（大多数用户选择 x64）
+          2. 运行安装程序，可自定义安装路径
+          3. 安装完成后启动 CodePilot
+          4. 在 Settings 页面配置 Anthropic API Key 或环境变量
 
           ## Requirements
 
-          - Windows 10+ / macOS 12.0+ / Linux (glibc 2.31+)
+          - macOS 12.0+ / Windows 10+
           - Anthropic API Key 或已配置 `ANTHROPIC_API_KEY` 环境变量
           - 如需使用代码相关功能，建议安装 Claude Code CLI
 

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -48,6 +48,7 @@ mac:
       arch: [arm64, x64]
 win:
   icon: build/icon.ico
+  artifactName: "${productName}-${version}-${arch}.${ext}"
   target:
     - target: nsis
       arch: [x64, arm64]


### PR DESCRIPTION
## Summary

- Rewrite `build.yml` to produce 4 platform artifacts via matrix strategy:
  - `CodePilot-{version}-arm64.dmg` (macOS Apple Silicon)
  - `CodePilot-{version}-x64.dmg` (macOS Intel)
  - `CodePilot-{version}-x64.exe` (Windows x64)
  - `CodePilot-{version}-arm64.exe` (Windows ARM64)
- Add `win.artifactName` in `electron-builder.yml` for arch-specific naming (consistent with macOS)
- Exclude `.blockmap` files from release artifacts
- Auto-generate changelog table in release notes
- Use `gh` CLI for release creation instead of third-party action
- Split build steps: `npm run build` + `node scripts/build-electron.mjs`
- Remove Linux build job (not tested/supported yet, config preserved in electron-builder.yml)

## Changes

| File | Change |
|------|--------|
| `.github/workflows/build.yml` | Rewrite: matrix build for macOS/Windows × x64/arm64, unified release job |
| `electron-builder.yml` | Add `win.artifactName: "${productName}-${version}-${arch}.${ext}"` |

## How it works

1. **Tag push** (`v*`) or **manual dispatch** triggers the workflow
2. `build-macos` job: matrix `[x64, arm64]` → 2 DMG artifacts
3. `build-windows` job: matrix `[x64, arm64]` → 2 EXE artifacts
4. `release` job: collects all artifacts (excluding blockmap), creates GitHub Release with changelog

## Test plan

- [ ] Push a test tag (e.g. `v0.9.1-test`) to verify all 4 builds complete
- [ ] Verify artifact naming: `CodePilot-{version}-{arch}.{ext}`
- [ ] Verify release notes format and changelog generation
- [ ] Verify no blockmap files in release assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)