### PR TITLE
Fix(Platform): Resolve Claude CLI path on Windows by parsing cmd wrappers

### DIFF
--- a/src/lib/claude-client.ts
+++ b/src/lib/claude-client.ts
@@ -19,7 +19,7 @@ import type { ClaudeStreamOptions, SSEEvent, TokenUsage, MCPServerConfig, Permis
 import { isImageFile } from '@/types';
 import { registerPendingPermission } from './permission-registry';
 import { getSetting, getActiveProvider } from './db';
-import { findClaudeBinary, findGitBash, getExpandedPath } from './platform';
+import { findClaudeBinary, findGitBash, getExpandedPath, resolveClaudeScriptPath } from './platform';
 import os from 'os';
 import fs from 'fs';
 import path from 'path';
@@ -264,6 +264,7 @@ export function streamClaude(options: ClaudeStreamOptions): ReadableStream<strin
 
         // Find claude binary for packaged app where PATH is limited
         const claudePath = findClaudePath();
+        
         if (claudePath) {
             // On Windows, if the binary is a .cmd/.bat file, we cannot use it directly
             // because the SDK uses spawn() without { shell: true } and doesn't expose an option to enable it.
@@ -272,7 +273,14 @@ export function streamClaude(options: ClaudeStreamOptions): ReadableStream<strin
             const isWindowsCmd = process.platform === 'win32' && /\.(cmd|bat)$/i.test(claudePath);
             
             if (isWindowsCmd) {
-                console.warn(`[claude-client] Ignoring system Claude binary "${claudePath}" because it requires shell execution (which SDK lacks). Falling back to internal implementation.`);
+                // Try to resolve the underlying JS file to run with node
+                const scriptPath = resolveClaudeScriptPath(claudePath);
+                if (scriptPath) {
+                     queryOptions.pathToClaudeCodeExecutable = scriptPath;
+                     // We rely on SDK default executable="node" to run this script
+                } else {
+                    console.warn(`[claude-client] Ignoring system Claude binary "${claudePath}" because it requires shell execution (which SDK lacks) and script resolution failed. Falling back to internal implementation.`);
+                }
             } else {
                 queryOptions.pathToClaudeCodeExecutable = claudePath;
             }

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -109,7 +109,7 @@ export function findClaudeBinary(): string | undefined {
         shell: needsShell(p),
       });
       return p;
-    } catch {
+    } catch (e) {
       // not found, try next
     }
   }
@@ -136,11 +136,11 @@ export function findClaudeBinary(): string | undefined {
           shell: needsShell(candidate),
         });
         return candidate;
-      } catch {
+      } catch (e) {
         continue;
       }
     }
-  } catch {
+  } catch (e) {
     // not found
   }
 
@@ -208,5 +208,60 @@ export function findGitBash(): string | null {
     // where git failed or timed out
   }
 
+  return null;
+}
+
+/**
+ * Resolve the actual JS script path from a Windows .cmd/.bat wrapper.
+ * This is needed because the SDK uses spawn() without shell, so we must run 'node <script>' directly.
+ */
+export function resolveClaudeScriptPath(cmdPath: string): string | null {
+  if (!isWindows || !/\.(cmd|bat)$/i.test(cmdPath)) {
+    return null;
+  }
+
+  try {
+    const content = fs.readFileSync(cmdPath, 'utf8');
+    
+    // Pattern 1: "%dp0%\node_modules\@anthropic-ai\claude-code\cli.js" (Standard npm global install)
+    // Pattern 2: node  "%~dp0\..\@anthropic-ai\claude-code\cli.js" (Some npm versions)
+    // Pattern 3: "%_prog%"  "%dp0%\node_modules\@anthropic-ai\claude-code\cli.js" (Current user case)
+    
+    // We want to find the argument that ends with cli.js
+    // The previous regex was too greedy or matched the wrong quotes
+    
+    // Strategy: Look for the specific segment containing cli.js, being careful about quotes.
+    // Match group 1 will be the path we want.
+    const match = content.match(/"([^"]*?node_modules[^"]*?cli\.js)"/i) || 
+                  content.match(/'([^']*?node_modules[^']*?cli\.js)'/i) ||
+                  content.match(/"([^"]*?cli\.js)"/i) ||
+                  content.match(/'([^']*?cli\.js)'/i) ||
+                  content.match(/([^\s"']+\.js)/i);
+
+    if (match && match[1]) {
+      let scriptPath = match[1];
+      
+      // Resolve %~dp0% or similar variables if present (simple replacement)
+      // Standard cmd variable for script directory is %~dp0
+      // In the user's file, it uses %dp0% which is set to %~dp0 earlier
+      if (scriptPath.includes('%~dp0') || scriptPath.includes('%dp0%')) {
+        const cmdDir = path.dirname(cmdPath);
+        scriptPath = scriptPath.replace(/%~dp0/g, cmdDir + '\\').replace(/%dp0%/g, cmdDir + '\\');
+      } else if (scriptPath.startsWith('.')) {
+         // Relative path
+         scriptPath = path.resolve(path.dirname(cmdPath), scriptPath);
+      }
+      
+      // Clean up path
+      scriptPath = path.normalize(scriptPath);
+      
+      if (fs.existsSync(scriptPath)) {
+        return scriptPath;
+      }
+    }
+  } catch (err) {
+    console.warn('[platform] Failed to resolve Claude script path:', err);
+  }
+  
   return null;
 }


### PR DESCRIPTION
## Description
This PR addresses an issue where the Claude Code executable is not found on Windows environments, specifically when running as a packaged application.

It implements logic to correctly parse Windows \.cmd\ / \.bat\ wrappers to locate the underlying \cli.js\ file, resolving issues with path resolution when \spawn\ cannot use \shell: true\.

## Dependency Note
> **️ This PR builds upon PR #39 (\ix/windows-spawn-einval\).**
> Please merge #39 first to ensure full Windows compatibility.

## Changes
- Added \esolveClaudeScriptPath\ in \platform.ts\ to parse \.cmd\ file content.
- Updated \claude-client.ts\ to use the resolved script path on Windows.
- Improved regex matching for quoted paths and \%~dp0\ variable expansion in batch files.