### PR TITLE
feat: forward slash commands to Claude via Telegram bridge

### DIFF
--- a/src/lib/bridge/adapters/telegram-adapter.ts
+++ b/src/lib/bridge/adapters/telegram-adapter.ts
@@ -319,14 +319,22 @@ export class TelegramAdapter extends BaseChannelAdapter {
     const customCommands = loadCustomCommands();
     const customTelegramCommands = customCommands
       .map(cmd => ({
-        // Telegram command names: lowercase, no special chars except underscores
-        // Colon-separated names (e.g. "review:pr") become "review_pr"
-        command: cmd.name.replace(/:/g, '_').toLowerCase().replace(/[^a-z0-9_]/g, ''),
+        // Use pre-computed telegramName from command-loader (explicit mapping)
+        command: cmd.telegramName,
         description: cmd.description.slice(0, 256),
       }))
       .filter(cmd => cmd.command.length > 0 && cmd.command.length <= 32);
 
+    const totalCommands = builtinCommands.length + customTelegramCommands.length;
+
     // Telegram API limits: max 100 commands
+    if (totalCommands > 100) {
+      console.warn(
+        `[telegram-adapter] ${totalCommands} commands exceed Telegram's 100-command limit. ` +
+        `${totalCommands - 100} custom command(s) will be silently truncated.`
+      );
+    }
+
     const allCommands = [...builtinCommands, ...customTelegramCommands].slice(0, 100);
 
     await callTelegramApi(token, 'setMyCommands', { commands: allCommands });

--- a/src/lib/bridge/bridge-manager.ts
+++ b/src/lib/bridge/bridge-manager.ts
@@ -358,67 +358,14 @@ async function handleMessage(
 
   // Regular message — route to conversation engine
   const binding = router.resolve(msg.address);
-
-  // Notify adapter that message processing is starting (e.g., typing indicator)
-  adapter.onMessageStart?.(msg.address.chatId);
-
-  // Create an AbortController so /stop can cancel this task externally
-  const taskAbort = new AbortController();
-  const state = getState();
-  state.activeTasks.set(binding.codepilotSessionId, taskAbort);
+  const promptText = text || (hasAttachments ? 'Describe this image.' : '');
 
   try {
-    // Pass permission callback so requests are forwarded to IM immediately
-    // during streaming (the stream blocks until permission is resolved).
-    // Use text or empty string for image-only messages (prompt is still required by streamClaude)
-    const promptText = text || (hasAttachments ? 'Describe this image.' : '');
-
-    const result = await engine.processMessage(binding, promptText, async (perm) => {
-      await broker.forwardPermissionRequest(
-        adapter,
-        msg.address,
-        perm.permissionRequestId,
-        perm.toolName,
-        perm.toolInput,
-        binding.codepilotSessionId,
-        perm.suggestions,
-      );
-    }, taskAbort.signal, hasAttachments ? msg.attachments : undefined);
-
-    // Send response text — render Markdown to Telegram HTML
-    if (result.responseText) {
-      const chunks = markdownToTelegramChunks(result.responseText, 4096);
-      if (chunks.length > 0) {
-        await deliverRendered(adapter, msg.address, chunks, {
-          sessionId: binding.codepilotSessionId,
-        });
-      }
-    } else if (result.hasError) {
-      const errorResponse: OutboundMessage = {
-        address: msg.address,
-        text: `<b>Error:</b> ${escapeHtml(result.errorMessage)}`,
-        parseMode: 'HTML',
-      };
-      await deliver(adapter, errorResponse);
-    }
-
-    // Persist the actual SDK session ID for future resume.
-    // If the result has an error and no session ID was captured, clear the
-    // stale ID so the next message starts fresh instead of retrying a broken resume.
-    if (binding.id) {
-      try {
-        if (result.sdkSessionId) {
-          updateChannelBinding(binding.id, { sdkSessionId: result.sdkSessionId });
-        } else if (result.hasError && binding.sdkSessionId) {
-          updateChannelBinding(binding.id, { sdkSessionId: '' });
-        }
-      } catch { /* best effort */ }
-    }
+    await processConversation(
+      adapter, msg, binding, promptText,
+      hasAttachments ? msg.attachments : undefined,
+    );
   } finally {
-    state.activeTasks.delete(binding.codepilotSessionId);
-    // Notify adapter that message processing ended
-    adapter.onMessageEnd?.(msg.address.chatId);
-    // Commit the offset only after full processing (success or failure)
     ack();
   }
 }
@@ -610,10 +557,9 @@ async function handleCommand(
       const commandName = command.slice(1); // Remove leading '/'
       const binding = router.resolve(msg.address);
 
-      // Try exact name first, then underscore→colon fallback
-      // (Telegram converts "review:pr" to "review_pr" in command names)
-      const customCmd = findCustomCommand(commandName, binding.workingDirectory)
-        ?? findCustomCommand(commandName.replace(/_/g, ':'), binding.workingDirectory);
+      // findCustomCommand handles both original names and Telegram-safe names
+      // (e.g. "review:pr" and "review_pr" both resolve correctly)
+      const customCmd = findCustomCommand(commandName, binding.workingDirectory);
 
       if (customCmd) {
         // Custom command found — expand the .md content as prompt,
@@ -642,16 +588,16 @@ async function handleCommand(
 }
 
 /**
- * Forward a prompt to the conversation engine and deliver the response.
- * Used for custom commands and unrecognized slash commands.
+ * Core conversation processing: send prompt to engine, deliver response, persist session.
+ * Shared by both regular message handling and slash command forwarding.
  */
-async function forwardToConversation(
+async function processConversation(
   adapter: BaseChannelAdapter,
   msg: InboundMessage,
-  binding: import('./types').ChannelBinding,
+  binding: ReturnType<typeof router.resolve>,
   prompt: string,
+  attachments?: InboundMessage['attachments'],
 ): Promise<void> {
-  // Notify adapter that message processing is starting
   adapter.onMessageStart?.(msg.address.chatId);
 
   const taskAbort = new AbortController();
@@ -669,7 +615,7 @@ async function forwardToConversation(
         binding.codepilotSessionId,
         perm.suggestions,
       );
-    }, taskAbort.signal);
+    }, taskAbort.signal, attachments);
 
     if (result.responseText) {
       const chunks = markdownToTelegramChunks(result.responseText, 4096);
@@ -686,7 +632,6 @@ async function forwardToConversation(
       });
     }
 
