### PR TITLE
fix: avoid Windows title bar overlap in RightPanel

### DIFF
--- a/src/components/layout/RightPanel.tsx
+++ b/src/components/layout/RightPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback } from "react";
+import { useCallback, useSyncExternalStore } from "react";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { StructureFolderIcon, PanelRightCloseIcon } from "@hugeicons/core-free-icons";
 import { Button } from "@/components/ui/button";
@@ -21,6 +21,9 @@ interface RightPanelProps {
 export function RightPanel({ width }: RightPanelProps) {
   const { panelOpen, setPanelOpen, workingDirectory, sessionId, previewFile, setPreviewFile } = usePanel();
   const { t } = useTranslation();
+  const emptySubscribe = useCallback(() => () => {}, []);
+  const mounted = useSyncExternalStore(emptySubscribe, () => true, () => false);
+  const isWindows = mounted && /windows/i.test(navigator.userAgent);
 
   const handleFileAdd = useCallback((path: string) => {
     window.dispatchEvent(new CustomEvent('attach-file-to-chat', { detail: { path } }));
@@ -50,7 +53,7 @@ export function RightPanel({ width }: RightPanelProps) {
 
   if (!panelOpen) {
     return (
-      <div className="flex flex-col items-center gap-2 bg-background p-2">
+      <div className={`flex flex-col items-center gap-2 bg-background px-2 pb-2 ${isWindows ? "pt-12" : "pt-2"}`}>
         <Tooltip>
           <TooltipTrigger asChild>
             <Button
@@ -71,7 +74,7 @@ export function RightPanel({ width }: RightPanelProps) {
   return (
     <aside className="hidden h-full shrink-0 flex-col overflow-hidden bg-background lg:flex" style={{ width: width ?? 288 }}>
       {/* Header */}
-      <div className="flex h-12 mt-5 shrink-0 items-center justify-between px-4">
+      <div className={`flex h-12 ${isWindows ? "mt-12" : "mt-5"} shrink-0 items-center justify-between px-4`}>
         <span className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
           {t('panel.tasks')}
         </span>


### PR DESCRIPTION
## Summary
- add Windows-only top spacing for collapsed and expanded RightPanel states
- keep the existing layout unchanged on non-Windows platforms
- avoid SSR mismatch by gating userAgent detection behind mounted state

## Validation
- npm run typecheck
- npx eslint src/components/layout/RightPanel.tsx