### PR TITLE
feat: Appearance settings

### DIFF
--- a/src/__tests__/unit/appearance-settings.test.ts
+++ b/src/__tests__/unit/appearance-settings.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Unit tests for appearance settings constants, validation, and lookup helpers.
+ *
+ * Run with: npx tsx --test src/__tests__/unit/appearance-settings.test.ts
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  FONT_SIZES,
+  DEFAULT_FONT_SIZE,
+  isValidFontSize,
+  getFontSizePx,
+  APPEARANCE_STORAGE_KEY,
+  readFontSizeFromStorage,
+  writeFontSizeToStorage,
+} from '../../lib/appearance';
+import type { FontSizeKey } from '../../lib/appearance';
+
+describe('Appearance Settings Constants', () => {
+  it('should have 4 font size presets', () => {
+    assert.equal(Object.keys(FONT_SIZES).length, 4);
+  });
+
+  it('should have all sizes in ascending order', () => {
+    const pxValues = Object.values(FONT_SIZES).map(s => s.px);
+    for (let i = 1; i < pxValues.length; i++) {
+      assert.ok(pxValues[i] > pxValues[i - 1], `${pxValues[i]} should be > ${pxValues[i - 1]}`);
+    }
+  });
+
+  it('should have default font size as a valid key', () => {
+    assert.ok(DEFAULT_FONT_SIZE in FONT_SIZES);
+  });
+
+  it('default font size should map to 16px', () => {
+    assert.equal(FONT_SIZES[DEFAULT_FONT_SIZE].px, 16);
+  });
+});
+
+describe('Appearance Settings Validation', () => {
+  it('should validate known font size keys', () => {
+    assert.equal(isValidFontSize('small'), true);
+    assert.equal(isValidFontSize('default'), true);
+    assert.equal(isValidFontSize('large'), true);
+    assert.equal(isValidFontSize('extra-large'), true);
+  });
+
+  it('should reject invalid font size keys', () => {
+    assert.equal(isValidFontSize('huge'), false);
+    assert.equal(isValidFontSize(''), false);
+    assert.equal(isValidFontSize(undefined as unknown as string), false);
+  });
+});
+
+describe('Appearance Settings Lookup Helpers', () => {
+  it('should return px for valid font size', () => {
+    assert.equal(getFontSizePx('large'), 18);
+  });
+
+  it('should fall back to default for invalid font size', () => {
+    assert.equal(getFontSizePx('huge' as FontSizeKey), FONT_SIZES[DEFAULT_FONT_SIZE].px);
+  });
+});
+
+describe('Appearance Settings localStorage helpers', () => {
+  let store: Record<string, string> = {};
+  const mockStorage = {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => { store[key] = value; },
+    removeItem: (key: string) => { delete store[key]; },
+  } as unknown as Storage;
+
+  it('APPEARANCE_STORAGE_KEY should be a namespaced string', () => {
+    store = {};
+    assert.ok(APPEARANCE_STORAGE_KEY.startsWith('codepilot_'));
+  });
+
+  it('writeFontSizeToStorage should write valid key', () => {
+    store = {};
+    writeFontSizeToStorage('large', mockStorage);
+    assert.equal(store[APPEARANCE_STORAGE_KEY], 'large');
+  });
+
+  it('readFontSizeFromStorage should return stored value', () => {
+    store = { [APPEARANCE_STORAGE_KEY]: 'small' };
+    assert.equal(readFontSizeFromStorage(mockStorage), 'small');
+  });
+
+  it('readFontSizeFromStorage should return default for missing key', () => {
+    store = {};
+    assert.equal(readFontSizeFromStorage(mockStorage), DEFAULT_FONT_SIZE);
+  });
+
+  it('readFontSizeFromStorage should return default for invalid value', () => {
+    store = { [APPEARANCE_STORAGE_KEY]: 'huge' };
+    assert.equal(readFontSizeFromStorage(mockStorage), DEFAULT_FONT_SIZE);
+  });
+});
+
+describe('Anti-FOUC font-size map consistency', () => {
+  it('FONT_SIZES px values should match the anti-FOUC inline map', () => {
+    const expected: Record<string, number> = {
+      small: 14,
+      default: 16,
+      large: 18,
+      'extra-large': 20,
+    };
+    for (const [key, opt] of Object.entries(FONT_SIZES)) {
+      assert.equal(opt.px, expected[key], `FONT_SIZES[${key}].px should be ${expected[key]}`);
+    }
+    assert.equal(Object.keys(FONT_SIZES).length, Object.keys(expected).length);
+  });
+});

