### PR TITLE
fix: 修复环形上下文进度条在非流式与多模型下的显示

### DIFF
--- a/src/app/api/providers/models/route.ts
+++ b/src/app/api/providers/models/route.ts
@@ -2,15 +2,21 @@ import { NextResponse } from 'next/server';
 import { getAllProviders, getDefaultProviderId } from '@/lib/db';
 import type { ErrorResponse, ProviderModelGroup } from '@/types';
 
+interface ModelOption {
+  value: string;
+  label: string;
+  context_window?: number;
+}
+
 // Default Claude model options
-const DEFAULT_MODELS = [
-  { value: 'sonnet', label: 'Sonnet 4.6' },
-  { value: 'opus', label: 'Opus 4.6' },
-  { value: 'haiku', label: 'Haiku 4.5' },
+const DEFAULT_MODELS: ModelOption[] = [
+  { value: 'sonnet', label: 'Sonnet 4.6', context_window: 200000 },
+  { value: 'opus', label: 'Opus 4.6', context_window: 200000 },
+  { value: 'haiku', label: 'Haiku 4.5', context_window: 200000 },
 ];
 
 // Provider-specific model label mappings (base_url -> alias -> display name)
-const PROVIDER_MODEL_LABELS: Record<string, { value: string; label: string }[]> = {
+const PROVIDER_MODEL_LABELS: Record<string, ModelOption[]> = {
   'https://api.z.ai/api/anthropic': [
     { value: 'sonnet', label: 'GLM-4.7' },
     { value: 'opus', label: 'GLM-5' },
@@ -47,9 +53,9 @@ const PROVIDER_MODEL_LABELS: Record<string, { value: string; label: string }[]> 
     { value: 'haiku', label: 'MiniMax-M2.5' },
   ],
   'https://openrouter.ai/api': [
-    { value: 'sonnet', label: 'Sonnet 4.6' },
-    { value: 'opus', label: 'Opus 4.6' },
-    { value: 'haiku', label: 'Haiku 4.5' },
+    { value: 'sonnet', label: 'Sonnet 4.6', context_window: 200000 },
+    { value: 'opus', label: 'Opus 4.6', context_window: 200000 },
+    { value: 'haiku', label: 'Haiku 4.5', context_window: 200000 },
   ],
   'https://coding.dashscope.aliyuncs.com/apps/anthropic': [
     { value: 'qwen3.5-plus', label: 'Qwen 3.5 Plus' },
@@ -65,9 +71,9 @@ const PROVIDER_MODEL_LABELS: Record<string, { value: string; label: string }[]> 
 /**
  * Deduplicate models: if multiple aliases map to the same label, keep only the first one.
  */
-function deduplicateModels(models: { value: string; label: string }[]): { value: string; label: string }[] {
+function deduplicateModels(models: ModelOption[]): ModelOption[] {
   const seen = new Set<string>();
-  const result: { value: string; label: string }[] = [];
+  const result: ModelOption[] = [];
   for (const m of models) {
     if (!seen.has(m.label)) {
       seen.add(m.label);
@@ -75,6 +81,19 @@ function deduplicateModels(models: { value: string; label: string }[]): { value:
     }
   }
   return result;
+}
+
+function parsePositiveInteger(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isInteger(value) && value > 0) {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const parsed = Number.parseInt(value, 10);
+    if (Number.isInteger(parsed) && parsed > 0) {
+      return parsed;
+    }
+  }
+  return undefined;
 }
 
 export async function GET() {
@@ -100,19 +119,31 @@ export async function GET() {
       if (MEDIA_PROVIDER_TYPES.has(provider.provider_type)) continue;
       const matched = PROVIDER_MODEL_LABELS[provider.base_url];
       let rawModels = matched || DEFAULT_MODELS;
+      let providerEnv: Record<string, unknown> = {};
+
+      try {
+        providerEnv = JSON.parse(provider.extra_env || '{}') as Record<string, unknown>;
+      } catch {
+        providerEnv = {};
+      }
+
+      const providerContextWindow = parsePositiveInteger(providerEnv.CODEPILOT_CONTEXT_WINDOW);
 
       // For providers with ANTHROPIC_MODEL in extra_env (e.g. Volcengine Ark),
       // show the configured model name in the selector
       if (!matched) {
-        try {
-          const envObj = JSON.parse(provider.extra_env || '{}');
-          if (envObj.ANTHROPIC_MODEL) {
-            rawModels = [{ value: envObj.ANTHROPIC_MODEL, label: envObj.ANTHROPIC_MODEL }];
-          }
-        } catch { /* use default */ }
+        const anthropicModel = providerEnv.ANTHROPIC_MODEL;
+        if (typeof anthropicModel === 'string' && anthropicModel.trim()) {
+          rawModels = [{ value: anthropicModel, label: anthropicModel }];
+        }
       }
 
-      const models = deduplicateModels(rawModels);
+      const models = deduplicateModels(
+        rawModels.map((model) => ({
+          ...model,
+          context_window: model.context_window ?? providerContextWindow,
+        }))
+      );
 
       groups.push({
         provider_id: provider.id,

--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -1,7 +1,14 @@
 'use client';
 
-import { useState, useCallback, useEffect, useRef } from 'react';
-import type { Message, MessagesResponse, FileAttachment, SessionStreamSnapshot } from '@/types';
+import { useState, useCallback, useEffect, useRef, useMemo } from 'react';
+import type {
+  Message,
+  MessagesResponse,
+  FileAttachment,
+  SessionStreamSnapshot,
+  ProviderModelGroup,
+  TokenUsage,
+} from '@/types';
 import { MessageList } from './MessageList';
 import { MessageInput } from './MessageInput';
 import { usePanel } from '@/hooks/usePanel';
@@ -26,7 +33,7 @@ interface ChatViewProps {
 }
 
 export function ChatView({ sessionId, initialMessages = [], initialHasMore = false, modelName, initialMode, providerId }: ChatViewProps) {
-  const { setStreamingSessionId, workingDirectory, setWorkingDirectory, setPanelOpen, setPendingApprovalSessionId } = usePanel();
+  const { setStreamingSessionId, workingDirectory, setPendingApprovalSessionId } = usePanel();
   const [messages, setMessages] = useState<Message[]>(initialMessages);
   const [hasMore, setHasMore] = useState(initialHasMore);
   const [loadingMore, setLoadingMore] = useState(false);
@@ -34,6 +41,8 @@ export function ChatView({ sessionId, initialMessages = [], initialHasMore = fal
   const [mode, setMode] = useState(initialMode || 'code');
   const [currentModel, setCurrentModel] = useState(modelName || (typeof window !== 'undefined' ? localStorage.getItem('codepilot:last-model') : null) || 'sonnet');
   const [currentProviderId, setCurrentProviderId] = useState(providerId || (typeof window !== 'undefined' ? localStorage.getItem('codepilot:last-provider-id') : null) || '');
+  const [providerModelGroups, setProviderModelGroups] = useState<ProviderModelGroup[]>([]);
+  const [providerGroupsDefaultId, setProviderGroupsDefaultId] = useState('');
 
   // Sync model/provider when session data loads (props update after async fetch)
   // Unconditional: when modelName is empty (old session with no saved model),
@@ -59,6 +68,12 @@ export function ChatView({ sessionId, initialMessages = [], initialHasMore = fal
   const statusText = streamSnapshot?.statusText;
   const pendingPermission = streamSnapshot?.pendingPermission ?? null;
   const permissionResolved = streamSnapshot?.permissionResolved ?? null;
+
+  // Context Ring states — derive from stream snapshot
+  const snapshotContextWindowTotal = streamSnapshot?.contextWindow?.total ?? 0;
+  const snapshotIsCompacting = streamSnapshot?.isCompacting ?? false;
+  const snapshotStreamingContextTokens = streamSnapshot?.streamingContextTokens ?? null;
+  const snapshotContextTokensPendingRefresh = streamSnapshot?.contextTokensPendingRefresh ?? false;
 
   // Pending image generation notices — flushed into the next user message so the LLM knows about generated images
   const pendingImageNoticesRef = useRef<string[]>([]);
@@ -384,6 +399,69 @@ export function ChatView({ sessionId, initialMessages = [], initialHasMore = fal
     return () => window.removeEventListener('image-gen-completed', handler);
   }, [sessionId]);
 
+  const latestAssistantUsage = useMemo<TokenUsage | null>(() => {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const msg = messages[i];
+      if (msg.role === 'assistant' && msg.token_usage) {
+        try {
+          return typeof msg.token_usage === 'string'
+            ? JSON.parse(msg.token_usage) as TokenUsage
+            : msg.token_usage as TokenUsage;
+        } catch { /* skip */ }
+      }
+    }
+    return null;
+  }, [messages]);
+
+  // Context tokens from message history (fallback when not actively streaming)
+  const contextTokens = useMemo(() => {
+    if (!latestAssistantUsage) return 0;
+    // Prefer last_input_tokens: this is the actual single-turn context size
+    // from the last API call's message_start event
+    if (typeof latestAssistantUsage.last_input_tokens === 'number' && latestAssistantUsage.last_input_tokens > 0) {
+      return latestAssistantUsage.last_input_tokens + (latestAssistantUsage.output_tokens || 0);
+    }
+    // Fallback: sum input + cache tokens for accurate context size
+    const input = (latestAssistantUsage.input_tokens || 0)
+      + (latestAssistantUsage.cache_read_input_tokens || 0)
+      + (latestAssistantUsage.cache_creation_input_tokens || 0);
+    const output = latestAssistantUsage.output_tokens || 0;
+    return input + output;
+  }, [latestAssistantUsage]);
+
+  const historyContextWindow = useMemo(() => {
+    const fromUsage = latestAssistantUsage?.context_window;
+    return typeof fromUsage === 'number' && fromUsage > 0 ? fromUsage : 0;
+  }, [latestAssistantUsage]);
+
+  const providerModelContextWindow = useMemo(() => {
+    const effectiveProviderId = currentProviderId || providerGroupsDefaultId || (providerModelGroups[0]?.provider_id ?? '');
+    const group = providerModelGroups.find((g) => g.provider_id === effectiveProviderId);
+    if (!group) return 0;
+    const model = group.models.find((m) => m.value === currentModel);
+    const cw = model?.context_window;
+    return typeof cw === 'number' && cw > 0 ? cw : 0;
+  }, [providerModelGroups, currentProviderId, providerGroupsDefaultId, currentModel]);
+
+  const handleProviderGroupsLoaded = useCallback((groups: ProviderModelGroup[], defaultProviderId?: string) => {
+    setProviderModelGroups(groups);
+    setProviderGroupsDefaultId(defaultProviderId || groups[0]?.provider_id || '');
+  }, []);
+
+  const contextWindowMax = snapshotContextWindowTotal > 0
+    ? snapshotContextWindowTotal
+    : historyContextWindow > 0
+      ? historyContextWindow
+      : providerModelContextWindow > 0
+        ? providerModelContextWindow
+        : 200000;
+
+  // Derive the context token count to pass to MessageInput:
+  // Prefer the live streaming value only while stream is active.
+  const effectiveContextTokens = (isStreaming && snapshotStreamingContextTokens)
+    ? snapshotStreamingContextTokens.used
+    : contextTokens;
+
   return (
     <div className="flex h-full min-h-0 flex-col">
       <MessageList
@@ -417,9 +495,14 @@ export function ChatView({ sessionId, initialMessages = [], initialHasMore = fal
         onModelChange={setCurrentModel}
         providerId={currentProviderId}
         onProviderModelChange={handleProviderModelChange}
+        onProviderGroupsLoaded={handleProviderGroupsLoaded}
         workingDirectory={workingDirectory}
         mode={mode}
         onModeChange={handleModeChange}
+        contextTokens={effectiveContextTokens}
+        contextStale={isStreaming ? snapshotContextTokensPendingRefresh : false}
+        maxContext={contextWindowMax}
+        isCompacting={isStreaming ? snapshotIsCompacting : false}
       />
     </div>
   );

--- a/src/components/chat/MessageInput.tsx
+++ b/src/components/chat/MessageInput.tsx
@@ -19,10 +19,13 @@ import {
   BrainIcon,
   GlobalIcon,
   StopIcon,
+  Folder01Icon,
+  File01Icon,
 } from "@hugeicons/core-free-icons";
 import { cn } from '@/lib/utils';
 import { useTranslation } from '@/hooks/useTranslation';
 import type { TranslationKey } from '@/i18n';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import {
   PromptInput,
   PromptInputTextarea,
@@ -82,6 +85,47 @@ const IMAGE_AGENT_SYSTEM_PROMPT = `你是一个图像生成助手。当用户请
 - 在输出结构化块之前，可以先简要说明你的理解和计划`;
 
 
+const FILE_TREE_DRAG_MIME = 'application/x-codepilot-path';
+const FILE_TREE_DRAG_FALLBACK_MIME = 'text/x-codepilot-path';
+
+function hasDragType(dataTransfer: DataTransfer | null | undefined, type: string): boolean {
+  if (!dataTransfer) return false;
+
+  const types = dataTransfer.types as unknown;
+  if (!types) return false;
+
+  if (typeof (types as { includes?: unknown }).includes === 'function') {
+    return (types as { includes: (value: string) => boolean }).includes(type);
+  }
+
+  if (typeof (types as { contains?: unknown }).contains === 'function') {
+    return (types as { contains: (value: string) => boolean }).contains(type);
+  }
+
+  return Array.from(types as ArrayLike<string>).includes(type);
+}
+
+function readFileTreeDropData(dataTransfer: DataTransfer | null | undefined) {
+  if (!dataTransfer) return null;
+
+  const raw = dataTransfer.getData(FILE_TREE_DRAG_MIME)
+    || dataTransfer.getData(FILE_TREE_DRAG_FALLBACK_MIME);
+
+  if (!raw) return null;
+
+  try {
+    const parsed = JSON.parse(raw) as Partial<{ path: string; name: string; type: string }>;
+    if (!parsed.path || typeof parsed.path !== 'string') return null;
+    return {
+      name: typeof parsed.name === 'string' ? parsed.name : '',
+      path: parsed.path,
+      type: parsed.type === 'directory' ? 'directory' : 'file',
+    };
+  } catch {
+    return null;
+  }
+}
+
 interface MessageInputProps {
   onSend: (content: string, files?: FileAttachment[], systemPromptAppend?: string, displayOverride?: string) => void;
   onImageGenerate?: (prompt: string, files?: FileAttachment[]) => void;
@@ -97,6 +141,11 @@ interface MessageInputProps {
   workingDirectory?: string;
   mode?: string;
   onModeChange?: (mode: string) => void;
+  contextTokens?: number;
+  contextStale?: boolean;
+  maxContext?: number;
+  isCompacting?: boolean;
+  onProviderGroupsLoaded?: (groups: ProviderModelGroup[], defaultProviderId?: string) => void;
 }
 
 interface PopoverItem {
@@ -117,6 +166,13 @@ interface CommandBadge {
   description: string;
   isSkill: boolean;
   installedSource?: "agents" | "claude";
+}
+
+interface ContextMention {
+  id: string;
+  path: string;
+  name: string;
+  type: 'file' | 'directory';
 }
 
 type PopoverMode = 'file' | 'skill' | null;
@@ -140,6 +196,8 @@ const BUILT_IN_COMMANDS: PopoverItem[] = [
   { label: 'terminal-setup', value: '/terminal-setup', description: 'Configure terminal settings', descriptionKey: 'messageInput.terminalSetupDesc', builtIn: true, icon: CommandLineIcon },
   { label: 'memory', value: '/memory', description: 'Edit project memory file', descriptionKey: 'messageInput.memoryDesc', builtIn: true, icon: BrainIcon },
 ];
+
+const BUILT_IN_COMMAND_NAMES = new Set(BUILT_IN_COMMANDS.map(c => c.label));
 
 interface ModeOption {
   value: string;
@@ -190,12 +248,14 @@ function FileAwareSubmitButton({
   disabled,
   inputValue,
   hasBadge,
+  hasContextMentions,
 }: {
   status: ChatStatus;
   onStop?: () => void;
   disabled?: boolean;
   inputValue: string;
   hasBadge: boolean;
+  hasContextMentions: boolean;
 }) {
   const attachments = usePromptInputAttachments();
   const hasFiles = attachments.files.length > 0;
@@ -205,7 +265,7 @@ function FileAwareSubmitButton({
     <PromptInputSubmit
       status={status}
       onStop={onStop}
-      disabled={disabled || (!isStreaming && !inputValue.trim() && !hasBadge && !hasFiles)}
+      disabled={disabled || (!isStreaming && !inputValue.trim() && !hasBadge && !hasFiles && !hasContextMentions)}
       className="rounded-full"
     >
       {isStreaming ? (
@@ -236,11 +296,13 @@ function AttachFileButton() {
 
 /**
  * Infer a MIME type from a filename extension so that files added from the
- * file tree pass the PromptInput accept-type validation.  Code / text files
+ * file tree pass the PromptInput accept-type validation. Code / text files
  * are mapped to `text/*` subtypes; images and PDFs get their standard types.
- * Falls back to `application/octet-stream` for unknown extensions.
+ * For extensionless/unknown files, prefer server-detected MIME when available,
+ * otherwise fall back to `text/plain` so common files like Dockerfile/README
+ * can still be attached from the file tree.
  */
-function mimeFromFilename(name: string): string {
+function mimeFromFilename(name: string, serverMime?: string): string {
   const ext = name.split('.').pop()?.toLowerCase() || '';
   const TEXT_EXTS: Record<string, string> = {
     md: 'text/markdown', mdx: 'text/markdown',
@@ -269,14 +331,24 @@ function mimeFromFilename(name: string): string {
   if (TEXT_EXTS[ext]) return TEXT_EXTS[ext];
   if (IMAGE_EXTS[ext]) return IMAGE_EXTS[ext];
   if (ext === 'pdf') return 'application/pdf';
-  return 'application/octet-stream';
+
+  // Use API-reported MIME when it looks meaningful.
+  if (serverMime && serverMime !== 'application/octet-stream') {
+    return serverMime;
+  }
+
+  return 'text/plain';
 }
 
 /**
  * Bridge component that listens for 'attach-file-to-chat' custom events
  * from the file tree and adds files as attachments. Must be rendered inside PromptInput.
  */
-function FileTreeAttachmentBridge() {
+function FileTreeAttachmentBridge({
+  onAttachFailed,
+}: {
+  onAttachFailed?: (filePath: string) => void;
+}) {
   const attachments = usePromptInputAttachments();
   const attachmentsRef = useRef(attachments);
 
@@ -294,6 +366,7 @@ function FileTreeAttachmentBridge() {
         const res = await fetch(`/api/files/raw?path=${encodeURIComponent(filePath)}`);
         if (!res.ok) {
           console.warn(`[FileTreeAttachment] Failed to fetch file: ${res.status} ${res.statusText}`, filePath);
+          onAttachFailed?.(filePath);
           return;
         }
         const blob = await res.blob();
@@ -301,17 +374,18 @@ function FileTreeAttachmentBridge() {
         const filename = filePath.split(/[/\\]/).pop() || 'file';
         // Use a proper MIME type derived from the extension so the file
         // passes PromptInput's accept-type validation (text/* etc.)
-        const mime = mimeFromFilename(filename);
+        const mime = mimeFromFilename(filename, blob.type);
         const file = new File([blob], filename, { type: mime });
         attachmentsRef.current.add([file]);
       } catch (err) {
         console.warn('[FileTreeAttachment] Error attaching file:', filePath, err);
+        onAttachFailed?.(filePath);
       }
     };
 
     window.addEventListener('attach-file-to-chat', handler);
     return () => window.removeEventListener('attach-file-to-chat', handler);
-  }, []);
+  }, [onAttachFailed]);
 
   return null;
 }
@@ -358,6 +432,86 @@ function FileAttachmentsCapsules() {
   );
 }
 
+/**
+ * Return Tailwind color classes for a context mention chip based on file extension.
+ */
+function getMentionColorClasses(mention: ContextMention): { chip: string; hover: string } {
+  if (mention.type === 'directory') {
+    return {
+      chip: "bg-amber-500/10 text-amber-600 dark:text-amber-400 border-amber-500/20",
+      hover: "hover:bg-amber-500/20",
+    };
+  }
+  const ext = mention.name.split('.').pop()?.toLowerCase() || '';
+  if (['doc', 'docx'].includes(ext)) {
+    return {
+      chip: "bg-blue-500/10 text-blue-600 dark:text-blue-400 border-blue-500/20",
+      hover: "hover:bg-blue-500/20",
+    };
+  }
+  if (['xls', 'xlsx', 'csv'].includes(ext)) {
+    return {
+      chip: "bg-green-500/10 text-green-600 dark:text-green-400 border-green-500/20",
+      hover: "hover:bg-green-500/20",
+    };
+  }
+  if (ext === 'pdf') {
+    return {
+      chip: "bg-red-500/10 text-red-600 dark:text-red-400 border-red-500/20",
+      hover: "hover:bg-red-500/20",
+    };
+  }
+  if (ext === 'txt') {
+    return {
+      chip: "bg-gray-500/10 text-gray-600 dark:text-gray-400 border-gray-500/20",
+      hover: "hover:bg-gray-500/20",
+    };
+  }
+  return {
+    chip: "bg-violet-500/10 text-violet-600 dark:text-violet-400 border-violet-500/20",
+    hover: "hover:bg-violet-500/20",
+  };
+}
+
+/**
+ * Chip display for context mentions (dragged files/folders), rendered inside PromptInput context.
+ */
+function ContextMentionChips({
+  mentions,
+  onRemove,
+}: {
+  mentions: ContextMention[];
+  onRemove: (id: string) => void;
+}) {
+  if (mentions.length === 0) return null;
+  return (
+    <div className="grid w-full grid-cols-5 gap-1.5 px-3 pt-2 pb-0 order-first">
+      {mentions.map((m) => {
+        const colors = getMentionColorClasses(m);
+        return (
+          <span
+            key={m.id}
+            className={cn(
+              "inline-flex items-center gap-1 rounded-full pl-2 pr-1 py-0.5 text-xs font-medium border min-w-0",
+              colors.chip
+            )}
+          >
+            <HugeiconsIcon icon={m.type === 'directory' ? Folder01Icon : File01Icon} className="h-3 w-3 shrink-0" />
+            <span className="truncate text-[11px] font-mono">{m.name}</span>
+            <button
+              type="button"
+              onClick={() => onRemove(m.id)}
+              className={cn("ml-auto shrink-0 rounded-full p-0.5 transition-colors", colors.hover)}
+            >
+              <HugeiconsIcon icon={Cancel01Icon} className="h-3 w-3" />
+            </button>
+          </span>
+        );
+      })}
+    </div>
+  );
+}
+
 export function MessageInput({
   onSend,
   onImageGenerate,
@@ -373,6 +527,11 @@ export function MessageInput({
   workingDirectory,
   mode = 'code',
   onModeChange,
+  contextTokens = 0,
+  contextStale = false,
+  maxContext = 200000,
+  isCompacting = false,
+  onProviderGroupsLoaded,
 }: MessageInputProps) {
   const { t } = useTranslation();
   const imageGen = useImageGen();
@@ -380,6 +539,7 @@ export function MessageInput({
   const popoverRef = useRef<HTMLDivElement>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const modelMenuRef = useRef<HTMLDivElement>(null);
+  const dropZoneRef = useRef<HTMLDivElement>(null);
 
   const [popoverMode, setPopoverMode] = useState<PopoverMode>(null);
   const [popoverItems, setPopoverItems] = useState<PopoverItem[]>([]);
@@ -395,34 +555,61 @@ export function MessageInput({
   const [aiSearchLoading, setAiSearchLoading] = useState(false);
   const aiSearchAbortRef = useRef<AbortController | null>(null);
   const aiSearchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [isDragOver, setIsDragOver] = useState(false);
+  const [contextMentions, setContextMentions] = useState<ContextMention[]>([]);
+
+  const removeContextMention = useCallback((id: string) => {
+    setContextMentions((prev) => prev.filter((m) => m.id !== id));
+  }, []);
+
+  const addContextMention = useCallback((path: string, name: string, type: 'file' | 'directory') => {
+    setContextMentions((prev) => {
+      if (prev.some((m) => m.path === path)) return prev;
+      return [...prev, { id: nanoid(), path, name, type }];
+    });
+    setTimeout(() => textareaRef.current?.focus(), 0);
+  }, []);
+
+  const appendPathMention = useCallback((path: string) => {
+    setInputValue((prev) => {
+      const suffix = `@${path} `;
+      return prev ? `${prev}${suffix}` : suffix;
+    });
+    setTimeout(() => textareaRef.current?.focus(), 0);
+  }, []);
 
   // Fetch provider groups from API
   const fetchProviderModels = useCallback(() => {
     fetch('/api/providers/models')
       .then((r) => r.json())
       .then((data) => {
+        let nextGroups: ProviderModelGroup[];
         if (data.groups && data.groups.length > 0) {
-          setProviderGroups(data.groups);
+          nextGroups = data.groups;
         } else {
-          setProviderGroups([{
+          nextGroups = [{
             provider_id: 'env',
             provider_name: 'Anthropic',
             provider_type: 'anthropic',
             models: DEFAULT_MODEL_OPTIONS,
-          }]);
+          }];
         }
+        setProviderGroups(nextGroups);
+        onProviderGroupsLoaded?.(nextGroups, data.default_provider_id || '');
         setDefaultProviderId(data.default_provider_id || '');
       })
       .catch(() => {
-        setProviderGroups([{
+        const fallbackGroups: ProviderModelGroup[] = [{
           provider_id: 'env',
           provider_name: 'Anthropic',
           provider_type: 'anthropic',
           models: DEFAULT_MODEL_OPTIONS,
-        }]);
+        }];
+        setProviderGroups(fallbackGroups);
+        onProviderGroupsLoaded?.(fallbackGroups, fallbackGroups[0]?.provider_id || '');
         setDefaultProviderId('');
       });
-  }, []);
+  }, [onProviderGroupsLoaded]);
 
   // Load models on mount and listen for provider changes
   useEffect(() => {
@@ -486,8 +673,7 @@ export function MessageInput({
     }
 
     // Deduplicate: remove API skills that share a name with built-in commands
-    const builtInNames = new Set(BUILT_IN_COMMANDS.map(c => c.label));
-    const uniqueSkills = apiSkills.filter(s => !builtInNames.has(s.label));
+    const uniqueSkills = apiSkills.filter(s => !BUILT_IN_COMMAND_NAMES.has(s.label));
 
     return [...BUILT_IN_COMMANDS, ...uniqueSkills];
   }, [workingDirectory]);
@@ -602,7 +788,11 @@ export function MessageInput({
 
   const handleSubmit = useCallback(async (msg: { text: string; files: Array<{ type: string; url: string; filename?: string; mediaType?: string }> }, e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    const content = inputValue.trim();
+    const rawContent = inputValue.trim();
+    const mentionPrefix = contextMentions.length > 0
+      ? contextMentions.map((m) => `@${m.path}`).join(' ') + ' '
+      : '';
+    const content = mentionPrefix + rawContent;
 
     closePopover();
 
@@ -679,6 +869,7 @@ export function MessageInput({
 
       const files = await convertFiles();
       setBadge(null);
+      setContextMentions([]);
       setInputValue('');
       onSend(finalPrompt, files.length > 0 ? files : undefined);
       return;
@@ -687,7 +878,7 @@ export function MessageInput({
     const files = await convertFiles();
     const hasFiles = files.length > 0;
 
-    if ((!content && !hasFiles) || disabled || isStreaming) return;
+    if ((!content && !hasFiles && contextMentions.length === 0) || disabled || isStreaming) return;
 
     // Check if it's a direct slash command typed in the input
     if (content.startsWith('/') && !hasFiles) {
@@ -724,8 +915,9 @@ export function MessageInput({
     }
 
     onSend(content || 'Please review the attached file(s).', hasFiles ? files : undefined);
+    setContextMentions([]);
     setInputValue('');
-  }, [inputValue, onSend, onImageGenerate, onCommand, disabled, isStreaming, closePopover, badge, imageGen]);
+  }, [inputValue, onSend, onImageGenerate, onCommand, disabled, isStreaming, closePopover, badge, contextMentions, imageGen]);
 
   const filteredItems = popoverItems.filter((item) => {
     const q = popoverFilter.toLowerCase();
@@ -905,10 +1097,57 @@ export function MessageInput({
   // Map isStreaming to ChatStatus for PromptInputSubmit
   const chatStatus: ChatStatus = isStreaming ? 'streaming' : 'ready';
 
+  // Handle file tree drag-and-drop onto the input area using native DOM events.
+  // Native listeners on the wrapper div fire before React's delegated handlers,
+  // ensuring preventDefault() reliably blocks the browser's default text-insert
+  // behaviour on the textarea (which caused file paths to leak into the input).
+  useEffect(() => {
+    const el = dropZoneRef.current;
+    if (!el) return;
+
+    const onDragOver = (e: DragEvent) => {
+      const isTreeDrag = hasDragType(e.dataTransfer, FILE_TREE_DRAG_MIME)
+        || hasDragType(e.dataTransfer, FILE_TREE_DRAG_FALLBACK_MIME);
+
+      if (isTreeDrag) {
+        e.preventDefault();
+        e.stopPropagation();
+        if (e.dataTransfer) e.dataTransfer.dropEffect = 'copy';
+        setIsDragOver(true);
+      }
+    };
+
+    const onDragLeave = (e: DragEvent) => {
+      if (el.contains(e.relatedTarget as Node)) return;
+      setIsDragOver(false);
+    };
+
+    const onDrop = (e: DragEvent) => {
+      setIsDragOver(false);
+      const data = readFileTreeDropData(e.dataTransfer);
+      if (!data) return;
+      e.preventDefault();
+      e.stopPropagation();
+      addContextMention(data.path, data.name, data.type as 'file' | 'directory');
+    };
+
+    el.addEventListener('dragover', onDragOver);
+    el.addEventListener('dragleave', onDragLeave);
+    el.addEventListener('drop', onDrop);
+    return () => {
+      el.removeEventListener('dragover', onDragOver);
+      el.removeEventListener('dragleave', onDragLeave);
+      el.removeEventListener('drop', onDrop);
+    };
+  }, [addContextMention]);
+
   return (
     <div className="bg-background/80 backdrop-blur-lg px-4 py-3">
       <div className="mx-auto">
-        <div className="relative">
+        <div
+          ref={dropZoneRef}
+          className={cn("relative", isDragOver && "ring-2 ring-primary/50 ring-offset-1 ring-offset-background rounded-xl")}
+        >
           {/* Popover */}
           {popoverMode && (allDisplayedItems.length > 0 || aiSearchLoading) && (() => {
             const builtInItems = filteredItems.filter(item => item.builtIn);
@@ -1069,7 +1308,7 @@ export function MessageInput({
             multiple
           >
             {/* Bridge: listens for file tree "+" button events */}
-            <FileTreeAttachmentBridge />
+            <FileTreeAttachmentBridge onAttachFailed={appendPathMention} />
             {/* Command badge */}
             {badge && (
               <div className="flex w-full items-center gap-1.5 px-3 pt-2.5 pb-0 order-first">
@@ -1092,6 +1331,8 @@ export function MessageInput({
             )}
             {/* File attachment capsules */}
             <FileAttachmentsCapsules />
+            {/* Context mention chips (dragged files/folders) */}
+            <ContextMentionChips mentions={contextMentions} onRemove={removeContextMention} />
             <PromptInputTextarea
               ref={textareaRef}
               placeholder={badge ? "Add details (optional), then press Enter..." : "Message Claude..."}
@@ -1178,6 +1419,46 @@ export function MessageInput({
                   )}
                 </div>
 
+                {/* Context usage ring */}
+                {(() => {
+                  const circumference = 2 * Math.PI * 8; // r=8
+                  const isContextStale = contextStale && !isCompacting;
+                  const ratio = isContextStale ? 0 : Math.min(contextTokens / maxContext, 1);
+                  const offset = circumference * (1 - ratio);
+                  const color = isCompacting
+                    ? '#a855f7'
+                    : isContextStale
+                      ? '#64748b'
+                    : ratio > 0.7 ? '#ef4444' : ratio > 0.5 ? '#eab308' : '#22c55e';
+                  const formatTokens = (n: number) => {
+                    if (n >= 1000000) return `${(n / 1000000).toFixed(1)}M`;
+                    if (n >= 1000) return `${(n / 1000).toFixed(0)}k`;
+                    return `${n}`;
+                  };
+                  const label = formatTokens(contextTokens);
+                  const maxLabel = formatTokens(maxContext);
+                  const tooltipText = isCompacting
+                    ? t('messageInput.compacting')
+                    : isContextStale
+                      ? t('messageInput.contextRefreshPending')
+                    : `${label} / ${maxLabel}`;
+                  return (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <button type="button" className="flex items-center justify-center h-7 w-7 rounded-md hover:bg-accent/50 transition-colors">
+                          <svg width="20" height="20" viewBox="0 0 20 20" className="-rotate-90">
+                            <circle cx="10" cy="10" r="8" fill="none" stroke="currentColor" strokeWidth="2.5" className="text-muted-foreground/15" />
+                            <circle cx="10" cy="10" r="8" fill="none" stroke={color} strokeWidth="2.5" strokeLinecap="round" strokeDasharray={isContextStale ? `${circumference * 0.35} ${circumference}` : `${circumference}`} strokeDashoffset={isCompacting ? circumference * 0.25 : offset} style={{ transition: 'stroke-dashoffset 0.4s ease, stroke 0.4s ease', ...(isCompacting ? { animation: 'spin 1.5s linear infinite', transformOrigin: 'center' } : {}) }} />
+                          </svg>
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent side="top">
+                        <span className="text-xs">{tooltipText}</span>
+                      </TooltipContent>
+                    </Tooltip>
+                  );
+                })()}
+
                 {/* Image Agent toggle */}
                 <ImageGenToggle />
               </PromptInputTools>
@@ -1188,6 +1469,7 @@ export function MessageInput({
                 disabled={disabled}
                 inputValue={inputValue}
                 hasBadge={!!badge}
+                hasContextMentions={contextMentions.length > 0}
               />
             </PromptInputFooter>
           </PromptInput>

--- a/src/hooks/useSSEStream.ts
+++ b/src/hooks/useSSEStream.ts
@@ -25,6 +25,10 @@ export interface SSECallbacks {
   onModeChanged: (mode: string) => void;
   onTaskUpdate: (sessionId: string) => void;
   onError: (accumulated: string) => void;
+  onCompactBoundary?: () => void;
+  onCompacting?: () => void;
+  onContextTokens?: (tokens: number) => void;
+  onMcpServers?: (servers: Array<{ name: string; status: string }>) => void;
 }
 
 /**
@@ -87,8 +91,16 @@ function handleSSEEvent(
     case 'status': {
       try {
         const statusData = JSON.parse(event.data);
-        if (statusData.session_id) {
+        if (typeof statusData.context_tokens === 'number' && Number.isFinite(statusData.context_tokens)) {
+          callbacks.onContextTokens?.(statusData.context_tokens);
+          return accumulated;
+        } else if (statusData.session_id) {
           callbacks.onStatus(`Connected (${statusData.model || 'claude'})`);
+          if (statusData.mcp_servers) {
+            callbacks.onMcpServers?.(statusData.mcp_servers);
+          }
+        } else if (statusData.compacting) {
+          callbacks.onCompacting?.();
         } else if (statusData.notification) {
           callbacks.onStatus(statusData.message || statusData.title || undefined);
         } else {
@@ -97,6 +109,11 @@ function handleSSEEvent(
       } catch {
         callbacks.onStatus(event.data || undefined);
       }
+      return accumulated;
+    }
+
+    case 'compact_boundary': {
+      callbacks.onCompactBoundary?.();
       return accumulated;
     }
 
@@ -233,6 +250,10 @@ export function useSSEStream() {
         onModeChanged: (m) => callbacksRef.current?.onModeChanged(m),
         onTaskUpdate: (s) => callbacksRef.current?.onTaskUpdate(s),
         onError: (a) => callbacksRef.current?.onError(a),
+        onCompactBoundary: () => callbacksRef.current?.onCompactBoundary?.(),
+        onCompacting: () => callbacksRef.current?.onCompacting?.(),
+        onContextTokens: (t) => callbacksRef.current?.onContextTokens?.(t),
+        onMcpServers: (s) => callbacksRef.current?.onMcpServers?.(s),
       };
 
       return consumeSSEStream(reader, proxied);

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -46,6 +46,8 @@ const en = {
   'messageInput.memoryDesc': 'Edit project memory file',
   'messageInput.modeCode': 'Code',
   'messageInput.modePlan': 'Plan',
+  'messageInput.compacting': 'Compacting...',
+  'messageInput.contextRefreshPending': 'Context compacted. Token gauge updates on the next turn.',
   'messageInput.aiSuggested': 'AI Suggested',
 
   // ── Streaming message ───────────────────────────────────────

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -43,6 +43,8 @@ const zh: Record<TranslationKey, string> = {
   'messageInput.memoryDesc': '编辑项目记忆文件',
   'messageInput.modeCode': '代码',
   'messageInput.modePlan': '计划',
+  'messageInput.compacting': '压缩中...',
+  'messageInput.contextRefreshPending': '上下文已压缩，Token 指示将在下一轮对话刷新。',
   'messageInput.aiSuggested': 'AI 推荐',
 
   // ── Streaming message ───────────────────────────────────────

--- a/src/lib/stream-session-manager.ts
+++ b/src/lib/stream-session-manager.ts
@@ -11,15 +11,12 @@
  */
 
 import { consumeSSEStream } from '@/hooks/useSSEStream';
-import { transferPendingToMessage } from '@/lib/image-ref-store';
 import type {
   ToolUseInfo,
   ToolResultInfo,
   SessionStreamSnapshot,
   StreamEvent,
   StreamEventListener,
-  TokenUsage,
-  PermissionRequestEvent,
   FileAttachment,
 } from '@/types';
 
@@ -95,6 +92,15 @@ function buildSnapshot(stream: ActiveStream): SessionStreamSnapshot {
     completedAt: stream.snapshot.completedAt,
     error: stream.snapshot.error,
     finalMessageContent: stream.snapshot.finalMessageContent,
+  };
+}
+
+function clearContextRingState(snapshot: SessionStreamSnapshot): SessionStreamSnapshot {
+  return {
+    ...snapshot,
+    isCompacting: false,
+    contextTokensPendingRefresh: false,
+    streamingContextTokens: null,
   };
 }
 
@@ -341,7 +347,7 @@ async function runStream(stream: ActiveStream, params: StartStreamParams): Promi
     }
 
     // Update snapshot with completion info
-    stream.snapshot = {
+    stream.snapshot = clearContextRingState({
       ...buildSnapshot(stream),
       phase: 'completed',
       completedAt: Date.now(),
@@ -350,7 +356,7 @@ async function runStream(stream: ActiveStream, params: StartStreamParams): Promi
       statusText: undefined,
       pendingPermission: null,
       permissionResolved: null,
-    };
+    });
     stream.accumulatedText = '';
     stream.toolUsesArray = [];
     stream.toolResultsArray = [];
@@ -374,7 +380,7 @@ async function runStream(stream: ActiveStream, params: StartStreamParams): Promi
           ? stream.accumulatedText.trim() + `\n\n**Error:** Stream idle timeout — no response for ${idleSecs}s. The connection may have dropped.`
           : `**Error:** Stream idle timeout — no response for ${idleSecs}s. The connection may have dropped.`;
 
-        stream.snapshot = {
+        stream.snapshot = clearContextRingState({
           ...buildSnapshot(stream),
           phase: 'error',
           completedAt: Date.now(),
@@ -383,7 +389,7 @@ async function runStream(stream: ActiveStream, params: StartStreamParams): Promi
           statusText: undefined,
           pendingPermission: null,
           permissionResolved: null,
-        };
+        });
         stream.accumulatedText = '';
         stream.toolUsesArray = [];
         stream.toolResultsArray = [];
@@ -397,7 +403,7 @@ async function runStream(stream: ActiveStream, params: StartStreamParams): Promi
           ? stream.accumulatedText.trim() + `\n\n*(tool ${timeoutInfo.toolName} timed out after ${timeoutInfo.elapsedSeconds}s)*`
           : null;
 
-        stream.snapshot = {
+        stream.snapshot = clearContextRingState({
           ...buildSnapshot(stream),
           phase: 'stopped',
           completedAt: Date.now(),
@@ -405,7 +411,7 @@ async function runStream(stream: ActiveStream, params: StartStreamParams): Promi
           statusText: undefined,
           pendingPermission: null,
           permissionResolved: null,
-        };
+        });
         stream.accumulatedText = '';
         stream.toolUsesArray = [];
         stream.toolResultsArray = [];
@@ -429,7 +435,7 @@ async function runStream(stream: ActiveStream, params: StartStreamParams): Promi
           ? stream.accumulatedText.trim() + '\n\n*(generation stopped)*'
           : null;
 
-        stream.snapshot = {
+        stream.snapshot = clearContextRingState({
           ...buildSnapshot(stream),
           phase: 'stopped',
           completedAt: Date.now(),
@@ -437,7 +443,7 @@ async function runStream(stream: ActiveStream, params: StartStreamParams): Promi
           statusText: undefined,
           pendingPermission: null,
           permissionResolved: null,
-        };
+        });
         stream.accumulatedText = '';
         stream.toolUsesArray = [];
         stream.toolResultsArray = [];
@@ -448,7 +454,7 @@ async function runStream(stream: ActiveStream, params: StartStreamParams): Promi
     } else {
       // Non-abort error
       const errMsg = error instanceof Error ? error.message : 'Unknown error';
-      stream.snapshot = {
+      stream.snapshot = clearContextRingState({
         ...buildSnapshot(stream),
         phase: 'error',
         completedAt: Date.now(),
@@ -457,7 +463,7 @@ async function runStream(stream: ActiveStream, params: StartStreamParams): Promi
         statusText: undefined,
         pendingPermission: null,
         permissionResolved: null,
-      };
+      });
       stream.accumulatedText = '';
       stream.toolUsesArray = [];
       stream.toolResultsArray = [];

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -122,7 +122,7 @@ export interface ProviderModelGroup {
   provider_id: string;       // provider DB id, or 'env' for environment variables
   provider_name: string;
   provider_type: string;
-  models: Array<{ value: string; label: string }>;
+  models: Array<{ value: string; label: string; context_window?: number }>;
 }
 
 export interface CreateProviderRequest {
@@ -162,6 +162,8 @@ export interface TokenUsage {
   cache_read_input_tokens?: number;
   cache_creation_input_tokens?: number;
   cost_usd?: number;
+  context_window?: number;
+  last_input_tokens?: number;
 }
 
 // ==========================================
@@ -356,6 +358,7 @@ export type SSEEventType =
   | 'permission_request' // permission approval needed
   | 'mode_changed'       // SDK permission mode changed (e.g. plan → code)
   | 'task_update'        // SDK TodoWrite task sync
+  | 'compact_boundary'   // context compaction boundary
   | 'done';              // stream complete
 
 export interface SSEEvent {
@@ -651,6 +654,14 @@ export interface SessionStreamSnapshot {
   error: string | null;
   /** Final message content built at stream completion for ChatView to consume */
   finalMessageContent: string | null;
+  /** Context Ring: context window usage */
+  contextWindow?: { used: number; total: number } | null;
+  /** Context Ring: whether context compaction is in progress */
+  isCompacting?: boolean;
+  /** Context Ring: streaming context token counts */
+  streamingContextTokens?: { used: number; total: number } | null;
+  /** Context Ring: whether context tokens need a refresh */
+  contextTokensPendingRefresh?: boolean;
 }
 
 export interface StreamEvent {


### PR DESCRIPTION
## 背景
当前“环形上下文进度条”存在两个核心问题：

1. 非流式阶段会继续显示旧的 streaming 上下文值，而不是最新会话上下文。
2. `maxContext` 主要依赖固定默认值（200k），对非 Claude / 自定义模型窗口支持不足。

## 变更内容

### 1) 非流式阶段显示“最新上下文”
- 在 `ChatView` 中新增基于最近一条 assistant `token_usage` 的上下文派生：
  - 优先 `last_input_tokens + output_tokens`
  - 回退 `input + cache_read + cache_creation + output`
- 仅在 `isStreaming === true` 且存在 `snapshot.streamingContextTokens` 时才使用实时 streaming 值。

### 2) 多来源 `maxContext` 计算优先级
`maxContext` 按以下顺序计算：
1. `streamSnapshot.contextWindow.total`
2. 历史消息中的 `token_usage.context_window`
3. 当前 provider+model 返回的 `context_window`
4. 默认值 `200000`

### 3) 支持非 Claude / 自定义模型窗口
- 扩展 `/api/providers/models` 返回：`models[].context_window`（可选）
- 支持从 provider `extra_env` 读取 `CODEPILOT_CONTEXT_WINDOW`（正整数）作为模型窗口回退。
- 扩展 `ProviderModelGroup` 类型以承载 `context_window`。

### 4) 终态统一清理环形状态
在 `stream-session-manager` 的完成/停止/错误/超时分支统一清理：
- `isCompacting = false`
- `contextTokensPendingRefresh = false`
- `streamingContextTokens = null`

避免结束后仍显示转圈或 stale 状态。

### 5) 健壮性与 i18n
- `useSSEStream` 中 `context_tokens` 改为数值校验（不再用 truthy 判断）。
- 补充 `messageInput.compacting`、`messageInput.contextRefreshPending` 的中英文文案键。

## 验证
- `npm run build` 通过

## 影响文件
- `src/app/api/providers/models/route.ts`
- `src/components/chat/ChatView.tsx`
- `src/components/chat/MessageInput.tsx`
- `src/hooks/useSSEStream.ts`
- `src/lib/stream-session-manager.ts`
- `src/types/index.ts`
- `src/i18n/en.ts`
- `src/i18n/zh.ts`