### PR TITLE
feat: add Hive Dashboard for multi-agent coordination

### DIFF
--- a/src/app/api/hive/events/route.ts
+++ b/src/app/api/hive/events/route.ts
@@ -1,0 +1,63 @@
+import { fetchHive } from '@/lib/hive';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: Request) {
+  const encoder = new TextEncoder();
+
+  const stream = new ReadableStream({
+    start(controller) {
+      let previousJson = '';
+
+      function sendEvent(event: string, data: unknown) {
+        controller.enqueue(
+          encoder.encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`)
+        );
+      }
+
+      async function poll() {
+        try {
+          const res = await fetchHive('/api/state');
+          if (!res.ok) {
+            sendEvent('hive:error', { message: 'Hivemind unavailable' });
+            return;
+          }
+          const data = await res.json();
+          const json = JSON.stringify(data);
+          if (json !== previousJson) {
+            previousJson = json;
+            sendEvent('hive:state', data);
+          }
+        } catch {
+          sendEvent('hive:error', { message: 'Connection to Hivemind lost' });
+        }
+      }
+
+      // Initial poll
+      poll();
+
+      // Poll every 3 seconds
+      const pollInterval = setInterval(poll, 3000);
+
+      // Keepalive every 30 seconds
+      const pingInterval = setInterval(() => {
+        sendEvent('hive:ping', { time: Date.now() });
+      }, 30000);
+
+      // Cleanup on disconnect
+      request.signal.addEventListener('abort', () => {
+        clearInterval(pollInterval);
+        clearInterval(pingInterval);
+        controller.close();
+      });
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive',
+    },
+  });
+}

--- a/src/app/api/hive/health/route.ts
+++ b/src/app/api/hive/health/route.ts
@@ -1,0 +1,15 @@
+import { fetchHive } from '@/lib/hive';
+
+export async function GET() {
+  try {
+    const res = await fetchHive('/api/health');
+    if (!res.ok) {
+      return Response.json({ error: 'Hivemind unavailable' }, { status: 502 });
+    }
+    const data = await res.json();
+    return Response.json(data);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to reach Hivemind';
+    return Response.json({ error: message }, { status: 502 });
+  }
+}

--- a/src/app/api/hive/state/route.ts
+++ b/src/app/api/hive/state/route.ts
@@ -1,0 +1,15 @@
+import { fetchHive } from '@/lib/hive';
+
+export async function GET() {
+  try {
+    const res = await fetchHive('/api/state');
+    if (!res.ok) {
+      return Response.json({ error: 'Hivemind unavailable' }, { status: 502 });
+    }
+    const data = await res.json();
+    return Response.json(data);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to reach Hivemind';
+    return Response.json({ error: message }, { status: 502 });
+  }
+}

--- a/src/app/api/hive/tasks/route.ts
+++ b/src/app/api/hive/tasks/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest } from 'next/server';
+import { fetchHive } from '@/lib/hive';
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const res = await fetchHive('/api/tasks/add', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        description: body.task,
+        priority: body.priority || 'normal',
+      }),
+    });
+    if (!res.ok) {
+      const errData = await res.json().catch(() => ({}));
+      return Response.json(
+        { error: errData.error || 'Failed to add task' },
+        { status: res.status }
+      );
+    }
+    const data = await res.json();
+    return Response.json(data, { status: 201 });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to reach Hivemind';
+    return Response.json({ error: message }, { status: 502 });
+  }
+}

--- a/src/app/hive/HivePageInner.tsx
+++ b/src/app/hive/HivePageInner.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useState } from "react";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { ArrowReloadHorizontalIcon } from "@hugeicons/core-free-icons";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Button } from "@/components/ui/button";
+import { useHive } from "@/hooks/useHive";
+import { OverviewPanel } from "@/components/hive/OverviewPanel";
+import { AgentsView } from "@/components/hive/AgentsView";
+import { TaskQueue } from "@/components/hive/TaskQueue";
+import { ActivityFeed } from "@/components/hive/ActivityFeed";
+import { FileLocksView } from "@/components/hive/FileLocksView";
+
+type HiveTab = "overview" | "agents" | "tasks" | "activity" | "locks";
+
+export function HivePageInner() {
+  const { state, health, connected, loading, error, refetch, addTask } = useHive();
+  const [tab, setTab] = useState<HiveTab>("overview");
+
+  return (
+    <div className="flex h-full flex-col">
+      {/* Header */}
+      <div className="px-6 pt-4 pb-0">
+        <div className="mb-3 flex items-center justify-between">
+          <div>
+            <h1 className="text-xl font-semibold">Hive Dashboard</h1>
+            <p className="text-sm text-muted-foreground">
+              Multi-agent coordination command center
+            </p>
+          </div>
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={refetch}
+            disabled={loading}
+            className="h-8 w-8"
+          >
+            <HugeiconsIcon
+              icon={ArrowReloadHorizontalIcon}
+              className={`h-4 w-4 ${loading ? "animate-spin" : ""}`}
+            />
+            <span className="sr-only">Refresh</span>
+          </Button>
+        </div>
+
+        {/* Error Banner */}
+        {error && !connected && (
+          <div className="mb-3 rounded-md border border-destructive/50 bg-destructive/10 px-4 py-2 text-sm text-destructive">
+            {error}
+          </div>
+        )}
+
+        {/* Tabs */}
+        <Tabs value={tab} onValueChange={(v) => setTab(v as HiveTab)}>
+          <TabsList>
+            <TabsTrigger value="overview">Overview</TabsTrigger>
+            <TabsTrigger value="agents">Agents</TabsTrigger>
+            <TabsTrigger value="tasks">Tasks</TabsTrigger>
+            <TabsTrigger value="activity">Activity</TabsTrigger>
+            <TabsTrigger value="locks">File Locks</TabsTrigger>
+          </TabsList>
+        </Tabs>
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 overflow-auto p-6">
+        {tab === "overview" && (
+          <OverviewPanel state={state} health={health} connected={connected} />
+        )}
+        {tab === "agents" && <AgentsView agents={state?.agents ?? []} />}
+        {tab === "tasks" && (
+          <TaskQueue tasks={state?.tasks ?? []} onAddTask={addTask} />
+        )}
+        {tab === "activity" && (
+          <ActivityFeed
+            decisions={state?.decisions ?? []}
+            activity={state?.activity ?? []}
+          />
+        )}
+        {tab === "locks" && <FileLocksView locks={state?.locks ?? []} />}
+      </div>
+    </div>
+  );
+}

--- a/src/app/hive/page.tsx
+++ b/src/app/hive/page.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { Suspense } from "react";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Loading02Icon } from "@hugeicons/core-free-icons";
+import { HivePageInner } from "./HivePageInner";
+
+export default function HivePage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex h-full items-center justify-center">
+          <HugeiconsIcon icon={Loading02Icon} className="h-5 w-5 animate-spin text-muted-foreground" />
+        </div>
+      }
+    >
+      <HivePageInner />
+    </Suspense>
+  );
+}

--- a/src/components/hive/ActivityFeed.tsx
+++ b/src/components/hive/ActivityFeed.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { formatRelativeTime } from "@/lib/hive";
+import type { HiveDecision, HiveActivity } from "@/types";
+
+interface ActivityFeedProps {
+  decisions: HiveDecision[];
+  activity: HiveActivity[];
+}
+
+interface TimelineEntry {
+  kind: "decision" | "activity";
+  agent: string;
+  message: string;
+  detail?: string;
+  timestamp: string;
+}
+
+export function ActivityFeed({ decisions, activity }: ActivityFeedProps) {
+  const entries: TimelineEntry[] = [
+    ...decisions.map(
+      (d): TimelineEntry => ({
+        kind: "decision",
+        agent: d.agent,
+        message: d.what,
+        detail: d.why,
+        timestamp: d.timestamp,
+      })
+    ),
+    ...activity.map(
+      (a): TimelineEntry => ({
+        kind: "activity",
+        agent: a.agent,
+        message: a.action,
+        detail: a.details,
+        timestamp: a.timestamp,
+      })
+    ),
+  ].sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
+
+  if (entries.length === 0) {
+    return (
+      <div className="flex h-48 items-center justify-center text-muted-foreground">
+        No activity yet
+      </div>
+    );
+  }
+
+  return (
+    <ScrollArea className="h-[calc(100vh-16rem)]">
+      <div className="space-y-3 pr-2">
+        {entries.map((entry, i) => (
+          <div key={`${entry.timestamp}-${i}`} className="flex gap-3 rounded-lg border p-3">
+            <div className="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-muted text-xs">
+              {entry.kind === "decision" ? "D" : "A"}
+            </div>
+            <div className="min-w-0 flex-1 space-y-1">
+              <div className="flex items-center gap-2">
+                <Badge variant="secondary" className="text-[10px]">
+                  {entry.agent}
+                </Badge>
+                <span className="text-xs text-muted-foreground">
+                  {formatRelativeTime(entry.timestamp)}
+                </span>
+              </div>
+              <p className="text-sm">{entry.message}</p>
+              {entry.detail && (
+                <p className="text-xs text-muted-foreground">{entry.detail}</p>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    </ScrollArea>
+  );
+}

--- a/src/components/hive/AgentsView.tsx
+++ b/src/components/hive/AgentsView.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { formatRelativeTime } from "@/lib/hive";
+import type { HiveAgent } from "@/types";
+
+interface AgentsViewProps {
+  agents: HiveAgent[];
+}
+
+export function AgentsView({ agents }: AgentsViewProps) {
+  if (agents.length === 0) {
+    return (
+      <div className="flex h-48 items-center justify-center text-muted-foreground">
+        No agents connected
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {agents.map((agent) => (
+        <Card key={agent.id} className="py-4">
+          <CardHeader className="pb-2">
+            <div className="flex items-center justify-between">
+              <CardTitle className="text-sm font-medium">{agent.name}</CardTitle>
+              <div className="flex items-center gap-1.5">
+                <span className="relative flex h-2.5 w-2.5">
+                  {agent.status === "online" && (
+                    <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-green-400 opacity-75" />
+                  )}
+                  <span
+                    className={`relative inline-flex h-2.5 w-2.5 rounded-full ${
+                      agent.status === "online" ? "bg-green-500" : "bg-gray-400"
+                    }`}
+                  />
+                </span>
+                <Badge
+                  variant={agent.status === "online" ? "secondary" : "outline"}
+                  className="text-[10px]"
+                >
+                  {agent.status}
+                </Badge>
+              </div>
+            </div>
+          </CardHeader>
+          <CardContent className="space-y-1">
+            {agent.currentTask ? (
+              <p className="text-sm text-muted-foreground line-clamp-2">
+                {agent.currentTask}
+              </p>
+            ) : (
+              <p className="text-sm text-muted-foreground italic">Idle</p>
+            )}
+            <p className="text-xs text-muted-foreground">
+              Last seen: {formatRelativeTime(agent.lastSeen)}
+            </p>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/src/components/hive/FileLocksView.tsx
+++ b/src/components/hive/FileLocksView.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { formatRelativeTime } from "@/lib/hive";
+import type { HiveFileLock } from "@/types";
+
+interface FileLocksViewProps {
+  locks: HiveFileLock[];
+}
+
+export function FileLocksView({ locks }: FileLocksViewProps) {
+  if (locks.length === 0) {
+    return (
+      <div className="flex h-48 items-center justify-center text-muted-foreground">
+        No file locks active
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+      {locks.map((lock) => (
+        <Card key={lock.file} className="py-3 gap-2">
+          <CardContent className="px-4 space-y-2">
+            <p className="truncate font-mono text-sm" title={lock.file}>
+              {lock.file}
+            </p>
+            <div className="flex items-center gap-2">
+              <Badge variant="secondary" className="text-[10px]">
+                {lock.owner}
+              </Badge>
+              <span className="text-xs text-muted-foreground">
+                {formatRelativeTime(lock.acquiredAt)}
+              </span>
+            </div>
+            {lock.expiresAt && (
+              <p className="text-xs text-muted-foreground">
+                Expires: {formatRelativeTime(lock.expiresAt)}
+              </p>
+            )}
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/src/components/hive/OverviewPanel.tsx
+++ b/src/components/hive/OverviewPanel.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import type { HiveState, HiveHealthResponse } from "@/types";
+
+interface OverviewPanelProps {
+  state: HiveState | null;
+  health: HiveHealthResponse | null;
+  connected: boolean;
+}
+
+export function OverviewPanel({ state, health, connected }: OverviewPanelProps) {
+  const agentCount = state?.agents?.length ?? health?.agentCount ?? 0;
+  const activeTasks = state?.tasks?.filter((t) => t.status !== "completed").length ?? 0;
+  const lockCount = state?.locks?.length ?? 0;
+
+  return (
+    <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+      {/* Connection Status */}
+      <Card className="py-4">
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-medium text-muted-foreground">
+            Connection
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex items-center gap-2">
+            <span className="relative flex h-3 w-3">
+              {connected && (
+                <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-green-400 opacity-75" />
+              )}
+              <span
+                className={`relative inline-flex h-3 w-3 rounded-full ${
+                  connected ? "bg-green-500" : "bg-red-500"
+                }`}
+              />
+            </span>
+            <Badge variant={connected ? "secondary" : "destructive"}>
+              {connected ? "Online" : "Offline"}
+            </Badge>
+          </div>
+          {health?.uptime != null && (
+            <p className="mt-1 text-xs text-muted-foreground">
+              Uptime: {Math.floor(health.uptime / 60)}m
+            </p>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Agent Count */}
+      <Card className="py-4">
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-medium text-muted-foreground">
+            Agents
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-2xl font-bold">{agentCount}</p>
+          <p className="text-xs text-muted-foreground">
+            {state?.agents?.filter((a) => a.status === "online").length ?? 0} online
+          </p>
+        </CardContent>
+      </Card>
+
+      {/* Active Tasks */}
+      <Card className="py-4">
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-medium text-muted-foreground">
+            Active Tasks
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-2xl font-bold">{activeTasks}</p>
+          <p className="text-xs text-muted-foreground">
+            {state?.tasks?.filter((t) => t.status === "in_progress").length ?? 0} in progress
+          </p>
+        </CardContent>
+      </Card>
+
+      {/* File Locks */}
+      <Card className="py-4">
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-medium text-muted-foreground">
+            File Locks
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-2xl font-bold">{lockCount}</p>
+          <p className="text-xs text-muted-foreground">
+            {lockCount === 1 ? "1 file locked" : `${lockCount} files locked`}
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/hive/TaskQueue.tsx
+++ b/src/components/hive/TaskQueue.tsx
@@ -1,0 +1,173 @@
+"use client";
+
+import { useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import type { HiveTask } from "@/types";
+
+interface TaskQueueProps {
+  tasks: HiveTask[];
+  onAddTask: (task: string, priority: "low" | "normal" | "high") => Promise<void>;
+}
+
+const PRIORITY_STYLES: Record<string, string> = {
+  high: "bg-red-500/10 text-red-500",
+  normal: "bg-blue-500/10 text-blue-500",
+  low: "bg-gray-500/10 text-gray-500",
+};
+
+const STATUS_STYLES: Record<string, string> = {
+  pending: "bg-yellow-500/10 text-yellow-600",
+  in_progress: "bg-blue-500/10 text-blue-500",
+  completed: "bg-green-500/10 text-green-500",
+};
+
+function TaskCard({ task }: { task: HiveTask }) {
+  return (
+    <Card className="py-3 gap-2">
+      <CardContent className="px-4 space-y-2">
+        <p className="text-sm line-clamp-3">{task.description}</p>
+        <div className="flex flex-wrap items-center gap-1.5">
+          <Badge variant="outline" className={PRIORITY_STYLES[task.priority]}>
+            {task.priority}
+          </Badge>
+          <Badge variant="outline" className={STATUS_STYLES[task.status]}>
+            {task.status.replace("_", " ")}
+          </Badge>
+          {task.assignedTo && (
+            <Badge variant="secondary" className="text-[10px]">
+              {task.assignedTo}
+            </Badge>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function TaskQueue({ tasks, onAddTask }: TaskQueueProps) {
+  const [taskInput, setTaskInput] = useState("");
+  const [priority, setPriority] = useState<"low" | "normal" | "high">("normal");
+  const [submitting, setSubmitting] = useState(false);
+
+  const pending = tasks.filter((t) => t.status === "pending");
+  const inProgress = tasks.filter((t) => t.status === "in_progress");
+  const completed = tasks.filter((t) => t.status === "completed");
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!taskInput.trim()) return;
+    setSubmitting(true);
+    try {
+      await onAddTask(taskInput.trim(), priority);
+      setTaskInput("");
+      setPriority("normal");
+    } catch {
+      // Error handled by parent
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Add Task Form */}
+      <form onSubmit={handleSubmit} className="flex items-end gap-2">
+        <div className="flex-1 space-y-1.5">
+          <Label htmlFor="task-input">New Task</Label>
+          <Input
+            id="task-input"
+            placeholder="Describe the task..."
+            value={taskInput}
+            onChange={(e) => setTaskInput(e.target.value)}
+            disabled={submitting}
+          />
+        </div>
+        <div className="space-y-1.5">
+          <Label>Priority</Label>
+          <Select value={priority} onValueChange={(v) => setPriority(v as typeof priority)}>
+            <SelectTrigger className="w-28">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="low">Low</SelectItem>
+              <SelectItem value="normal">Normal</SelectItem>
+              <SelectItem value="high">High</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        <Button type="submit" disabled={submitting || !taskInput.trim()}>
+          {submitting ? "Adding..." : "Add"}
+        </Button>
+      </form>
+
+      {/* 3-Column Kanban */}
+      <div className="grid grid-cols-3 gap-4 min-h-0">
+        {/* Pending */}
+        <div className="flex flex-col gap-2">
+          <h3 className="text-sm font-medium text-muted-foreground">
+            Pending ({pending.length})
+          </h3>
+          <ScrollArea className="h-[calc(100vh-22rem)]">
+            <div className="flex flex-col gap-2 pr-2">
+              {pending.length === 0 ? (
+                <p className="text-xs text-muted-foreground italic py-4 text-center">
+                  No pending tasks
+                </p>
+              ) : (
+                pending.map((t) => <TaskCard key={t.id} task={t} />)
+              )}
+            </div>
+          </ScrollArea>
+        </div>
+
+        {/* In Progress */}
+        <div className="flex flex-col gap-2">
+          <h3 className="text-sm font-medium text-muted-foreground">
+            In Progress ({inProgress.length})
+          </h3>
+          <ScrollArea className="h-[calc(100vh-22rem)]">
+            <div className="flex flex-col gap-2 pr-2">
+              {inProgress.length === 0 ? (
+                <p className="text-xs text-muted-foreground italic py-4 text-center">
+                  No tasks in progress
+                </p>
+              ) : (
+                inProgress.map((t) => <TaskCard key={t.id} task={t} />)
+              )}
+            </div>
+          </ScrollArea>
+        </div>
+
+        {/* Completed */}
+        <div className="flex flex-col gap-2">
+          <h3 className="text-sm font-medium text-muted-foreground">
+            Completed ({completed.length})
+          </h3>
+          <ScrollArea className="h-[calc(100vh-22rem)]">
+            <div className="flex flex-col gap-2 pr-2">
+              {completed.length === 0 ? (
+                <p className="text-xs text-muted-foreground italic py-4 text-center">
+                  No completed tasks
+                </p>
+              ) : (
+                completed.map((t) => <TaskCard key={t.id} task={t} />)
+              )}
+            </div>
+          </ScrollArea>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/NavRail.tsx
+++ b/src/components/layout/NavRail.tsx
@@ -10,6 +10,7 @@ import {
   Message02Icon,
   PlusSignIcon,
   GridIcon,
+  Share08Icon,
   Settings02Icon,
   Moon02Icon,
   Sun02Icon,
@@ -31,6 +32,7 @@ interface NavRailProps {
 
 const navItems = [
   { href: "/chat", label: "Chats", icon: Message02Icon },
+  { href: "/hive", label: "Hive", icon: Share08Icon },
   { href: "/extensions", label: "Extensions", icon: GridIcon },
   { href: "/settings", label: "Settings", icon: Settings02Icon },
 ] as const;

--- a/src/hooks/useHive.ts
+++ b/src/hooks/useHive.ts
@@ -1,0 +1,124 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { HiveState, HiveHealthResponse } from "@/types";
+
+interface UseHiveReturn {
+  state: HiveState | null;
+  health: HiveHealthResponse | null;
+  connected: boolean;
+  loading: boolean;
+  error: string | null;
+  refetch: () => void;
+  addTask: (task: string, priority?: "low" | "normal" | "high") => Promise<void>;
+}
+
+export function useHive(): UseHiveReturn {
+  const [state, setState] = useState<HiveState | null>(null);
+  const [health, setHealth] = useState<HiveHealthResponse | null>(null);
+  const [connected, setConnected] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const eventSourceRef = useRef<EventSource | null>(null);
+
+  const fetchInitial = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const [stateRes, healthRes] = await Promise.all([
+        fetch("/api/hive/state"),
+        fetch("/api/hive/health"),
+      ]);
+
+      if (stateRes.ok) {
+        const stateData = await stateRes.json();
+        setState(stateData);
+        setConnected(true);
+      } else {
+        setConnected(false);
+        setError("Hivemind unavailable");
+      }
+
+      if (healthRes.ok) {
+        const healthData = await healthRes.json();
+        setHealth(healthData);
+      }
+    } catch {
+      setConnected(false);
+      setError("Failed to connect to Hivemind");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const connectSSE = useCallback(() => {
+    if (eventSourceRef.current) {
+      eventSourceRef.current.close();
+    }
+
+    const es = new EventSource("/api/hive/events");
+    eventSourceRef.current = es;
+
+    es.addEventListener("hive:state", (event) => {
+      try {
+        const data = JSON.parse(event.data);
+        setState(data);
+        setConnected(true);
+        setError(null);
+      } catch {
+        // ignore parse errors
+      }
+    });
+
+    es.addEventListener("hive:error", (event) => {
+      try {
+        const data = JSON.parse(event.data);
+        setError(data.message);
+        setConnected(false);
+      } catch {
+        setError("Connection error");
+        setConnected(false);
+      }
+    });
+
+    es.onerror = () => {
+      setConnected(false);
+      setError("SSE connection lost");
+      es.close();
+      // Reconnect after 5 seconds
+      setTimeout(connectSSE, 5000);
+    };
+  }, []);
+
+  useEffect(() => {
+    fetchInitial();
+    connectSSE();
+
+    return () => {
+      eventSourceRef.current?.close();
+    };
+  }, [fetchInitial, connectSSE]);
+
+  const refetch = useCallback(() => {
+    fetchInitial();
+  }, [fetchInitial]);
+
+  const addTask = useCallback(
+    async (task: string, priority: "low" | "normal" | "high" = "normal") => {
+      const res = await fetch("/api/hive/tasks", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ task, priority }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error || "Failed to add task");
+      }
+      // Refetch to pick up the new task
+      await fetchInitial();
+    },
+    [fetchInitial]
+  );
+
+  return { state, health, connected, loading, error, refetch, addTask };
+}

--- a/src/lib/hive.ts
+++ b/src/lib/hive.ts
@@ -1,0 +1,31 @@
+export const HIVE_BASE_URL = process.env.HIVE_URL || 'http://localhost:8700';
+
+export async function fetchHive(path: string, options?: RequestInit): Promise<Response> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 5000);
+
+  try {
+    const res = await fetch(`${HIVE_BASE_URL}${path}`, {
+      ...options,
+      signal: controller.signal,
+    });
+    return res;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export function formatRelativeTime(dateStr: string): string {
+  const date = new Date(dateStr.includes('T') ? dateStr : dateStr + 'Z');
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMin = Math.floor(diffMs / 60000);
+  const diffHr = Math.floor(diffMin / 60);
+  const diffDay = Math.floor(diffHr / 24);
+
+  if (diffMin < 1) return 'just now';
+  if (diffMin < 60) return `${diffMin}m ago`;
+  if (diffHr < 24) return `${diffHr}h ago`;
+  if (diffDay < 7) return `${diffDay}d ago`;
+  return date.toLocaleDateString();
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -433,3 +433,67 @@ export interface ClaudeStreamOptions {
   permissionMode?: string;
   files?: FileAttachment[];
 }
+
+// ==========================================
+// Hive (Multi-Agent Coordination) Types
+// ==========================================
+
+export interface HiveAgent {
+  id: string;
+  name: string;
+  status: 'online' | 'offline';
+  currentTask?: string;
+  lastSeen: string;
+}
+
+export interface HiveTask {
+  id: string;
+  description: string;
+  status: 'pending' | 'in_progress' | 'completed';
+  priority: 'low' | 'normal' | 'high';
+  assignedTo?: string;
+  createdAt: string;
+  completedAt?: string;
+  result?: string;
+}
+
+export interface HiveFileLock {
+  file: string;
+  owner: string;
+  acquiredAt: string;
+  expiresAt?: string;
+}
+
+export interface HiveDecision {
+  agent: string;
+  what: string;
+  why: string;
+  timestamp: string;
+}
+
+export interface HiveActivity {
+  agent: string;
+  action: string;
+  timestamp: string;
+  details?: string;
+}
+
+export interface HiveState {
+  agents: HiveAgent[];
+  tasks: HiveTask[];
+  locks: HiveFileLock[];
+  decisions: HiveDecision[];
+  activity: HiveActivity[];
+  context?: Record<string, unknown>;
+}
+
+export interface HiveHealthResponse {
+  status: string;
+  uptime: number;
+  agentCount: number;
+}
+
+export interface HiveAddTaskRequest {
+  task: string;
+  priority?: 'low' | 'normal' | 'high';
+}


### PR DESCRIPTION
## Summary

- Add `/hive` route with a real-time dashboard for Hivemind multi-agent coordination system
- Includes SSE-based live updates (3s polling server-side, pushed as SSE events), agent monitoring, task kanban board with add-task form, unified activity/decision feed, and file lock tracking
- Zero new dependencies — uses existing shadcn/ui components, `@hugeicons/core-free-icons`, and native `fetch`/`EventSource`

## New Files

| File | Purpose |
|------|---------|
| `src/types/index.ts` | 8 new Hive interfaces |
| `src/lib/hive.ts` | Shared fetch utility + `formatRelativeTime` |
| `src/app/api/hive/health/route.ts` | Health check proxy |
| `src/app/api/hive/state/route.ts` | State proxy |
| `src/app/api/hive/tasks/route.ts` | Task submission proxy |
| `src/app/api/hive/events/route.ts` | SSE real-time stream |
| `src/hooks/useHive.ts` | Hive state management hook |
| `src/components/hive/OverviewPanel.tsx` | Connection, agents, tasks, locks stat cards |
| `src/components/hive/AgentsView.tsx` | Agent card grid with online/offline pulse |
| `src/components/hive/TaskQueue.tsx` | Add task form + 3-column kanban |
| `src/components/hive/ActivityFeed.tsx` | Decisions + activity timeline |
| `src/components/hive/FileLocksView.tsx` | File lock cards |
| `src/app/hive/page.tsx` | Page with Suspense wrapper |
| `src/app/hive/HivePageInner.tsx` | Tabs layout with error banner |
| `src/components/layout/NavRail.tsx` | Hive nav item (Share08Icon) |

## Test plan

- [ ] Start Hivemind on `localhost:8700` and launch CodePilot
- [ ] Click Hive icon in NavRail → dashboard loads with Overview tab
- [ ] Verify stat cards show correct agent count, tasks, locks
- [ ] Switch between all 5 tabs — each renders data
- [ ] Add a task via the form → appears in Pending column
- [ ] Acquire a lock from another terminal → appears in File Locks tab via SSE
- [ ] Stop Hivemind → error banner appears, connection shows Offline

🤖 Generated with [Claude Code](https://claude.com/claude-code)