### PR TITLE
fix: handle SDK keep_alive to prevent false idle timeout

### DIFF
--- a/src/hooks/useSSEStream.ts
+++ b/src/hooks/useSSEStream.ts
@@ -24,6 +24,7 @@ export interface SSECallbacks {
   onToolTimeout: (toolName: string, elapsedSeconds: number) => void;
   onModeChanged: (mode: string) => void;
   onTaskUpdate: (sessionId: string) => void;
+  onKeepAlive: () => void;
   onError: (accumulated: string) => void;
 }
 
@@ -146,6 +147,11 @@ function handleSSEEvent(
       return accumulated;
     }
 
+    case 'keep_alive': {
+      callbacks.onKeepAlive();
+      return accumulated;
+    }
+
     case 'error': {
       const next = accumulated + '\n\n**Error:** ' + event.data;
       callbacks.onError(next);
@@ -232,6 +238,7 @@ export function useSSEStream() {
         onToolTimeout: (n, s) => callbacksRef.current?.onToolTimeout(n, s),
         onModeChanged: (m) => callbacksRef.current?.onModeChanged(m),
         onTaskUpdate: (s) => callbacksRef.current?.onTaskUpdate(s),
+        onKeepAlive: () => callbacksRef.current?.onKeepAlive(),
         onError: (a) => callbacksRef.current?.onError(a),
       };
 

--- a/src/lib/claude-client.ts
+++ b/src/lib/claude-client.ts
@@ -873,6 +873,13 @@ export function streamClaude(options: ClaudeStreamOptions): ReadableStream<strin
               }));
               break;
             }
+
+            default: {
+              if ((message as { type: string }).type === 'keep_alive') {
+                controller.enqueue(formatSSE({ type: 'keep_alive', data: '' }));
+              }
+              break;
+            }
           }
         }
 

--- a/src/lib/stream-session-manager.ts
+++ b/src/lib/stream-session-manager.ts
@@ -311,6 +311,9 @@ async function runStream(stream: ActiveStream, params: StartStreamParams): Promi
         markActive();
         window.dispatchEvent(new CustomEvent('tasks-updated'));
       },
+      onKeepAlive: () => {
+        markActive();
+      },
       onError: (acc) => {
         markActive();
         stream.accumulatedText = acc;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -356,6 +356,7 @@ export type SSEEventType =
   | 'permission_request' // permission approval needed
   | 'mode_changed'       // SDK permission mode changed (e.g. plan → code)
   | 'task_update'        // SDK TodoWrite task sync
+  | 'keep_alive'         // SDK keep-alive heartbeat (resets idle timer)
   | 'done';              // stream complete
 
 export interface SSEEvent {


### PR DESCRIPTION
## Summary

- Fixes false "Stream idle timeout — no response for 330s" errors during long-running Claude Code operations
- The Claude Code SDK sends `keep_alive` heartbeat messages during idle periods, but CodePilot silently drops them — the 330s idle timer never resets and fires even though Claude is still working
- Threads `keep_alive` through the existing 3-layer SSE event pipeline so they call `markActive()` and reset the idle timer

## Root Cause

In `claude-client.ts`, the SDK message iterator handles only 6 message types and has no `default` case. The SDK's `keep_alive` messages (`SDKKeepAliveMessage`) are silently discarded, so `stream-session-manager.ts` never calls `markActive()` during quiet tool execution periods.

## Changes

| File | Change |
|------|--------|
| `src/types/index.ts` | Add `'keep_alive'` to `SSEEventType` union |
| `src/lib/claude-client.ts` | Add `default` case that forwards `keep_alive` SDK messages as SSE events |
| `src/hooks/useSSEStream.ts` | Add `onKeepAlive` callback to `SSECallbacks` interface, switch, and proxy |
| `src/lib/stream-session-manager.ts` | Add `onKeepAlive` callback that calls `markActive()` |

~10 new lines across 4 files. No UI impact.

## Test plan

- [ ] `npx tsc --noEmit` passes with zero errors
- [ ] Start a long-running Claude Code task that previously triggered the 330s timeout
- [ ] Verify the session stays alive beyond 330s when Claude is actively working
- [ ] Verify normal short conversations are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)