### PR TITLE
feat: 支持从文件树拖拽到输入框生成 ContextMention Chip

### DIFF
--- a/src/components/ai-elements/file-tree.tsx
+++ b/src/components/ai-elements/file-tree.tsx
@@ -24,6 +24,9 @@ import {
   useState,
 } from "react";
 
+const TREE_PATH_MIME = "application/x-codepilot-path";
+const TREE_PATH_FALLBACK_MIME = "text/x-codepilot-path";
+
 interface FileTreeContextType {
   expandedPaths: Set<string>;
   togglePath: (path: string) => void;
@@ -132,6 +135,17 @@ export const FileTreeFolder = ({
     togglePath(path);
   }, [togglePath, path]);
 
+  const handleDragStart = useCallback(
+    (e: React.DragEvent) => {
+      const payload = JSON.stringify({ path, name, type: "directory" });
+      e.dataTransfer.setData(TREE_PATH_MIME, payload);
+      e.dataTransfer.setData(TREE_PATH_FALLBACK_MIME, payload);
+      e.dataTransfer.setData("text/plain", path);
+      e.dataTransfer.effectAllowed = "copy";
+    },
+    [path, name]
+  );
+
   const folderContextValue = useMemo(
     () => ({ isExpanded, name, path }),
     [isExpanded, name, path]
@@ -148,6 +162,8 @@ export const FileTreeFolder = ({
         >
           <div
             className="flex w-full items-center gap-1 rounded px-2 py-1 text-left transition-colors hover:bg-muted/50"
+            draggable
+            onDragStart={handleDragStart}
           >
             <CollapsibleTrigger asChild>
               <button
@@ -232,6 +248,17 @@ export const FileTreeFile = ({
 
   const fileContextValue = useMemo(() => ({ name, path }), [name, path]);
 
+  const handleDragStart = useCallback(
+    (e: React.DragEvent) => {
+      const payload = JSON.stringify({ path, name, type: "file" });
+      e.dataTransfer.setData(TREE_PATH_MIME, payload);
+      e.dataTransfer.setData(TREE_PATH_FALLBACK_MIME, payload);
+      e.dataTransfer.setData("text/plain", path);
+      e.dataTransfer.effectAllowed = "copy";
+    },
+    [path, name]
+  );
+
   return (
     <FileTreeFileContext.Provider value={fileContextValue}>
       <div
@@ -242,6 +269,8 @@ export const FileTreeFile = ({
         )}
         onClick={handleClick}
         onKeyDown={handleKeyDown}
+        draggable
+        onDragStart={handleDragStart}
         role="treeitem"
         tabIndex={0}
         {...props}
@@ -255,7 +284,10 @@ export const FileTreeFile = ({
             {onAdd && (
               <button
                 type="button"
+                draggable={false}
                 className="ml-auto flex size-5 shrink-0 items-center justify-center rounded opacity-0 transition-opacity hover:bg-muted group-hover/file:opacity-100"
+                onMouseDown={(e) => e.stopPropagation()}
+                onPointerDown={(e) => e.stopPropagation()}
                 onClick={handleAdd}
                 title="Add to chat"
               >

--- a/src/components/chat/MessageInput.tsx
+++ b/src/components/chat/MessageInput.tsx
@@ -19,6 +19,8 @@ import {
   BrainIcon,
   GlobalIcon,
   StopIcon,
+  Folder01Icon,
+  File01Icon,
 } from "@hugeicons/core-free-icons";
 import { cn } from '@/lib/utils';
 import { useTranslation } from '@/hooks/useTranslation';
@@ -82,6 +84,47 @@ const IMAGE_AGENT_SYSTEM_PROMPT = `你是一个图像生成助手。当用户请
 - 在输出结构化块之前，可以先简要说明你的理解和计划`;
 
 
+const FILE_TREE_DRAG_MIME = 'application/x-codepilot-path';
+const FILE_TREE_DRAG_FALLBACK_MIME = 'text/x-codepilot-path';
+
+function hasDragType(dataTransfer: DataTransfer | null | undefined, type: string): boolean {
+  if (!dataTransfer) return false;
+
+  const types = dataTransfer.types as unknown;
+  if (!types) return false;
+
+  if (typeof (types as { includes?: unknown }).includes === 'function') {
+    return (types as { includes: (value: string) => boolean }).includes(type);
+  }
+
+  if (typeof (types as { contains?: unknown }).contains === 'function') {
+    return (types as { contains: (value: string) => boolean }).contains(type);
+  }
+
+  return Array.from(types as ArrayLike<string>).includes(type);
+}
+
+function readFileTreeDropData(dataTransfer: DataTransfer | null | undefined) {
+  if (!dataTransfer) return null;
+
+  const raw = dataTransfer.getData(FILE_TREE_DRAG_MIME)
+    || dataTransfer.getData(FILE_TREE_DRAG_FALLBACK_MIME);
+
+  if (!raw) return null;
+
+  try {
+    const parsed = JSON.parse(raw) as Partial<{ path: string; name: string; type: string }>;
+    if (!parsed.path || typeof parsed.path !== 'string') return null;
+    return {
+      name: typeof parsed.name === 'string' ? parsed.name : '',
+      path: parsed.path,
+      type: parsed.type === 'directory' ? 'directory' : 'file',
+    };
+  } catch {
+    return null;
+  }
+}
+
 interface MessageInputProps {
   onSend: (content: string, files?: FileAttachment[], systemPromptAppend?: string, displayOverride?: string) => void;
   onImageGenerate?: (prompt: string, files?: FileAttachment[]) => void;
@@ -117,6 +160,13 @@ interface CommandBadge {
   description: string;
   isSkill: boolean;
   installedSource?: "agents" | "claude";
+}
+
+interface ContextMention {
+  id: string;
+  path: string;
+  name: string;
+  type: 'file' | 'directory';
 }
 
 type PopoverMode = 'file' | 'skill' | null;
@@ -190,12 +240,14 @@ function FileAwareSubmitButton({
   disabled,
   inputValue,
   hasBadge,
+  hasContextMentions,
 }: {
   status: ChatStatus;
   onStop?: () => void;
   disabled?: boolean;
   inputValue: string;
   hasBadge: boolean;
+  hasContextMentions: boolean;
 }) {
   const attachments = usePromptInputAttachments();
   const hasFiles = attachments.files.length > 0;
@@ -205,7 +257,7 @@ function FileAwareSubmitButton({
     <PromptInputSubmit
       status={status}
       onStop={onStop}
-      disabled={disabled || (!isStreaming && !inputValue.trim() && !hasBadge && !hasFiles)}
+      disabled={disabled || (!isStreaming && !inputValue.trim() && !hasBadge && !hasFiles && !hasContextMentions)}
       className="rounded-full"
     >
       {isStreaming ? (
@@ -236,11 +288,13 @@ function AttachFileButton() {
 
 /**
  * Infer a MIME type from a filename extension so that files added from the
- * file tree pass the PromptInput accept-type validation.  Code / text files
+ * file tree pass the PromptInput accept-type validation. Code / text files
  * are mapped to `text/*` subtypes; images and PDFs get their standard types.
- * Falls back to `application/octet-stream` for unknown extensions.
+ * For extensionless/unknown files, prefer server-detected MIME when available,
+ * otherwise fall back to `text/plain` so common files like Dockerfile/README
+ * can still be attached from the file tree.
  */
-function mimeFromFilename(name: string): string {
+function mimeFromFilename(name: string, serverMime?: string): string {
   const ext = name.split('.').pop()?.toLowerCase() || '';
   const TEXT_EXTS: Record<string, string> = {
     md: 'text/markdown', mdx: 'text/markdown',
@@ -269,14 +323,24 @@ function mimeFromFilename(name: string): string {
   if (TEXT_EXTS[ext]) return TEXT_EXTS[ext];
   if (IMAGE_EXTS[ext]) return IMAGE_EXTS[ext];
   if (ext === 'pdf') return 'application/pdf';
-  return 'application/octet-stream';
+
+  // Use API-reported MIME when it looks meaningful.
+  if (serverMime && serverMime !== 'application/octet-stream') {
+    return serverMime;
+  }
+
+  return 'text/plain';
 }
 
 /**
  * Bridge component that listens for 'attach-file-to-chat' custom events
  * from the file tree and adds files as attachments. Must be rendered inside PromptInput.
  */
-function FileTreeAttachmentBridge() {
+function FileTreeAttachmentBridge({
+  onAttachFailed,
+}: {
+  onAttachFailed?: (filePath: string) => void;
+}) {
   const attachments = usePromptInputAttachments();
   const attachmentsRef = useRef(attachments);
 
@@ -294,6 +358,7 @@ function FileTreeAttachmentBridge() {
         const res = await fetch(`/api/files/raw?path=${encodeURIComponent(filePath)}`);
         if (!res.ok) {
           console.warn(`[FileTreeAttachment] Failed to fetch file: ${res.status} ${res.statusText}`, filePath);
+          onAttachFailed?.(filePath);
           return;
         }
         const blob = await res.blob();
@@ -301,17 +366,18 @@ function FileTreeAttachmentBridge() {
         const filename = filePath.split(/[/\\]/).pop() || 'file';
         // Use a proper MIME type derived from the extension so the file
         // passes PromptInput's accept-type validation (text/* etc.)
-        const mime = mimeFromFilename(filename);
+        const mime = mimeFromFilename(filename, blob.type);
         const file = new File([blob], filename, { type: mime });
         attachmentsRef.current.add([file]);
       } catch (err) {
         console.warn('[FileTreeAttachment] Error attaching file:', filePath, err);
+        onAttachFailed?.(filePath);
       }
     };
 
     window.addEventListener('attach-file-to-chat', handler);
     return () => window.removeEventListener('attach-file-to-chat', handler);
-  }, []);
+  }, [onAttachFailed]);
 
   return null;
 }
@@ -358,6 +424,86 @@ function FileAttachmentsCapsules() {
   );
 }
 
+/**
+ * Return Tailwind color classes for a context mention chip based on file extension.
+ */
+function getMentionColorClasses(mention: ContextMention): { chip: string; hover: string } {
+  if (mention.type === 'directory') {
+    return {
+      chip: "bg-amber-500/10 text-amber-600 dark:text-amber-400 border-amber-500/20",
+      hover: "hover:bg-amber-500/20",
+    };
+  }
+  const ext = mention.name.split('.').pop()?.toLowerCase() || '';
+  if (['doc', 'docx'].includes(ext)) {
+    return {
+      chip: "bg-blue-500/10 text-blue-600 dark:text-blue-400 border-blue-500/20",
+      hover: "hover:bg-blue-500/20",
+    };
+  }
+  if (['xls', 'xlsx', 'csv'].includes(ext)) {
+    return {
+      chip: "bg-green-500/10 text-green-600 dark:text-green-400 border-green-500/20",
+      hover: "hover:bg-green-500/20",
+    };
+  }
+  if (ext === 'pdf') {
+    return {
+      chip: "bg-red-500/10 text-red-600 dark:text-red-400 border-red-500/20",
+      hover: "hover:bg-red-500/20",
+    };
+  }
+  if (ext === 'txt') {
+    return {
+      chip: "bg-gray-500/10 text-gray-600 dark:text-gray-400 border-gray-500/20",
+      hover: "hover:bg-gray-500/20",
+    };
+  }
+  return {
+    chip: "bg-violet-500/10 text-violet-600 dark:text-violet-400 border-violet-500/20",
+    hover: "hover:bg-violet-500/20",
+  };
+}
+
+/**
+ * Chip display for context mentions (dragged files/folders), rendered inside PromptInput context.
+ */
+function ContextMentionChips({
+  mentions,
+  onRemove,
+}: {
+  mentions: ContextMention[];
+  onRemove: (id: string) => void;
+}) {
+  if (mentions.length === 0) return null;
+  return (
+    <div className="grid w-full grid-cols-5 gap-1.5 px-3 pt-2 pb-0 order-first">
+      {mentions.map((m) => {
+        const colors = getMentionColorClasses(m);
+        return (
+          <span
+            key={m.id}
+            className={cn(
+              "inline-flex items-center gap-1 rounded-full pl-2 pr-1 py-0.5 text-xs font-medium border min-w-0",
+              colors.chip
+            )}
+          >
+            <HugeiconsIcon icon={m.type === 'directory' ? Folder01Icon : File01Icon} className="h-3 w-3 shrink-0" />
+            <span className="truncate text-[11px] font-mono">{m.name}</span>
+            <button
+              type="button"
+              onClick={() => onRemove(m.id)}
+              className={cn("ml-auto shrink-0 rounded-full p-0.5 transition-colors", colors.hover)}
+            >
+              <HugeiconsIcon icon={Cancel01Icon} className="h-3 w-3" />
+            </button>
+          </span>
+        );
+      })}
+    </div>
+  );
+}
+
 export function MessageInput({
   onSend,
   onImageGenerate,
@@ -380,6 +526,7 @@ export function MessageInput({
   const popoverRef = useRef<HTMLDivElement>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const modelMenuRef = useRef<HTMLDivElement>(null);
+  const dropZoneRef = useRef<HTMLDivElement>(null);
 
   const [popoverMode, setPopoverMode] = useState<PopoverMode>(null);
   const [popoverItems, setPopoverItems] = useState<PopoverItem[]>([]);
@@ -395,6 +542,28 @@ export function MessageInput({
   const [aiSearchLoading, setAiSearchLoading] = useState(false);
   const aiSearchAbortRef = useRef<AbortController | null>(null);
   const aiSearchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [isDragOver, setIsDragOver] = useState(false);
+  const [contextMentions, setContextMentions] = useState<ContextMention[]>([]);
+
+  const removeContextMention = useCallback((id: string) => {
+    setContextMentions((prev) => prev.filter((m) => m.id !== id));
+  }, []);
+
+  const addContextMention = useCallback((path: string, name: string, type: 'file' | 'directory') => {
+    setContextMentions((prev) => {
+      if (prev.some((m) => m.path === path)) return prev;
+      return [...prev, { id: nanoid(), path, name, type }];
+    });
+    setTimeout(() => textareaRef.current?.focus(), 0);
+  }, []);
+
+  const appendPathMention = useCallback((path: string) => {
+    setInputValue((prev) => {
+      const suffix = `@${path} `;
+      return prev ? `${prev}${suffix}` : suffix;
+    });
+    setTimeout(() => textareaRef.current?.focus(), 0);
+  }, []);
 
   // Fetch provider groups from API
   const fetchProviderModels = useCallback(() => {
@@ -602,7 +771,11 @@ export function MessageInput({
 
   const handleSubmit = useCallback(async (msg: { text: string; files: Array<{ type: string; url: string; filename?: string; mediaType?: string }> }, e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    const content = inputValue.trim();
+    const rawContent = inputValue.trim();
+    const mentionPrefix = contextMentions.length > 0
+      ? contextMentions.map((m) => `@${m.path}`).join(' ') + ' '
+      : '';
+    const content = mentionPrefix + rawContent;
 
     closePopover();
 
@@ -679,6 +852,7 @@ export function MessageInput({
 
       const files = await convertFiles();
       setBadge(null);
+      setContextMentions([]);
       setInputValue('');
       onSend(finalPrompt, files.length > 0 ? files : undefined);
       return;
@@ -687,7 +861,7 @@ export function MessageInput({
     const files = await convertFiles();
     const hasFiles = files.length > 0;
 
-    if ((!content && !hasFiles) || disabled || isStreaming) return;
+    if ((!content && !hasFiles && contextMentions.length === 0) || disabled || isStreaming) return;
 
     // Check if it's a direct slash command typed in the input
     if (content.startsWith('/') && !hasFiles) {
@@ -724,8 +898,9 @@ export function MessageInput({
     }
 
     onSend(content || 'Please review the attached file(s).', hasFiles ? files : undefined);
+    setContextMentions([]);
     setInputValue('');
-  }, [inputValue, onSend, onImageGenerate, onCommand, disabled, isStreaming, closePopover, badge, imageGen]);
+  }, [inputValue, onSend, onImageGenerate, onCommand, disabled, isStreaming, closePopover, badge, contextMentions, imageGen]);
 
   const filteredItems = popoverItems.filter((item) => {
     const q = popoverFilter.toLowerCase();
@@ -905,10 +1080,57 @@ export function MessageInput({
   // Map isStreaming to ChatStatus for PromptInputSubmit
   const chatStatus: ChatStatus = isStreaming ? 'streaming' : 'ready';
 
+  // Handle file tree drag-and-drop onto the input area using native DOM events.
+  // Native listeners on the wrapper div fire before React's delegated handlers,
+  // ensuring preventDefault() reliably blocks the browser's default text-insert
+  // behaviour on the textarea (which caused file paths to leak into the input).
+  useEffect(() => {
+    const el = dropZoneRef.current;
+    if (!el) return;
+
+    const onDragOver = (e: DragEvent) => {
+      const isTreeDrag = hasDragType(e.dataTransfer, FILE_TREE_DRAG_MIME)
+        || hasDragType(e.dataTransfer, FILE_TREE_DRAG_FALLBACK_MIME);
+
+      if (isTreeDrag) {
+        e.preventDefault();
+        e.stopPropagation();
+        if (e.dataTransfer) e.dataTransfer.dropEffect = 'copy';
+        setIsDragOver(true);
+      }
+    };
+
+    const onDragLeave = (e: DragEvent) => {
+      if (el.contains(e.relatedTarget as Node)) return;
+      setIsDragOver(false);
+    };
+
+    const onDrop = (e: DragEvent) => {
+      setIsDragOver(false);
+      const data = readFileTreeDropData(e.dataTransfer);
+      if (!data) return;
+      e.preventDefault();
+      e.stopPropagation();
+      addContextMention(data.path, data.name, data.type as 'file' | 'directory');
+    };
+
+    el.addEventListener('dragover', onDragOver);
+    el.addEventListener('dragleave', onDragLeave);
+    el.addEventListener('drop', onDrop);
+    return () => {
+      el.removeEventListener('dragover', onDragOver);
+      el.removeEventListener('dragleave', onDragLeave);
+      el.removeEventListener('drop', onDrop);
+    };
+  }, [addContextMention]);
+
   return (
     <div className="bg-background/80 backdrop-blur-lg px-4 py-3">
       <div className="mx-auto">
-        <div className="relative">
+        <div
+          ref={dropZoneRef}
+          className={cn("relative", isDragOver && "ring-2 ring-primary/50 ring-offset-1 ring-offset-background rounded-xl")}
+        >
           {/* Popover */}
           {popoverMode && (allDisplayedItems.length > 0 || aiSearchLoading) && (() => {
             const builtInItems = filteredItems.filter(item => item.builtIn);
@@ -1069,7 +1291,7 @@ export function MessageInput({
             multiple
           >
             {/* Bridge: listens for file tree "+" button events */}
-            <FileTreeAttachmentBridge />
+            <FileTreeAttachmentBridge onAttachFailed={appendPathMention} />
             {/* Command badge */}
             {badge && (
               <div className="flex w-full items-center gap-1.5 px-3 pt-2.5 pb-0 order-first">
@@ -1092,6 +1314,8 @@ export function MessageInput({
             )}
             {/* File attachment capsules */}
             <FileAttachmentsCapsules />
+            {/* Context mention chips (dragged files/folders) */}
+            <ContextMentionChips mentions={contextMentions} onRemove={removeContextMention} />
             <PromptInputTextarea
               ref={textareaRef}
               placeholder={badge ? "Add details (optional), then press Enter..." : "Message Claude..."}
@@ -1188,6 +1412,7 @@ export function MessageInput({
                 disabled={disabled}
                 inputValue={inputValue}
                 hasBadge={!!badge}
+                hasContextMentions={contextMentions.length > 0}
               />
             </PromptInputFooter>
           </PromptInput>


### PR DESCRIPTION
## 变更说明

本 PR 为文件树拖拽交互补全：支持从 `FileTree` 拖拽**文件/目录**到 `MessageInput`，并生成 `ContextMention` Chip。

### 主要改动
- 在 `src/components/ai-elements/file-tree.tsx` 增加拖拽源能力
  - 文件、目录节点均支持 `draggable`
  - `onDragStart` 写入自定义 MIME：`application/x-codepilot-path`（及回退类型）
- 在 `src/components/chat/MessageInput.tsx` 增加拖拽目标和上下文 chip 流程
  - 识别文件树自定义拖拽 MIME
  - Drop 后新增 `contextMentions` 状态（按路径去重）
  - 渲染 `ContextMentionChips`（可移除）
  - 发送时自动将 mentions 作为 `@路径` 前缀拼接到消息
  - 仅有 context mentions 时发送按钮可用

### 兼容性
- 保留原有 `+` 按钮“添加附件到聊天”的通路
- 此 PR 仅涉及 2 个文件，不改动后端接口

## 验证
- 本地执行：
  - `npm run lint -- src/components/chat/MessageInput.tsx src/components/ai-elements/file-tree.tsx`
- 结果：通过（仅有既有 warning，无 error）