--- a/src/app/api/settings/app/route.ts
+++ b/src/app/api/settings/app/route.ts
@@ -12,6 +12,7 @@ const ALLOWED_KEYS = [
   'dangerously_skip_permissions',
   'locale',
   'thinking_mode',
+  'appearance_font_size',
 ];
 
 export async function GET() {

--- a/src/app/chat/[id]/page.tsx
+++ b/src/app/chat/[id]/page.tsx
@@ -217,7 +217,7 @@ export default function ChatSessionPage({ params }: ChatSessionPageProps) {
                 </TooltipTrigger>
                 <TooltipContent>
                   <p className="text-xs break-all">{sessionWorkingDir || projectName}</p>
-                  <p className="text-[10px] text-muted-foreground mt-0.5">Click to open in Finder</p>
+                  <p className="text-[0.625rem] text-muted-foreground mt-0.5">Click to open in Finder</p>
                 </TooltipContent>
               </Tooltip>
               <span className="text-xs text-muted-foreground shrink-0">/</span>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,8 @@ import { I18nProvider } from "@/components/layout/I18nProvider";
 import { AppShell } from "@/components/layout/AppShell";
 import { getAllThemeFamilies, getThemeFamilyMetas } from "@/lib/theme/loader";
 import { renderThemeFamilyCSS } from "@/lib/theme/render-css";
+import { AppearanceProvider } from "@/components/layout/AppearanceProvider";
+import { FONT_SIZES, DEFAULT_FONT_SIZE, APPEARANCE_STORAGE_KEY } from "@/lib/appearance";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -32,12 +34,18 @@ export default function RootLayout({
   const familiesMeta = getThemeFamilyMetas();
   const themeFamilyCSS = renderThemeFamilyCSS(families);
   const validIds = families.map((f) => f.id);
+  const fontSizePxMap = JSON.stringify(
+    Object.fromEntries(Object.entries(FONT_SIZES).map(([k, v]) => [k, v.px]))
+  );
 
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
         {/* Anti-FOUC: set data-theme-family from localStorage, validate against known IDs */}
         <script dangerouslySetInnerHTML={{ __html: `(function(){try{var v=${JSON.stringify(validIds)};var f=localStorage.getItem('codepilot_theme_family')||'default';if(v.indexOf(f)<0)f='default';document.documentElement.setAttribute('data-theme-family',f)}catch(e){}})();` }} />
+        {/* Anti-FOUC: set font-size from localStorage before hydration.
+            Key and px map generated from @/lib/appearance — no hardcoded values. */}
+        <script dangerouslySetInnerHTML={{ __html: `(function(){try{var s=localStorage.getItem(${JSON.stringify(APPEARANCE_STORAGE_KEY)});var m=${fontSizePxMap};var p=m[s]||${FONT_SIZES[DEFAULT_FONT_SIZE].px};document.documentElement.style.fontSize=p+'px'}catch(e){}})();` }} />
         <style id="theme-family-vars" dangerouslySetInnerHTML={{ __html: themeFamilyCSS }} />
       </head>
       <body
@@ -45,9 +53,11 @@ export default function RootLayout({
       >
         <ThemeProvider>
           <ThemeFamilyProvider families={familiesMeta}>
-            <I18nProvider>
-              <AppShell>{children}</AppShell>
-            </I18nProvider>
+            <AppearanceProvider>
+              <I18nProvider>
+                <AppShell>{children}</AppShell>
+              </I18nProvider>
+            </AppearanceProvider>
           </ThemeFamilyProvider>
         </ThemeProvider>
       </body>

--- a/src/components/ai-elements/tool-actions-group.tsx
+++ b/src/components/ai-elements/tool-actions-group.tsx
@@ -164,7 +164,7 @@ function ToolActionRow({ tool }: { tool: ToolAction }) {
       </span>
 
       {filePath && (category === 'read' || category === 'write') && (
-        <span className="text-muted-foreground/40 text-[11px] font-mono truncate max-w-[200px] hidden sm:inline">
+        <span className="text-muted-foreground/40 text-[0.6875rem] font-mono truncate max-w-[200px] hidden sm:inline">
           {truncatePath(filePath)}
         </span>
       )}
@@ -236,7 +236,7 @@ export function ToolActionsGroup({
           )}
         />
 
-        <span className="inline-flex items-center justify-center rounded bg-muted/80 px-1.5 py-0.5 text-[10px] font-medium leading-none text-muted-foreground/70 tabular-nums">
+        <span className="inline-flex items-center justify-center rounded bg-muted/80 px-1.5 py-0.5 text-[0.625rem] font-medium leading-none text-muted-foreground/70 tabular-nums">
           {tools.length}
         </span>
 
@@ -246,7 +246,7 @@ export function ToolActionsGroup({
 
         {/* Show running task description on the right */}
         {runningDesc && (
-          <span className="ml-auto text-muted-foreground/40 text-[11px] font-mono truncate max-w-[40%]">
+          <span className="ml-auto text-muted-foreground/40 text-[0.6875rem] font-mono truncate max-w-[40%]">
             {runningDesc}
           </span>
         )}

--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -42,7 +42,6 @@ export function ChatView({ sessionId, initialMessages = [], initialHasMore = fal
   const router = useRouter();
   const [messages, setMessages] = useState<Message[]>(initialMessages);
   const [permissionProfile, setPermissionProfile] = useState<'default' | 'full_access'>(initialPermissionProfile || 'default');
-
   // Workspace mismatch banner state
   const [workspaceMismatchPath, setWorkspaceMismatchPath] = useState<string | null>(null);
   const [hasMore, setHasMore] = useState(initialHasMore);

--- a/src/components/chat/CliToolsPopover.tsx
+++ b/src/components/chat/CliToolsPopover.tsx
@@ -89,7 +89,7 @@ export function CliToolsPopover({
                 <Terminal size={16} className="shrink-0 text-muted-foreground" />
                 <span className="font-medium text-xs truncate">{tool.name}</span>
                 {tool.version && (
-                  <span className="text-[10px] text-muted-foreground shrink-0">v{tool.version}</span>
+                  <span className="text-[0.625rem] text-muted-foreground shrink-0">v{tool.version}</span>
                 )}
                 {tool.summary && (
                   <span className="text-xs text-muted-foreground truncate ml-auto max-w-[200px]">{tool.summary}</span>

--- a/src/components/chat/ContextUsageIndicator.tsx
+++ b/src/components/chat/ContextUsageIndicator.tsx
@@ -110,7 +110,7 @@ export function ContextUsageIndicator({ messages, modelName }: ContextUsageIndic
                 <span>{formatTokens(usage.outputTokens)}</span>
               </div>
             </div>
-            <p className="text-[10px] text-muted-foreground pt-1 border-t border-border">
+            <p className="text-[0.625rem] text-muted-foreground pt-1 border-t border-border">
               {t('context.estimate')}
             </p>
           </div>

--- a/src/components/chat/ImageGenCard.tsx
+++ b/src/components/chat/ImageGenCard.tsx
@@ -114,7 +114,7 @@ export function ImageGenCard({
       {/* Reference images (垫图) */}
       {referenceImages && referenceImages.length > 0 && (
         <div>
-          <span className="text-[10px] text-muted-foreground/60 mb-1 block">
+          <span className="text-[0.625rem] text-muted-foreground/60 mb-1 block">
             {t('imageGen.referenceImages' as TranslationKey)}
           </span>
           <div className="flex gap-1.5 flex-wrap">
@@ -140,18 +140,18 @@ export function ImageGenCard({
       <div className="flex items-center justify-between gap-2">
         <div className="flex items-center gap-1.5 flex-wrap">
           {model && (
-            <Badge variant="secondary" className="text-[10px] gap-1">
+            <Badge variant="secondary" className="text-[0.625rem] gap-1">
               <PaintBrush size={12} />
               {model}
             </Badge>
           )}
           {aspectRatio && (
-            <Badge variant="outline" className="text-[10px]">
+            <Badge variant="outline" className="text-[0.625rem]">
               {aspectRatio}
             </Badge>
           )}
           {imageSize && (
-            <Badge variant="outline" className="text-[10px]">
+            <Badge variant="outline" className="text-[0.625rem]">
               {imageSize}
             </Badge>
           )}

--- a/src/components/chat/MessageInputParts.tsx
+++ b/src/components/chat/MessageInputParts.tsx
@@ -117,7 +117,7 @@ export function FileAttachmentsCapsules() {
                 className="h-5 w-5 rounded object-cover"
               />
             )}
-            <span className="max-w-[120px] truncate text-[11px]">
+            <span className="max-w-[120px] truncate text-[0.6875rem]">
               {file.filename || 'file'}
             </span>
             <Button
@@ -153,7 +153,7 @@ export function CommandBadge({
       <span className="inline-flex items-center gap-1.5 rounded-full bg-primary/10 text-primary pl-2.5 pr-1.5 py-1 text-xs font-medium border border-primary/20">
         <span className="font-mono">{command}</span>
         {description && (
-          <span className="text-primary/60 text-[10px]">{description}</span>
+          <span className="text-primary/60 text-[0.625rem]">{description}</span>
         )}
         <Button
           type="button"

--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -306,7 +306,7 @@ function TokenUsageDisplay({ usage }: { usage: TokenUsage }) {
   return (
     <span className="group/tokens relative cursor-default text-xs text-muted-foreground/50">
       <span>{totalTokens.toLocaleString()} tokens{costStr}</span>
-      <span className="pointer-events-none absolute bottom-full left-0 mb-1.5 whitespace-nowrap rounded-md bg-popover px-2.5 py-1.5 text-[11px] text-popover-foreground shadow-md border border-border/50 opacity-0 group-hover/tokens:opacity-100 transition-opacity duration-150 z-50">
+      <span className="pointer-events-none absolute bottom-full left-0 mb-1.5 whitespace-nowrap rounded-md bg-popover px-2.5 py-1.5 text-[0.6875rem] text-popover-foreground shadow-md border border-border/50 opacity-0 group-hover/tokens:opacity-100 transition-opacity duration-150 z-50">
         In: {usage.input_tokens.toLocaleString()} · Out: {usage.output_tokens.toLocaleString()}
         {usage.cache_read_input_tokens ? ` · Cache: ${usage.cache_read_input_tokens.toLocaleString()}` : ''}
         {costStr}

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -93,7 +93,7 @@ function RewindButton({ sessionId, userMessageId }: { sessionId: string; userMes
 
   if (state === 'done') {
     return (
-      <span className="text-[10px] text-status-success-foreground ml-2">
+      <span className="text-[0.625rem] text-status-success-foreground ml-2">
         {t('messageList.rewindDone' as TranslationKey)}
       </span>
     );
@@ -102,14 +102,14 @@ function RewindButton({ sessionId, userMessageId }: { sessionId: string; userMes
   if (state === 'preview' && preview) {
     return (
       <span className="inline-flex items-center gap-1.5 ml-2">
-        <span className="text-[10px] text-muted-foreground">
+        <span className="text-[0.625rem] text-muted-foreground">
           {preview.filesChanged?.length || 0} files, +{preview.insertions || 0}/-{preview.deletions || 0}
         </span>
         <Button
           variant="link"
           size="xs"
           onClick={handleRewind}
-          className="text-[10px] text-primary h-auto p-0"
+          className="text-[0.625rem] text-primary h-auto p-0"
         >
           {t('messageList.rewindConfirm' as TranslationKey)}
         </Button>
@@ -117,7 +117,7 @@ function RewindButton({ sessionId, userMessageId }: { sessionId: string; userMes
           variant="link"
           size="xs"
           onClick={() => setState('idle')}
-          className="text-[10px] text-muted-foreground h-auto p-0"
+          className="text-[0.625rem] text-muted-foreground h-auto p-0"
         >
           {t('messageList.rewindCancel' as TranslationKey)}
         </Button>
@@ -131,7 +131,7 @@ function RewindButton({ sessionId, userMessageId }: { sessionId: string; userMes
       size="xs"
       onClick={handleDryRun}
       disabled={state === 'loading'}
-      className="text-[10px] text-muted-foreground hover:text-foreground ml-2 opacity-0 group-hover:opacity-100 h-auto p-0"
+      className="text-[0.625rem] text-muted-foreground hover:text-foreground ml-2 opacity-0 group-hover:opacity-100 h-auto p-0"
     >
       {state === 'loading' ? '...' : t('messageList.rewindToHere' as TranslationKey)}
     </Button>

--- a/src/components/chat/PermissionPrompt.tsx
+++ b/src/components/chat/PermissionPrompt.tsx
@@ -105,7 +105,7 @@ function AskUserQuestionUI({
         return (
           <div key={qIdx} className="space-y-2">
             {q.header && (
-              <span className="inline-block rounded-full bg-muted px-2 py-0.5 text-[10px] font-medium text-muted-foreground">
+              <span className="inline-block rounded-full bg-muted px-2 py-0.5 text-[0.625rem] font-medium text-muted-foreground">
                 {q.header}
               </span>
             )}
@@ -217,7 +217,7 @@ function ExitPlanModeUI({
           <ul className="space-y-0.5">
             {allowedPrompts.map((p, i) => (
               <li key={i} className="flex items-center gap-1.5 text-xs text-muted-foreground">
-                <span className="rounded bg-muted px-1.5 py-0.5 font-mono text-[10px]">{p.tool}</span>
+                <span className="rounded bg-muted px-1.5 py-0.5 font-mono text-[0.625rem]">{p.tool}</span>
                 <span>{p.prompt}</span>
               </li>
             ))}

--- a/src/components/chat/StreamingMessage.tsx
+++ b/src/components/chat/StreamingMessage.tsx
@@ -145,10 +145,10 @@ function StreamingStatusBar({ statusText, onForceStop }: { statusText?: string; 
           <Shimmer duration={1.5}>{displayText}</Shimmer>
         </span>
         {isWarning && !isCritical && (
-          <span className="text-status-warning-foreground text-[10px]">Running longer than usual</span>
+          <span className="text-status-warning-foreground text-[0.625rem]">Running longer than usual</span>
         )}
         {isCritical && (
-          <span className="text-status-error-foreground text-[10px]">Tool may be stuck</span>
+          <span className="text-status-error-foreground text-[0.625rem]">Tool may be stuck</span>
         )}
       </div>
       <span className="text-muted-foreground/50">|</span>
@@ -158,7 +158,7 @@ function StreamingStatusBar({ statusText, onForceStop }: { statusText?: string; 
           variant="outline"
           size="xs"
           onClick={onForceStop}
-          className="ml-auto border-status-error-border bg-status-error-muted text-[10px] font-medium text-status-error-foreground hover:bg-status-error-muted"
+          className="ml-auto border-status-error-border bg-status-error-muted text-[0.625rem] font-medium text-status-error-foreground hover:bg-status-error-muted"
         >
           Force stop
         </Button>

--- a/src/components/chat/batch-image-gen/BatchExecutionItem.tsx
+++ b/src/components/chat/batch-image-gen/BatchExecutionItem.tsx
@@ -59,18 +59,18 @@ export function BatchExecutionItem({ item }: BatchExecutionItemProps) {
       <div className="flex-1 min-w-0">
         <p className="text-xs text-foreground truncate">{item.prompt}</p>
         <div className="flex items-center gap-2 mt-0.5">
-          <span className="text-[10px] text-muted-foreground">{item.aspect_ratio}</span>
-          <span className="text-[10px] text-muted-foreground">{item.image_size}</span>
-          <span className={`text-[10px] font-medium ${statusColor}`}>{statusLabel}</span>
+          <span className="text-[0.625rem] text-muted-foreground">{item.aspect_ratio}</span>
+          <span className="text-[0.625rem] text-muted-foreground">{item.image_size}</span>
+          <span className={`text-[0.625rem] font-medium ${statusColor}`}>{statusLabel}</span>
           {item.error && (
-            <span className="text-[10px] text-status-error-foreground truncate">{item.error}</span>
+            <span className="text-[0.625rem] text-status-error-foreground truncate">{item.error}</span>
           )}
         </div>
       </div>
 
       {/* Retry count */}
       {item.retry_count > 0 && (
-        <span className="text-[10px] text-muted-foreground shrink-0">
+        <span className="text-[0.625rem] text-muted-foreground shrink-0">
           retry {item.retry_count}
         </span>
       )}

--- a/src/components/chat/batch-image-gen/BatchPlanRow.tsx
+++ b/src/components/chat/batch-image-gen/BatchPlanRow.tsx
@@ -69,7 +69,7 @@ export function BatchPlanRow({ item, index, onUpdate, onRemove, disabled }: Batc
             {item.tags.length > 0 && (
               <div className="flex items-center gap-1 overflow-hidden">
                 {item.tags.map((tag, i) => (
-                  <span key={i} className="inline-block rounded-full bg-purple-500/10 text-purple-600 dark:text-purple-400 px-1.5 py-0 text-[10px]">
+                  <span key={i} className="inline-block rounded-full bg-purple-500/10 text-purple-600 dark:text-purple-400 px-1.5 py-0 text-[0.625rem]">
                     {tag}
                   </span>
                 ))}
@@ -84,7 +84,7 @@ export function BatchPlanRow({ item, index, onUpdate, onRemove, disabled }: Batc
               size="xs"
               onClick={() => onRemove(index)}
               disabled={disabled}
-              className="text-[10px] text-muted-foreground hover:text-status-error-foreground opacity-0 group-hover:opacity-100 disabled:opacity-0 h-auto p-0"
+              className="text-[0.625rem] text-muted-foreground hover:text-status-error-foreground opacity-0 group-hover:opacity-100 disabled:opacity-0 h-auto p-0"
             >
               {t('batchImageGen.removeItem' as TranslationKey)}
             </Button>

--- a/src/components/cli-tools/CliToolCard.tsx
+++ b/src/components/cli-tools/CliToolCard.tsx
@@ -68,7 +68,7 @@ export function CliToolCard({
           {tool.categories.map(cat => (
             <span
               key={cat}
-              className="inline-block rounded-full bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground shrink-0"
+              className="inline-block rounded-full bg-muted px-1.5 py-0.5 text-[0.625rem] text-muted-foreground shrink-0"
             >
               {t(`cliTools.category.${cat}` as TranslationKey)}
             </span>

--- a/src/components/cli-tools/CliToolsManager.tsx
+++ b/src/components/cli-tools/CliToolsManager.tsx
@@ -180,7 +180,7 @@ export function CliToolsManager() {
             <div className="text-xs text-muted-foreground">
               <p className="font-medium text-foreground mb-1">{t('cliTools.brewNotInstalled')}</p>
               <p>{t('cliTools.brewInstallGuide')}</p>
-              <code className="block mt-1.5 bg-muted/50 rounded px-2 py-1 text-[11px] font-mono select-all">
+              <code className="block mt-1.5 bg-muted/50 rounded px-2 py-1 text-[0.6875rem] font-mono select-all">
                 /bin/bash -c &quot;$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)&quot;
               </code>
             </div>

--- a/src/components/gallery/GalleryDetail.tsx
+++ b/src/components/gallery/GalleryDetail.tsx
@@ -197,18 +197,18 @@ export function GalleryDetail({
             {/* Metadata badges */}
             <div className="flex items-center gap-1.5 flex-wrap">
               {item.model && (
-                <Badge variant="secondary" className="text-[10px] gap-1">
+                <Badge variant="secondary" className="text-[0.625rem] gap-1">
                   <PaintBrush size={12} />
                   {item.model}
                 </Badge>
               )}
               {item.aspectRatio && (
-                <Badge variant="outline" className="text-[10px]">
+                <Badge variant="outline" className="text-[0.625rem]">
                   {item.aspectRatio}
                 </Badge>
               )}
               {item.imageSize && (
-                <Badge variant="outline" className="text-[10px]">
+                <Badge variant="outline" className="text-[0.625rem]">
                   {item.imageSize}
                 </Badge>
               )}

--- a/src/components/gallery/GalleryGrid.tsx
+++ b/src/components/gallery/GalleryGrid.tsx
@@ -67,7 +67,7 @@ export function GalleryGrid({ items, onSelect }: GalleryGridProps) {
                 </div>
               )}
               {item.images.length > 1 && (
-                <span className="absolute top-1.5 right-1.5 rounded-full bg-black/50 px-1.5 py-0.5 text-[10px] text-white font-medium">
+                <span className="absolute top-1.5 right-1.5 rounded-full bg-black/50 px-1.5 py-0.5 text-[0.625rem] text-white font-medium">
                   {item.images.length}
                 </span>
               )}

--- a/src/components/gallery/TagManager.tsx
+++ b/src/components/gallery/TagManager.tsx
@@ -73,7 +73,7 @@ export function TagManager({
               <Badge
                 variant={isSelected ? 'default' : 'outline'}
                 className={cn(
-                  'text-[11px] cursor-pointer transition-colors',
+                  'text-[0.6875rem] cursor-pointer transition-colors',
                   compact && 'px-1.5 py-0',
                   isSelected && tag.color && 'border-transparent'
                 )}

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -71,20 +71,16 @@ export function AppShell({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
   const router = useRouter();
 
-  const [chatListOpenRaw, setChatListOpenRaw] = useState(() => {
-    if (typeof window === "undefined") return false;
-    return window.matchMedia(`(min-width: ${LG_BREAKPOINT}px)`).matches;
-  });
+  // Hydration-safe: initialise with server defaults, sync client values in useEffect
+  const [chatListOpenRaw, setChatListOpenRaw] = useState(false);
+  const [chatListWidth, setChatListWidth] = useState(240);
+  const [rightPanelWidth, setRightPanelWidth] = useState(288);
 
-  // Panel width state with localStorage persistence
-  const [chatListWidth, setChatListWidth] = useState(() => {
-    if (typeof window === "undefined") return 240;
-    return parseInt(localStorage.getItem("codepilot_chatlist_width") || "240");
-  });
-  const [rightPanelWidth, setRightPanelWidth] = useState(() => {
-    if (typeof window === "undefined") return 288;
-    return parseInt(localStorage.getItem("codepilot_rightpanel_width") || "288");
-  });
+  useEffect(() => {
+    setChatListOpenRaw(window.matchMedia(`(min-width: ${LG_BREAKPOINT}px)`).matches);
+    setChatListWidth(parseInt(localStorage.getItem("codepilot_chatlist_width") || "240"));
+    setRightPanelWidth(parseInt(localStorage.getItem("codepilot_rightpanel_width") || "288"));
+  }, []);
 
   const handleChatListResize = useCallback((delta: number) => {
     setChatListWidth((w) => Math.min(CHATLIST_MAX, Math.max(CHATLIST_MIN, w + delta)));
@@ -297,10 +293,12 @@ export function AppShell({ children }: { children: React.ReactNode }) {
   // --- Doc Preview state ---
   const [previewFile, setPreviewFileRaw] = useState<string | null>(null);
   const [previewViewMode, setPreviewViewMode] = useState<PreviewViewMode>("source");
-  const [docPreviewWidth, setDocPreviewWidth] = useState(() => {
-    if (typeof window === "undefined") return 480;
-    return parseInt(localStorage.getItem("codepilot_docpreview_width") || "480");
-  });
+  const [docPreviewWidth, setDocPreviewWidth] = useState(480);
+
+  // Hydrate doc preview width from localStorage (after mount to avoid SSR mismatch)
+  useEffect(() => {
+    setDocPreviewWidth(parseInt(localStorage.getItem("codepilot_docpreview_width") || "480"));
+  }, []);
 
   const setPreviewFile = useCallback((path: string | null) => {
     setPreviewFileRaw(path);

--- a/src/components/layout/AppearanceProvider.tsx
+++ b/src/components/layout/AppearanceProvider.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { createContext, useState, useEffect, useCallback, useMemo, type ReactNode } from 'react';
+import {
+  type FontSizeKey,
+  DEFAULT_FONT_SIZE,
+  isValidFontSize,
+  getFontSizePx,
+  readFontSizeFromStorage,
+  writeFontSizeToStorage,
+} from '@/lib/appearance';
+
+interface AppearanceContextValue {
+  fontSize: FontSizeKey;
+  setFontSize: (size: FontSizeKey) => void;
+}
+
+export const AppearanceContext = createContext<AppearanceContextValue>({
+  fontSize: DEFAULT_FONT_SIZE,
+  setFontSize: () => {},
+});
+
+function applyToDocument(size: FontSizeKey) {
+  document.documentElement.style.fontSize = `${getFontSizePx(size)}px`;
+}
+
+export function AppearanceProvider({ children }: { children: ReactNode }) {
+  // Initialize from localStorage (sync — matches anti-FOUC script)
+  const [fontSize, setFontSizeState] = useState<FontSizeKey>(() => readFontSizeFromStorage());
+
+  // On mount: fetch from API in case localStorage is stale, then reconcile.
+  // API is the source of truth — if it disagrees with localStorage, API wins.
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      try {
+        const res = await fetch('/api/settings/app');
+        if (!res.ok || cancelled) return;
+        const data = await res.json();
+        if (cancelled) return;
+        const savedSize = data.settings?.appearance_font_size;
+        const apiSize = isValidFontSize(savedSize) ? savedSize : DEFAULT_FONT_SIZE;
+        const localSize = readFontSizeFromStorage();
+
+        // Only update if API disagrees with localStorage
+        if (apiSize !== localSize) {
+          writeFontSizeToStorage(apiSize);
+          applyToDocument(apiSize);
+          setFontSizeState(apiSize);
+        }
+      } catch {
+        // ignore — localStorage value already applied by anti-FOUC script
+      }
+    }
+    load();
+    return () => { cancelled = true; };
+  }, []);
+
+  const setFontSize = useCallback((size: FontSizeKey) => {
+    setFontSizeState(size);
+    writeFontSizeToStorage(size);
+    applyToDocument(size);
+    // Persist to API (fire and forget)
+    fetch('/api/settings/app', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ settings: { appearance_font_size: size } }),
+    }).catch(() => {});
+  }, []);
+
+  const value = useMemo(() => ({ fontSize, setFontSize }), [fontSize, setFontSize]);
+
+  return (
+    <AppearanceContext.Provider value={value}>
+      {children}
+    </AppearanceContext.Provider>
+  );
+}

--- a/src/components/layout/ChatListPanel.tsx
+++ b/src/components/layout/ChatListPanel.tsx
@@ -372,7 +372,7 @@ export function ChatListPanel({ open, width }: ChatListPanelProps) {
         <div className="flex flex-col pb-3">
           {/* Section title */}
           <div className="px-2 pt-1 pb-1.5">
-            <span className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground/60">
+            <span className="text-[0.6875rem] font-medium uppercase tracking-wider text-muted-foreground/60">
               {t('chatList.threads')}
             </span>
           </div>
@@ -393,7 +393,7 @@ export function ChatListPanel({ open, width }: ChatListPanelProps) {
           )}
 
           {filteredSessions.length === 0 && (!isSplitActive || splitSessions.length === 0) ? (
-            <p className="px-2.5 py-3 text-[11px] text-muted-foreground/60">
+            <p className="px-2.5 py-3 text-[0.6875rem] text-muted-foreground/60">
               {searchQuery ? "No matching threads" : t('chatList.noSessions')}
             </p>
           ) : (
@@ -461,7 +461,7 @@ export function ChatListPanel({ open, width }: ChatListPanelProps) {
 
       {/* Version */}
       <div className="shrink-0 px-3 py-2 text-center">
-        <span className="text-[10px] text-muted-foreground/40">
+        <span className="text-[0.625rem] text-muted-foreground/40">
           v{process.env.NEXT_PUBLIC_APP_VERSION}
         </span>
       </div>

--- a/src/components/layout/ConnectionStatus.tsx
+++ b/src/components/layout/ConnectionStatus.tsx
@@ -125,7 +125,7 @@ export function ConnectionStatus() {
         size="sm"
         onClick={() => setDialogOpen(true)}
         className={cn(
-          "h-7 rounded-full px-2.5 text-[11px] font-medium gap-1.5",
+          "h-7 rounded-full px-2.5 text-[0.6875rem] font-medium gap-1.5",
           status === null
             ? "bg-muted text-muted-foreground"
             : connected

--- a/src/components/layout/DocPreview.tsx
+++ b/src/components/layout/DocPreview.tsx
@@ -146,11 +146,11 @@ export function DocPreview({
 
       {/* Breadcrumb + language — subtle, no border */}
       <div className="flex shrink-0 items-center gap-2 px-3 pb-2">
-        <p className="min-w-0 flex-1 truncate text-[11px] text-muted-foreground/60">
+        <p className="min-w-0 flex-1 truncate text-[0.6875rem] text-muted-foreground/60">
           {breadcrumb}
         </p>
         {preview && (
-          <span className="shrink-0 text-[10px] text-muted-foreground/50">
+          <span className="shrink-0 text-[0.625rem] text-muted-foreground/50">
             {preview.language}
           </span>
         )}
@@ -187,7 +187,7 @@ function ViewModeToggle({
   onChange: (v: ViewMode) => void;
 }) {
   return (
-    <div className="flex h-6 items-center rounded-full bg-muted p-0.5 text-[11px]">
+    <div className="flex h-6 items-center rounded-full bg-muted p-0.5 text-[0.6875rem]">
       <Button
         variant="ghost"
         size="sm"
@@ -236,7 +236,7 @@ function SourceView({ preview, isDark }: { preview: FilePreviewType; isDark: boo
           margin: 0,
           padding: "8px",
           borderRadius: 0,
-          fontSize: "11px",
+          fontSize: "0.6875rem",
           lineHeight: "1.5",
           background: "transparent",
         }}

--- a/src/components/layout/ImportSessionDialog.tsx
+++ b/src/components/layout/ImportSessionDialog.tsx
@@ -229,7 +229,7 @@ export function ImportSessionDialog({
                           {session.gitBranch && (
                             <Badge
                               variant="secondary"
-                              className="text-[10px] px-1.5 py-0 h-4 shrink-0"
+                              className="text-[0.625rem] px-1.5 py-0 h-4 shrink-0"
                             >
                               <GitBranch size={10} className="mr-0.5" />
                               {session.gitBranch}
@@ -262,7 +262,7 @@ export function ImportSessionDialog({
                     </div>
 
                     {/* Bottom row: metadata */}
-                    <div className="flex items-center gap-3 text-[10px] text-muted-foreground/60">
+                    <div className="flex items-center gap-3 text-[0.625rem] text-muted-foreground/60">
                       <span
                         className="flex items-center gap-0.5 truncate"
                         title={session.cwd}

--- a/src/components/layout/ProjectGroupHeader.tsx
+++ b/src/components/layout/ProjectGroupHeader.tsx
@@ -75,7 +75,7 @@ export function ProjectGroupHeader({
           ) : (
             <FolderOpen size={16} className="shrink-0 text-muted-foreground" />
           )}
-          <span className="flex-1 truncate text-[13px] font-medium text-sidebar-foreground">
+          <span className="flex-1 truncate text-[0.8125rem] font-medium text-sidebar-foreground">
             {displayName}
           </span>
           {isWorkspace && (
@@ -110,7 +110,7 @@ export function ProjectGroupHeader({
       </TooltipTrigger>
       <TooltipContent side="right" className="max-w-xs">
         <p className="text-xs break-all">{workingDirectory || 'No Project'}</p>
-        {workingDirectory && <p className="text-[10px] text-muted-foreground mt-0.5">Double-click to open in Finder</p>}
+        {workingDirectory && <p className="text-[0.625rem] text-muted-foreground mt-0.5">Double-click to open in Finder</p>}
       </TooltipContent>
     </Tooltip>
   );

--- a/src/components/layout/RightPanel.tsx
+++ b/src/components/layout/RightPanel.tsx
@@ -71,7 +71,7 @@ export function RightPanel({ width }: RightPanelProps) {
     <aside className="hidden h-full shrink-0 flex-col overflow-hidden bg-background lg:flex" style={{ width: width ?? 288 }}>
       {/* Header */}
       <div className="flex h-12 mt-5 shrink-0 items-center justify-between px-4">
-        <span className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+        <span className="text-[0.6875rem] font-semibold uppercase tracking-wider text-muted-foreground">
           {t('panel.tasks')}
         </span>
         <Tooltip>
@@ -102,7 +102,7 @@ export function RightPanel({ width }: RightPanelProps) {
         {/* File tree */}
         <div className="flex-1 min-h-0 overflow-hidden">
           <div className="px-4 pt-1 pb-1">
-            <span className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+            <span className="text-[0.6875rem] font-semibold uppercase tracking-wider text-muted-foreground">
               {t('panel.files')}
             </span>
           </div>

--- a/src/components/layout/SessionListItem.tsx
+++ b/src/components/layout/SessionListItem.tsx
@@ -99,14 +99,14 @@ export function SessionListItem({
           )}
         </span>
         <div className="flex-1 min-w-0">
-          <span className="line-clamp-1 text-[13px] font-medium leading-tight break-all">
+          <span className="line-clamp-1 text-[0.8125rem] font-medium leading-tight break-all">
             {session.title}
           </span>
         </div>
         {/* Right area — fixed width, time and delete stacked with opacity */}
         <div className="relative w-[38px] h-4 shrink-0">
           <span className={cn(
-            "absolute inset-0 flex items-center justify-end text-[11px] text-muted-foreground/40 truncate transition-opacity",
+            "absolute inset-0 flex items-center justify-end text-[0.6875rem] text-muted-foreground/40 truncate transition-opacity",
             (isHovered || isDeleting) ? "opacity-0" : "opacity-100"
           )}>
             {formatRelativeTime(session.updated_at, t)}
@@ -192,7 +192,7 @@ export function SplitGroupSection({
                 </span>
               )}
               <div className="flex-1 min-w-0">
-                <span className="line-clamp-1 text-[13px] font-medium leading-tight break-all">
+                <span className="line-clamp-1 text-[0.8125rem] font-medium leading-tight break-all">
                   {session.title}
                 </span>
               </div>

--- a/src/components/layout/SplitColumn.tsx
+++ b/src/components/layout/SplitColumn.tsx
@@ -162,11 +162,11 @@ export function SplitColumn({ sessionId, isActive, onClose, onFocus }: SplitColu
         <div className="flex items-center gap-1.5 min-w-0">
           {projectName && (
             <>
-              <span className="text-[11px] text-muted-foreground shrink-0">{projectName}</span>
-              <span className="text-[11px] text-muted-foreground shrink-0">/</span>
+              <span className="text-[0.6875rem] text-muted-foreground shrink-0">{projectName}</span>
+              <span className="text-[0.6875rem] text-muted-foreground shrink-0">/</span>
             </>
           )}
-          <span className="text-[11px] font-medium truncate">{sessionTitle}</span>
+          <span className="text-[0.6875rem] font-medium truncate">{sessionTitle}</span>
         </div>
         <Button
           variant="ghost"

--- a/src/components/patterns/CommandList.tsx
+++ b/src/components/patterns/CommandList.tsx
@@ -125,7 +125,7 @@ export function CommandListGroup({ label, separator, children }: CommandListGrou
   return (
     <div className={cn(separator && "border-t")}>
       {label && (
-        <div className="px-3 py-1.5 text-[10px] font-medium text-muted-foreground">
+        <div className="px-3 py-1.5 text-[0.625rem] font-medium text-muted-foreground">
           {label}
         </div>
       )}

--- a/src/components/plugins/McpManager.tsx
+++ b/src/components/plugins/McpManager.tsx
@@ -319,7 +319,7 @@ export function McpManager() {
                   }`} />
                   <span className="text-xs font-medium truncate">{s.name}</span>
                 </div>
-                <Badge variant="outline" className="text-[10px] shrink-0">
+                <Badge variant="outline" className="text-[0.625rem] shrink-0">
                   {s.status}
                 </Badge>
               </div>

--- a/src/components/plugins/McpServerList.tsx
+++ b/src/components/plugins/McpServerList.tsx
@@ -153,7 +153,7 @@ export function McpServerList({ servers, onEdit, onDelete, runtimeStatus, active
                     : `${server.command} ${server.args?.join(' ') || ''}`}
                 </CardDescription>
                 {runtime?.serverInfo && (
-                  <p className="text-[10px] text-muted-foreground mt-0.5">
+                  <p className="text-[0.625rem] text-muted-foreground mt-0.5">
                     {runtime.serverInfo.name} v{runtime.serverInfo.version}
                   </p>
                 )}

--- a/src/components/project/FilePreview.tsx
+++ b/src/components/project/FilePreview.tsx
@@ -95,10 +95,10 @@ export function FilePreview({ filePath, onBack }: FilePreviewProps) {
       {/* File info */}
       {preview && (
         <div className="flex items-center gap-2 pb-2">
-          <Badge variant="secondary" className="text-[10px]">
+          <Badge variant="secondary" className="text-[0.625rem]">
             {preview.language}
           </Badge>
-          <span className="text-[10px] text-muted-foreground">
+          <span className="text-[0.625rem] text-muted-foreground">
             {t('filePreview.lines', { count: preview.line_count })}
           </span>
         </div>
@@ -132,7 +132,7 @@ export function FilePreview({ filePath, onBack }: FilePreviewProps) {
                 margin: 0,
                 padding: "8px",
                 borderRadius: "6px",
-                fontSize: "11px",
+                fontSize: "0.6875rem",
                 lineHeight: "1.5",
               }}
               lineNumberStyle={{

--- a/src/components/project/TaskCard.tsx
+++ b/src/components/project/TaskCard.tsx
@@ -118,11 +118,11 @@ export function TaskCard({ task, onUpdate, onDelete }: TaskCardProps) {
           </p>
         )}
         {task.description && (
-          <p className="mt-0.5 truncate text-[10px] text-muted-foreground">
+          <p className="mt-0.5 truncate text-[0.625rem] text-muted-foreground">
             {task.description}
           </p>
         )}
-        <p className="mt-0.5 text-[10px] text-muted-foreground">
+        <p className="mt-0.5 text-[0.625rem] text-muted-foreground">
           {formatTime(task.updated_at)}
         </p>
       </div>

--- a/src/components/settings/AppearanceSection.tsx
+++ b/src/components/settings/AppearanceSection.tsx
@@ -8,8 +8,13 @@ import {
   resolveShikiTheme,
   resolveShikiThemes,
 } from "@/lib/theme/code-themes";
+import { useAppearance } from "@/hooks/useAppearance";
 import { useTranslation } from "@/hooks/useTranslation";
 import { Sun, Moon, Desktop } from "@/components/ui/icon";
+import {
+  FONT_SIZES,
+  type FontSizeKey,
+} from "@/lib/appearance";
 import {
   Select,
   SelectContent,
@@ -21,6 +26,7 @@ import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { SettingsCard } from "@/components/patterns/SettingsCard";
 import { FieldRow } from "@/components/patterns/FieldRow";
+import type { TranslationKey } from "@/i18n";
 
 // ── Theme Mode Pill Selector ────────────────────────────────────────
 
@@ -120,24 +126,34 @@ function UIPreview() {
       <Button size="sm" className="text-xs h-auto py-1">Primary</Button>
       <Button size="sm" variant="secondary" className="text-xs h-auto py-1">Secondary</Button>
       <Button size="sm" variant="destructive" className="text-xs h-auto py-1">Destructive</Button>
-      <span className="inline-flex items-center rounded-full bg-accent px-2.5 py-0.5 text-[10px] font-medium text-accent-foreground">
+      <span className="inline-flex items-center rounded-full bg-accent px-2.5 py-0.5 text-[0.625rem] font-medium text-accent-foreground">
         Badge
       </span>
-      <span className="inline-flex items-center rounded-full border border-border bg-card px-2.5 py-0.5 text-[10px] text-card-foreground">
+      <span className="inline-flex items-center rounded-full border border-border bg-card px-2.5 py-0.5 text-[0.625rem] text-card-foreground">
         Card
       </span>
-      <span className="inline-flex items-center rounded-full bg-muted px-2.5 py-0.5 text-[10px] text-muted-foreground">
+      <span className="inline-flex items-center rounded-full bg-muted px-2.5 py-0.5 text-[0.625rem] text-muted-foreground">
         Muted
       </span>
     </div>
   );
 }
 
+// ── Font Size Labels ────────────────────────────────────────────────
+
+const FONT_SIZE_LABELS: Record<FontSizeKey, TranslationKey> = {
+  small: "settings.fontSizeSmall",
+  default: "settings.fontSizeDefault",
+  large: "settings.fontSizeLarge",
+  "extra-large": "settings.fontSizeXL",
+};
+
 // ── Main Appearance Section ─────────────────────────────────────────
 
 export function AppearanceSection() {
   const { theme, setTheme, resolvedTheme } = useTheme();
   const { family, setFamily, families } = useThemeFamily();
+  const { fontSize, setFontSize } = useAppearance();
   const { t } = useTranslation();
   const isDark = resolvedTheme === "dark";
 
@@ -148,6 +164,8 @@ export function AppearanceSection() {
   );
 
   if (!mounted) return null;
+
+  const fontSizeKeys = Object.keys(FONT_SIZES) as FontSizeKey[];
 
   return (
     <div className="space-y-4">
@@ -167,7 +185,7 @@ export function AppearanceSection() {
       </FieldRow>
 
       {theme === "system" && resolvedTheme && (
-        <p className="text-[11px] text-muted-foreground pl-1">
+        <p className="text-[0.6875rem] text-muted-foreground pl-1">
           {resolvedTheme === "dark" ? t("settings.modeDark") : t("settings.modeLight")}
         </p>
       )}
@@ -204,6 +222,32 @@ export function AppearanceSection() {
             ))}
           </SelectContent>
         </Select>
+      </FieldRow>
+
+      {/* Font Size */}
+      <FieldRow
+        label={t("settings.fontSize")}
+        description={t("settings.fontSizeDesc")}
+        separator
+      >
+        <div className="flex gap-2">
+          {fontSizeKeys.map((key) => (
+            <Button
+              key={key}
+              variant="ghost"
+              size="sm"
+              onClick={() => setFontSize(key)}
+              className={cn(
+                "rounded-md px-3 py-1.5 text-xs font-medium h-auto",
+                fontSize === key
+                  ? "bg-accent text-accent-foreground"
+                  : "text-muted-foreground hover:bg-accent/50 hover:text-foreground"
+              )}
+            >
+              {t(FONT_SIZE_LABELS[key])}
+            </Button>
+          ))}
+        </div>
       </FieldRow>
 
       {/* Preview */}

--- a/src/components/settings/GeneralSection.tsx
+++ b/src/components/settings/GeneralSection.tsx
@@ -23,7 +23,6 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { SettingsCard } from "@/components/patterns/SettingsCard";
 import { FieldRow } from "@/components/patterns/FieldRow";
 import { StatusBanner } from "@/components/patterns/StatusBanner";
-import { AppearanceSection } from "./AppearanceSection";
 
 function UpdateCard() {
   const { updateInfo, checking, checkForUpdates, downloadUpdate, quitAndInstall, setShowDialog } = useUpdate();
@@ -254,9 +253,6 @@ export function GeneralSection() {
           </Select>
         </FieldRow>
       </SettingsCard>
-
-      {/* Appearance */}
-      <AppearanceSection />
 
       {/* Account info */}
       {accountInfo && (

--- a/src/components/settings/PresetConnectDialog.tsx
+++ b/src/components/settings/PresetConnectDialog.tsx
@@ -358,7 +358,7 @@ export function PresetConnectDialog({
                 placeholder="ark-code-latest"
                 className="text-sm font-mono"
               />
-              <p className="text-[11px] text-muted-foreground">
+              <p className="text-[0.6875rem] text-muted-foreground">
                 {isZh
                   ? '在服务商控制台配置的模型名称，如 ark-code-latest、doubao-seed-2.0-code'
                   : 'Model name configured in provider console, e.g. ark-code-latest'}
@@ -399,7 +399,7 @@ export function PresetConnectDialog({
                       <Label className="text-xs text-muted-foreground">
                         {isZh ? '模型名称映射' : 'Model Name Mapping'}
                       </Label>
-                      <p className="text-[11px] text-muted-foreground leading-relaxed">
+                      <p className="text-[0.6875rem] text-muted-foreground leading-relaxed">
                         {isZh
                           ? '如果服务商使用不同的模型名称（如 claude-sonnet-4-6），在此映射。留空则使用默认名称（sonnet / opus / haiku）。'
                           : 'Map model names if the provider uses different IDs (e.g. claude-sonnet-4-6). Leave empty to use defaults (sonnet / opus / haiku).'}

--- a/src/components/settings/ProviderManager.tsx
+++ b/src/components/settings/ProviderManager.tsx
@@ -199,18 +199,18 @@ export function ProviderManager() {
               <div className="flex-1 min-w-0">
                 <div className="flex items-center gap-2">
                   <span className="text-sm font-medium">Claude Code</span>
-                  <Badge variant="outline" className="text-[10px] px-1.5 py-0">
+                  <Badge variant="outline" className="text-[0.625rem] px-1.5 py-0">
                     {t('provider.default')}
                   </Badge>
                   {Object.keys(envDetected).length > 0 && (
-                    <Badge variant="outline" className="text-[10px] px-1.5 py-0 text-status-success-foreground border-status-success-border">
+                    <Badge variant="outline" className="text-[0.625rem] px-1.5 py-0 text-status-success-foreground border-status-success-border">
                       ENV
                     </Badge>
                   )}
                 </div>
               </div>
             </div>
-            <p className="text-[11px] text-muted-foreground ml-[34px] leading-relaxed">
+            <p className="text-[0.6875rem] text-muted-foreground ml-[34px] leading-relaxed">
               {t('provider.ccSwitchHint')}
             </p>
           </div>
@@ -229,7 +229,7 @@ export function ProviderManager() {
                   <div className="flex-1 min-w-0">
                     <div className="flex items-center gap-2">
                       <span className="text-sm font-medium truncate">{provider.name}</span>
-                      <Badge variant="secondary" className="text-[10px] px-1.5 py-0">
+                      <Badge variant="secondary" className="text-[0.625rem] px-1.5 py-0">
                         {provider.api_key
                           ? (provider.extra_env?.includes("ANTHROPIC_AUTH_TOKEN") ? "Auth Token" : "API Key")
                           : t('provider.configured')}
@@ -258,7 +258,7 @@ export function ProviderManager() {
                 {/* Gemini Image model selector — capsule buttons */}
                 {provider.provider_type === 'gemini-image' && (
                   <div className="ml-[34px] mt-2 flex items-center gap-1.5">
-                    <span className="text-[11px] text-muted-foreground mr-1">{isZh ? '模型' : 'Model'}:</span>
+                    <span className="text-[0.6875rem] text-muted-foreground mr-1">{isZh ? '模型' : 'Model'}:</span>
                     {GEMINI_IMAGE_MODELS.map((m) => {
                       const isActive = getGeminiImageModel(provider) === m.value;
                       return (
@@ -267,7 +267,7 @@ export function ProviderManager() {
                           variant="ghost"
                           size="sm"
                           onClick={() => handleImageModelChange(provider, m.value)}
-                          className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-[11px] font-medium border h-auto ${
+                          className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-[0.6875rem] font-medium border h-auto ${
                             isActive
                               ? 'bg-primary/10 text-primary border-primary/30'
                               : 'text-muted-foreground border-border/60 hover:text-foreground hover:border-foreground/30 hover:bg-accent/50'

--- a/src/components/settings/SettingsLayout.tsx
+++ b/src/components/settings/SettingsLayout.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useCallback, useSyncExternalStore } from "react";
-import { type Icon, Gear, Code, UserCircle, Plug, ChartBar } from "@/components/ui/icon";
+import { type Icon, Gear, Code, UserCircle, Plug, ChartBar, PaintBrush } from "@/components/ui/icon";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { GeneralSection } from "./GeneralSection";
@@ -9,10 +9,11 @@ import { ProviderManager } from "./ProviderManager";
 import { CliSettingsSection } from "./CliSettingsSection";
 import { UsageStatsSection } from "./UsageStatsSection";
 import { AssistantWorkspaceSection } from "./AssistantWorkspaceSection";
+import { AppearanceSection } from "./AppearanceSection";
 import { useTranslation } from "@/hooks/useTranslation";
 import type { TranslationKey } from "@/i18n";
 
-type Section = "general" | "providers" | "cli" | "usage" | "assistant";
+type Section = "general" | "appearance" | "providers" | "cli" | "usage" | "assistant";
 
 interface SidebarItem {
   id: Section;
@@ -22,6 +23,7 @@ interface SidebarItem {
 
 const sidebarItems: SidebarItem[] = [
   { id: "general", label: "General", icon: Gear },
+  { id: "appearance", label: "Appearance", icon: PaintBrush },
   { id: "providers", label: "Providers", icon: Plug },
   { id: "cli", label: "Claude CLI", icon: Code },
   { id: "usage", label: "Usage", icon: ChartBar },
@@ -55,6 +57,7 @@ export function SettingsLayout() {
 
   const settingsLabelKeys: Record<string, TranslationKey> = {
     'General': 'settings.general',
+    'Appearance': 'settings.appearance',
     'Providers': 'settings.providers',
     'Claude CLI': 'settings.claudeCli',
     'Usage': 'settings.usage',
@@ -101,6 +104,7 @@ export function SettingsLayout() {
         {/* Content */}
         <div className="flex-1 overflow-auto p-6">
           {activeSection === "general" && <GeneralSection />}
+          {activeSection === "appearance" && <AppearanceSection />}
           {activeSection === "providers" && <ProviderManager />}
           {activeSection === "cli" && <CliSettingsSection />}
           {activeSection === "usage" && <UsageStatsSection />}

--- a/src/components/settings/UsageStatsSection.tsx
+++ b/src/components/settings/UsageStatsSection.tsx
@@ -386,7 +386,7 @@ function StatCard({
     <div className="rounded-lg border border-border/50 p-4 transition-shadow hover:shadow-sm">
       <p className="text-xs text-muted-foreground">{label}</p>
       <p className="mt-1 text-xl font-semibold tabular-nums">{value}</p>
-      {sub && <p className="mt-0.5 text-[11px] text-muted-foreground">{sub}</p>}
+      {sub && <p className="mt-0.5 text-[0.6875rem] text-muted-foreground">{sub}</p>}
     </div>
   );
 }

--- a/src/components/settings/WorkspaceTabPanels.tsx
+++ b/src/components/settings/WorkspaceTabPanels.tsx
@@ -94,7 +94,7 @@ export function TaxonomyTabPanel({ taxonomy }: TaxonomyTabPanelProps) {
               </div>
               <div className="flex items-center gap-2">
                 <span className="text-muted-foreground">{t('assistant.taxonomySource')}: {cat.source}</span>
-                <span className={`px-1.5 py-0.5 rounded text-[10px] ${
+                <span className={`px-1.5 py-0.5 rounded text-[0.625rem] ${
                   cat.confidence > 0.7 ? 'bg-status-success-muted text-status-success-foreground' :
                   cat.confidence > 0.4 ? 'bg-status-warning-muted text-status-warning-foreground' :
                   'bg-status-error-muted text-status-error-foreground'

--- a/src/components/skills/MarketplaceBrowser.tsx
+++ b/src/components/skills/MarketplaceBrowser.tsx
@@ -93,7 +93,7 @@ export function MarketplaceBrowser({ onInstalled }: MarketplaceBrowserProps) {
             {error && (
               <div className="flex flex-col items-center gap-2 py-8 text-muted-foreground px-3">
                 <p className="text-xs text-center text-status-error-foreground">{t('skills.marketplaceError')}</p>
-                <p className="text-[10px] text-center">{error}</p>
+                <p className="text-[0.625rem] text-center">{error}</p>
               </div>
             )}
             {!loading && !error && results.length === 0 && (

--- a/src/components/skills/MarketplaceSkillCard.tsx
+++ b/src/components/skills/MarketplaceSkillCard.tsx
@@ -36,7 +36,7 @@ export function MarketplaceSkillCard({
           {skill.isInstalled ? (
             <Badge
               variant="outline"
-              className="text-[10px] px-1.5 py-0 border-status-success-border text-status-success-foreground"
+              className="text-[0.625rem] px-1.5 py-0 border-status-success-border text-status-success-foreground"
             >
               <CheckCircle size={10} className="mr-0.5" />
               {t('skills.installed')}

--- a/src/components/skills/MarketplaceSkillDetail.tsx
+++ b/src/components/skills/MarketplaceSkillDetail.tsx
@@ -92,7 +92,7 @@ export function MarketplaceSkillDetail({
               {skill.isInstalled && (
                 <Badge
                   variant="outline"
-                  className="text-[10px] px-1.5 py-0 border-status-success-border text-status-success-foreground shrink-0"
+                  className="text-[0.625rem] px-1.5 py-0 border-status-success-border text-status-success-foreground shrink-0"
                 >
                   <CheckCircle size={10} className="mr-0.5" />
                   {t('skills.installed')}

--- a/src/components/skills/SkillEditor.tsx
+++ b/src/components/skills/SkillEditor.tsx
@@ -119,7 +119,7 @@ export function SkillEditor({ skill, onSave, onDelete }: SkillEditorProps) {
           <Badge
             variant="outline"
             className={cn(
-              "text-[10px] px-1.5 py-0 shrink-0",
+              "text-[0.625rem] px-1.5 py-0 shrink-0",
               skill.source === "global"
                 ? "border-status-success-border text-status-success-foreground"
                 : skill.source === "installed"

--- a/src/components/skills/SkillsManager.tsx
+++ b/src/components/skills/SkillsManager.tsx
@@ -215,7 +215,7 @@ export function SkillsManager() {
             <div className="p-1">
               {globalSkills.length > 0 && (
                 <div className="mb-1">
-                  <span className="px-3 py-1 text-[10px] font-medium uppercase text-muted-foreground">
+                  <span className="px-3 py-1 text-[0.625rem] font-medium uppercase text-muted-foreground">
                     Global
                   </span>
                   {globalSkills.map((skill) => (
@@ -235,7 +235,7 @@ export function SkillsManager() {
               )}
               {installedSkills.length > 0 && (
                 <div className="mb-1">
-                  <span className="px-3 py-1 text-[10px] font-medium uppercase text-muted-foreground">
+                  <span className="px-3 py-1 text-[0.625rem] font-medium uppercase text-muted-foreground">
                     Installed
                   </span>
                   {installedSkills.map((skill) => (
@@ -255,7 +255,7 @@ export function SkillsManager() {
               )}
               {pluginSkills.length > 0 && (
                 <div className="mb-1">
-                  <span className="px-3 py-1 text-[10px] font-medium uppercase text-muted-foreground">
+                  <span className="px-3 py-1 text-[0.625rem] font-medium uppercase text-muted-foreground">
                     Plugins
                   </span>
                   {pluginSkills.map((skill) => (

--- a/src/hooks/useAppearance.ts
+++ b/src/hooks/useAppearance.ts
@@ -1,0 +1,6 @@
+import { useContext } from 'react';
+import { AppearanceContext } from '@/components/layout/AppearanceProvider';
+
+export function useAppearance() {
+  return useContext(AppearanceContext);
+}

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -85,6 +85,12 @@ const en = {
   'settings.language': 'Language',
   'settings.languageDesc': 'Choose the display language for the interface',
   'settings.usage': 'Usage',
+  'settings.fontSize': 'Font Size',
+  'settings.fontSizeDesc': 'Controls the base text size. All UI elements scale proportionally.',
+  'settings.fontSizeSmall': 'Small',
+  'settings.fontSizeDefault': 'Default',
+  'settings.fontSizeLarge': 'Large',
+  'settings.fontSizeXL': 'Extra Large',
 
   // ── Settings: Appearance ──────────────────────────────────────
   'settings.appearance': 'Appearance',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -82,6 +82,12 @@ const zh: Record<TranslationKey, string> = {
   'settings.language': '语言',
   'settings.languageDesc': '选择界面显示语言',
   'settings.usage': '用量统计',
+  'settings.fontSize': '字号',
+  'settings.fontSizeDesc': '控制基础文字大小，所有界面元素会按比例缩放。',
+  'settings.fontSizeSmall': '小',
+  'settings.fontSizeDefault': '默认',
+  'settings.fontSizeLarge': '大',
+  'settings.fontSizeXL': '特大',
 
   // ── Settings: Appearance ──────────────────────────────────────
   'settings.appearance': '外观',

--- a/src/lib/appearance.ts
+++ b/src/lib/appearance.ts
@@ -1,0 +1,54 @@
+export type FontSizeKey = 'small' | 'default' | 'large' | 'extra-large';
+
+interface FontSizeOption {
+  px: number;
+}
+
+export const FONT_SIZES: Record<FontSizeKey, FontSizeOption> = {
+  small:         { px: 14 },
+  default:       { px: 16 },
+  large:         { px: 18 },
+  'extra-large': { px: 20 },
+};
+
+export const DEFAULT_FONT_SIZE: FontSizeKey = 'default';
+
+/** Type guard: returns true if value is a valid FontSizeKey */
+export function isValidFontSize(value: string | undefined | null): value is FontSizeKey {
+  return typeof value === 'string' && value in FONT_SIZES;
+}
+
+/** Returns px value for a font size key, falling back to default if invalid */
+export function getFontSizePx(key: FontSizeKey | string): number {
+  if (isValidFontSize(key)) return FONT_SIZES[key].px;
+  return FONT_SIZES[DEFAULT_FONT_SIZE].px;
+}
+
+export const APPEARANCE_STORAGE_KEY = 'codepilot_appearance_font_size';
+
+/** Read font size from localStorage, returning DEFAULT_FONT_SIZE if missing or invalid. */
+export function readFontSizeFromStorage(storage?: Storage): FontSizeKey {
+  if (!storage) {
+    if (typeof window === 'undefined') return DEFAULT_FONT_SIZE;
+    storage = localStorage;
+  }
+  try {
+    const raw = storage.getItem(APPEARANCE_STORAGE_KEY);
+    return isValidFontSize(raw) ? raw : DEFAULT_FONT_SIZE;
+  } catch {
+    return DEFAULT_FONT_SIZE;
+  }
+}
+
+/** Write font size to localStorage. */
+export function writeFontSizeToStorage(size: FontSizeKey, storage?: Storage): void {
+  if (!storage) {
+    if (typeof window === 'undefined') return;
+    storage = localStorage;
+  }
+  try {
+    storage.setItem(APPEARANCE_STORAGE_KEY, size);
+  } catch {
+    // localStorage may be unavailable (SSR, private browsing quota)
+  }
+}


### PR DESCRIPTION
The app lacked user-facing controls for visual customization. Font size was fixed, and UI elements like the mode.

### Added: Font Size Scaling
- **Pure data module** defining four font sizes (small 14px, default 16px, large 18px, extra-large 20px), validation helpers, and localStorage read/write with SSR guards
- **React context provider** that initializes instantly from localStorage, then reconciles with the API on mount (API wins on conflict). Exposes a `setFontSize` callback that updates state, localStorage, DOM, and API in one call
- **Thin context hook** for components to consume the appearance context
- **Font size selector UI** with live preview added to the dedicated Appearance settings tab
- **Anti-FOUC inline script** in the root layout that reads localStorage and sets `document.documentElement.style.fontSize` before React hydrates — px map is generated from the source-of-truth constant, no hardcoded values
- **6 unit tests** covering localStorage helpers (read, write, fallback on missing/invalid values) and anti-FOUC map consistency

### Changed: px → rem Conversion
- All hardcoded `text-[Npx]` Tailwind classes converted to rem equivalents so UI text scales with the root font-size set by the provider. All UI elements scale proportionally via rem-based sizing. All fixed px font sizes (e.g. text-[11px], text-[13px]) were converted to rem equivalents (text-[0.6875rem], text-xs) so they scale proportionally when the user changes the base font size in Appearance settings. Since AppearanceProvider sets font-size on <html>, only rem-based values respond to that change — px values would stay fixed and break visual consistency.

### Restructured: Settings Tabs
- Moved appearance section out of the General tab into its own dedicated Appearance tab with a PaintBrush icon
- Added `appearance_font_size` to the API settings whitelist
- Added i18n keys for font size labels and appearance tab in both languages