### PR TITLE
docs: add missing electron build step before electron:dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ npm install
 npm run dev
 
 # -- or start the full Electron app in dev mode --
+node scripts/build-electron.mjs   # compile Electron main process (first time only)
 npm run electron:dev
 ```
 
@@ -196,6 +197,9 @@ codepilot/
 ```bash
 # Run Next.js dev server only (opens in browser)
 npm run dev
+
+# Compile the Electron main process (required before first run)
+node scripts/build-electron.mjs
 
 # Run the full Electron app in dev mode
 # (starts Next.js + waits for it, then opens Electron)

--- a/README_CN.md
+++ b/README_CN.md
@@ -64,6 +64,7 @@ npm install
 npm run dev
 
 # -- 或者启动完整的 Electron 桌面应用 --
+node scripts/build-electron.mjs   # 编译 Electron 主进程（首次运行前需要）
 npm run electron:dev
 ```
 
@@ -196,6 +197,9 @@ codepilot/
 ```bash
 # 仅运行 Next.js 开发服务器（在浏览器中打开）
 npm run dev
+
+# 编译 Electron 主进程（首次运行前需要执行）
+node scripts/build-electron.mjs
 
 # 运行完整的 Electron 桌面应用（开发模式）
 # （先启动 Next.js，等待就绪后打开 Electron）

--- a/README_JA.md
+++ b/README_JA.md
@@ -73,6 +73,7 @@ npm install
 npm run dev
 
 # -- または、開発モードで完全な Electron アプリを起動 --
+node scripts/build-electron.mjs   # Electron メインプロセスをコンパイル（初回のみ必要）
 npm run electron:dev
 ```
 
@@ -191,6 +192,9 @@ codepilot/
 ```bash
 # Next.js 開発サーバーのみを実行（ブラウザで開く）
 npm run dev
+
+# Electron メインプロセスをコンパイル（初回実行前に必要）
+node scripts/build-electron.mjs
 
 # 開発モードで完全な Electron アプリを実行
 # (Next.js を起動して待機し、その後 Electron を開く)


### PR DESCRIPTION
The `electron:dev` script requires `dist-electron/main.js` to exist, but the README does not mention running `node scripts/build-electron.mjs` beforehand. Without this step, `electron .` fails with:
  "Cannot find module '/path/to/dist-electron/main.js'"

Add the build command to both the Quick Start and Development sections in all three README files (EN, CN, JA).