-    // Persist SDK session ID for future resume
     if (binding.id) {
       try {
         if (result.sdkSessionId) {
@@ -700,4 +645,17 @@ async function forwardToConversation(
     state.activeTasks.delete(binding.codepilotSessionId);
     adapter.onMessageEnd?.(msg.address.chatId);
   }
+}
+
+/**
+ * Forward a prompt to the conversation engine and deliver the response.
+ * Used for custom commands and unrecognized slash commands.
+ */
+async function forwardToConversation(
+  adapter: BaseChannelAdapter,
+  msg: InboundMessage,
+  binding: ReturnType<typeof router.resolve>,
+  prompt: string,
+): Promise<void> {
+  await processConversation(adapter, msg, binding, prompt);
 }

--- a/src/lib/bridge/command-loader.ts
+++ b/src/lib/bridge/command-loader.ts
@@ -7,6 +7,8 @@
  *
  * These are the same directories that Claude Code CLI uses for custom slash commands.
  * Commands are loaded as prompt templates that get forwarded to the conversation engine.
+ *
+ * Results are cached in memory with a TTL to avoid repeated filesystem scans.
  */
 
 import fs from 'fs';
@@ -17,6 +19,8 @@ import os from 'os';
 export interface CustomCommand {
   /** Command name without leading slash (e.g. "commit", "review:pr") */
   readonly name: string;
+  /** Telegram-safe command name (colons → underscores, lowercase, alphanumeric only) */
+  readonly telegramName: string;
   /** Short description extracted from the first line of the .md file */
   readonly description: string;
   /** Full prompt template content */
@@ -35,6 +39,18 @@ const RESERVED_COMMANDS = new Set([
   'status', 'sessions', 'stop', 'help',
 ]);
 
+/** Cache entry with TTL tracking. */
+interface CacheEntry {
+  readonly commands: readonly CustomCommand[];
+  readonly expiresAt: number;
+}
+
+/** In-memory cache keyed by working directory (or '__global__' for no-project calls). */
+const cache = new Map<string, CacheEntry>();
+
+/** Cache TTL in milliseconds (30 seconds). */
+const CACHE_TTL_MS = 30_000;
+
 /**
  * Get the global commands directory path.
  */
@@ -47,6 +63,14 @@ function getGlobalCommandsDir(): string {
  */
 function getProjectCommandsDir(workingDirectory?: string): string {
   return path.join(workingDirectory || process.cwd(), '.claude', 'commands');
+}
+
+/**
+ * Convert a command name to a Telegram-compatible command name.
+ * Colons → underscores, lowercase, strip non-alphanumeric/underscore chars.
+ */
+function toTelegramName(name: string): string {
+  return name.replace(/:/g, '_').toLowerCase().replace(/[^a-z0-9_]/g, '');
 }
 
 /**
@@ -92,14 +116,22 @@ function scanDirectory(
 
       commands.push({
         name,
+        telegramName: toTelegramName(name),
         description: description.slice(0, 256),
         content,
         source,
         filePath: fullPath,
       });
     }
-  } catch {
-    // Silently ignore read errors (directory might not exist or be inaccessible)
+  } catch (err: unknown) {
+    // Log permission errors specifically to aid troubleshooting
+    if (err instanceof Error && 'code' in err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === 'EACCES' || code === 'EPERM') {
+        console.warn(`[command-loader] Permission denied reading ${dir}: ${err.message}`);
+      }
+    }
+    // Other errors (e.g. directory vanished between exists check and read) are silently ignored
   }
 
   return commands;
@@ -109,9 +141,17 @@ function scanDirectory(
  * Load all custom commands from global and project directories.
  *
  * Project commands take priority over global commands with the same name.
- * Returns an immutable array of commands.
+ * Results are cached in memory with a 30-second TTL to avoid repeated I/O.
  */
 export function loadCustomCommands(workingDirectory?: string): readonly CustomCommand[] {
+  const cacheKey = workingDirectory || '__global__';
+  const now = Date.now();
+
+  const cached = cache.get(cacheKey);
+  if (cached && cached.expiresAt > now) {
+    return cached.commands;
+  }
+
   const globalDir = getGlobalCommandsDir();
   const projectDir = getProjectCommandsDir(workingDirectory);
 
@@ -122,11 +162,14 @@ export function loadCustomCommands(workingDirectory?: string): readonly CustomCo
   const projectNames = new Set(projectCommands.map(c => c.name));
   const dedupedGlobal = globalCommands.filter(c => !projectNames.has(c.name));
 
-  return [...projectCommands, ...dedupedGlobal];
+  const result = [...projectCommands, ...dedupedGlobal];
+  cache.set(cacheKey, { commands: result, expiresAt: now + CACHE_TTL_MS });
+
+  return result;
 }
 
 /**
- * Find a specific custom command by name.
+ * Find a custom command by its original name or Telegram-safe name.
  * Searches project commands first, then global commands.
  */
 export function findCustomCommand(
@@ -134,7 +177,16 @@ export function findCustomCommand(
   workingDirectory?: string,
 ): CustomCommand | null {
   const commands = loadCustomCommands(workingDirectory);
-  return commands.find(c => c.name === name) ?? null;
+
+  // Exact match on original name
+  const exact = commands.find(c => c.name === name);
+  if (exact) return exact;
+
+  // Match on Telegram-safe name (handles underscore↔colon mapping)
+  const byTelegram = commands.find(c => c.telegramName === name);
+  if (byTelegram) return byTelegram;
+
+  return null;
 }
 
 /**
@@ -142,4 +194,11 @@ export function findCustomCommand(
  */
 export function isReservedCommand(name: string): boolean {
   return RESERVED_COMMANDS.has(name);
+}
+
+/**
+ * Clear the command cache. Useful for testing or when commands have changed.
+ */
+export function clearCommandCache(): void {
+  cache.clear();
 }


### PR DESCRIPTION
## Summary

- **Custom commands**: Loads `.md` files from `~/.claude/commands/` and `<project>/.claude/commands/`, expanding them as prompt templates when invoked via Telegram (e.g. `/commit`, `/review_pr`)
- **SDK-native commands**: Unrecognized commands like `/compact`, `/init` are forwarded directly to Claude instead of returning "Unknown command"
- **BotFather registration**: Custom commands are dynamically registered via `setMyCommands` so they appear in Telegram's native `/` menu

### Files changed

| File | Change |
|------|--------|
| `src/lib/bridge/command-loader.ts` | **New** — scans `~/.claude/commands/` and `.claude/commands/` for `.md` command files |
| `src/lib/bridge/bridge-manager.ts` | Forward unknown `/commands` to conversation engine; dynamic `/help` text |
| `src/lib/bridge/adapters/telegram-adapter.ts` | Register custom commands with BotFather alongside built-in ones |

### How it works

1. When a user sends `/mycommand` in Telegram, `handleCommand()` checks built-in commands first
2. If no match, it searches for `mycommand.md` in the commands directories (with `_` → `:` fallback for Telegram's naming restrictions)
3. If found, the `.md` content is used as a prompt template, with any user args appended as context
4. If not found, the raw text is forwarded directly to Claude (SDK may handle it natively)
5. Slash commands now use session locks since they may trigger long-running conversations

### Details

- Telegram command name restrictions (lowercase, no colons) are handled by converting `:` to `_` during registration and reversing on lookup
- Telegram API limit of 100 commands is respected
- Reserved bridge command names (`start`, `help`, `stop`, etc.) cannot be overridden by custom commands
- `/help` and `/start` now dynamically list available custom commands

## Test plan

- [ ] Deploy with custom commands in `~/.claude/commands/` and verify they appear in Telegram's `/` menu
- [ ] Send a custom command (e.g. `/commit`) and verify the `.md` content is expanded and sent to Claude
- [ ] Send an unknown command (e.g. `/compact`) and verify it's forwarded to Claude instead of returning "Unknown command"
- [ ] Verify built-in commands (`/new`, `/help`, `/status`, etc.) still work as before
- [ ] Verify `/help` lists custom commands under a separate section
- [ ] Test colon-separated commands (e.g. `review:pr` → `/review_pr` in Telegram)

🤖 Generated with [Claude Code](https://claude.com/claude-code)