### PR TITLE
feat: add proxy support for Telegram Bot API

### DIFF
--- a/src/lib/bridge/adapters/telegram-adapter.ts
+++ b/src/lib/bridge/adapters/telegram-adapter.ts
@@ -15,7 +15,7 @@ import type {
 } from '../types';
 import type { FileAttachment } from '@/types';
 import { BaseChannelAdapter, registerAdapterFactory } from '../channel-adapter';
-import { callTelegramApi, sendMessageDraft } from './telegram-utils';
+import { callTelegramApi, sendMessageDraft, proxyFetch, getProxyUrl } from './telegram-utils';
 import {
   isImageEnabled,
   downloadPhoto,
@@ -101,6 +101,14 @@ export class TelegramAdapter extends BaseChannelAdapter {
     if (configError) {
       console.warn('[telegram-adapter] Cannot start:', configError);
       return;
+    }
+
+    // Log proxy configuration
+    const proxyUrl = getProxyUrl();
+    if (proxyUrl) {
+      console.log('[telegram-adapter] Using proxy:', proxyUrl.replace(/:.*@/, ':***@'));
+    } else {
+      console.log('[telegram-adapter] No proxy configured, using direct connection');
     }
 
     // Resolve bot identity via getMe before starting the poll loop.
@@ -391,7 +399,7 @@ export class TelegramAdapter extends BaseChannelAdapter {
 
     try {
       const url = `${TELEGRAM_API}/bot${token}/getMe`;
-      const res = await fetch(url, {
+      const res = await proxyFetch(url, {
         method: 'GET',
         signal: AbortSignal.timeout(10_000),
       });
@@ -475,7 +483,7 @@ export class TelegramAdapter extends BaseChannelAdapter {
         }
 
         const url = `${TELEGRAM_API}/bot${token}/getUpdates`;
-        const res = await fetch(url, {
+        const res = await proxyFetch(url, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({

--- a/src/lib/bridge/adapters/telegram-media.ts
+++ b/src/lib/bridge/adapters/telegram-media.ts
@@ -8,6 +8,7 @@
 
 import type { FileAttachment } from '@/types';
 import { getSetting } from '../../db';
+import { proxyFetch } from './telegram-utils';
 
 const TELEGRAM_API = 'https://api.telegram.org';
 
@@ -201,7 +202,7 @@ async function downloadFileById(
     try {
       // Step 1: Get file path from Telegram
       const getFileUrl = `${TELEGRAM_API}/bot${botToken}/getFile`;
-      const getFileRes = await fetch(getFileUrl, {
+      const getFileRes = await proxyFetch(getFileUrl, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ file_id: fileId }),
@@ -229,7 +230,7 @@ async function downloadFileById(
 
       // Step 2: Download the file
       const downloadUrl = `${TELEGRAM_API}/file/bot${botToken}/${filePath}`;
-      const downloadRes = await fetch(downloadUrl, {
+      const downloadRes = await proxyFetch(downloadUrl, {
         signal: AbortSignal.timeout(60_000),
       });
 

--- a/src/lib/bridge/adapters/telegram-utils.ts
+++ b/src/lib/bridge/adapters/telegram-utils.ts
@@ -5,7 +5,31 @@
  * Extracted from telegram-bot.ts to avoid duplication.
  */
 
+import { ProxyAgent } from 'undici';
+
 const TELEGRAM_API = 'https://api.telegram.org';
+
+/**
+ * Get proxy URL from environment variables.
+ * Supports HTTP_PROXY, HTTPS_PROXY, and ALL_PROXY.
+ */
+export function getProxyUrl(): string | undefined {
+  return process.env.HTTPS_PROXY || process.env.HTTP_PROXY || process.env.ALL_PROXY;
+}
+
+/**
+ * Proxy-enabled fetch for Telegram API calls.
+ * Falls back to native fetch if no proxy is configured.
+ */
+export async function proxyFetch(url: string | URL, init?: RequestInit): Promise<Response> {
+  const proxyUrl = getProxyUrl();
+  if (proxyUrl) {
+    const dispatcher = new ProxyAgent(proxyUrl);
+    // @ts-expect-error - dispatcher is an undici-specific extension not in standard fetch types
+    return fetch(url, { ...init, dispatcher });
+  }
+  return fetch(url, init);
+}
 
 export interface TelegramSendResult {
   ok: boolean;
@@ -41,7 +65,7 @@ export async function callTelegramApi(
 ): Promise<TelegramSendResult> {
   try {
     const url = `${TELEGRAM_API}/bot${botToken}/${method}`;
-    const res = await fetch(url, {
+    const res = await proxyFetch(url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(params),

--- a/src/lib/telegram-bot.ts
+++ b/src/lib/telegram-bot.ts
@@ -21,6 +21,7 @@ import {
   escapeHtml,
   splitMessage,
   formatSessionHeader,
+  proxyFetch,
 } from './bridge/adapters/telegram-utils';
 
 // ── Types ──────────────────────────────────────────────────────
@@ -279,7 +280,7 @@ export async function verifyBot(
 ): Promise<{ ok: boolean; botName?: string; error?: string }> {
   try {
     const url = `${TELEGRAM_API}/bot${botToken}/getMe`;
-    const res = await fetch(url);
+    const res = await proxyFetch(url);
     const data: TelegramBotInfo = await res.json();
 
     if (!data.ok || !data.result) {
@@ -317,7 +318,7 @@ export async function detectChatId(
   try {
     // Try getUpdates first (works when polling hasn't consumed the message)
     const url = `${TELEGRAM_API}/bot${botToken}/getUpdates`;
-    const res = await fetch(url, {
+    const res = await proxyFetch(url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ limit: 100, timeout: 0, allowed_updates: ['message'] }),
@@ -493,7 +494,7 @@ async function pollLoop(botToken: string, chatId: string, state: PollerState): P
   while (state.running) {
     try {
       const url = `${TELEGRAM_API}/bot${botToken}/getUpdates`;
-      const res = await fetch(url, {
+      const res = await proxyFetch(url, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({


### PR DESCRIPTION
## 概述
为 Telegram Bot 功能添加代理支持，解决国内网络环境下无法访问 Telegram API 的问题。

## 变更内容
- 新增 `proxyFetch` 函数，使用 undici 的 ProxyAgent
- 自动读取 `HTTP_PROXY`、`HTTPS_PROXY`、`ALL_PROXY` 环境变量
- 替换所有 Telegram 模块中的 fetch 调用
- 添加代理配置日志，方便调试

## 代理配置

### 临时配置（当前终端会话）
```bash
# 根据你的代理软件设置相应的端口
export HTTPS_PROXY=http://127.0.0.1:端口
export HTTP_PROXY=http://127.0.0.1:端口

# 例如 Clash Verge
export HTTPS_PROXY=http://127.0.0.1:7891
```

### 永久配置（添加到 shell 配置文件）
```bash
# macOS - 编辑 ~/.zshrc
echo 'export HTTPS_PROXY=http://127.0.0.1:你的端口' >> ~/.zshrc
echo 'export HTTP_PROXY=http://127.0.0.1:你的端口' >> ~/.zshrc
source ~/.zshrc

# Windows - 设置环境变量
setx HTTPS_PROXY http://127.0.0.1:你的端口
setx HTTP_PROXY http://127.0.0.1:你的端口
```

### 查找你的代理端口
```bash
# macOS/Linux - 查看常见代理软件端口
lsof -iTCP -sTCP:LISTEN -P | grep -E ':(7890|7891|10809|1087|6152|6153)'

# 或查看系统代理设置
scutil --proxy  # macOS
netsh winhttp show proxy  # Windows
```

## 测试步骤
1. 配置代理环境变量（见上方）
2. 启动 CodePilot，查看日志确认代理生效：`[telegram-adapter] Using proxy: ...`
3. 配置 Telegram Bot Token 和 Chat ID
4. 点击验证按钮确认连接成功
5. 发送测试消息确认双向通信正常

## 关闭 Issue
Fixes #210