### PR TITLE
fix: preserve paragraph breaks between text blocks in bridge responses

### DIFF
--- a/src/lib/bridge/conversation-engine.ts
+++ b/src/lib/bridge/conversation-engine.ts
@@ -349,7 +349,7 @@ async function consumeStream(
         : contentBlocks
             .filter((b): b is Extract<MessageContentBlock, { type: 'text' }> => b.type === 'text')
             .map((b) => b.text)
-            .join('')
+            .join('\n\n')
             .trim();
 
       if (content) {
@@ -386,7 +386,7 @@ async function consumeStream(
         : contentBlocks
             .filter((b): b is Extract<MessageContentBlock, { type: 'text' }> => b.type === 'text')
             .map((b) => b.text)
-            .join('')
+            .join('\n\n')
             .trim();
       if (content) {
         addMessage(sessionId, 'assistant', content);


### PR DESCRIPTION
## Summary

- Fixed `.join('')` → `.join('\n\n')` in conversation engine's text block assembly, which was causing multi-paragraph responses to render as a single wall of text in Telegram

### Root cause

When Claude's response includes tool calls (Read, Edit, Bash, etc.), the SSE stream splits the response into multiple text content blocks:

```
Text Block 1: "Let me check the code..."  → tool_use: Read
Text Block 2: "Found the issue. Here's the fix..."  → tool_use: Edit  
Text Block 3: "Done. The changes are..."
```

These blocks were joined with `.join('')` (empty string), producing:

> Let me check the code...Found the issue. Here's the fix...Done. The changes are...

Now joined with `.join('\n\n')`:

> Let me check the code...
>
> Found the issue. Here's the fix...
>
> Done. The changes are...

### Files changed

| File | Change |
|------|--------|
| `src/lib/bridge/conversation-engine.ts` | `.join('')` → `.join('\n\n')` in both normal and error-recovery paths |

## Test plan

- [ ] Send a message that triggers tool usage (e.g. "read file X and explain it") → verify response paragraphs have proper line breaks in Telegram
- [ ] Send a simple message with no tool calls → verify single text block still renders correctly
- [ ] Verify the desktop UI is unaffected (it uses a different rendering path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)