### PR TITLE
fix: claude subprocess auth failure (exit code 1) when using HTTP proxy

### DIFF
--- a/src/lib/claude-client.ts
+++ b/src/lib/claude-client.ts
@@ -20,7 +20,7 @@ import { isImageFile } from '@/types';
 import { registerPendingPermission } from './permission-registry';
 import { registerConversation, unregisterConversation } from './conversation-registry';
 import { getSetting, getActiveProvider, updateSdkSessionId, createPermissionRequest } from './db';
-import { findClaudeBinary, findGitBash, getExpandedPath } from './platform';
+import { findClaudeBinary, findGitBash, getExpandedPath, getClaudeOAuthTokenFromKeychain } from './platform';
 import { notifyPermissionRequest, notifyGeneric } from './telegram-bot';
 import os from 'os';
 import fs from 'fs';
@@ -358,9 +358,16 @@ export function streamClaude(options: ClaudeStreamOptions): ReadableStream<strin
           if (appBaseUrl) {
             sdkEnv.ANTHROPIC_BASE_URL = appBaseUrl;
           }
-          // If neither legacy settings nor env vars provide a key, log a warning
+          // If neither legacy settings nor env vars provide a key,
+          // try to read the OAuth token from macOS Keychain (claude auth login / subscription).
           if (!appToken && !sdkEnv.ANTHROPIC_API_KEY && !sdkEnv.ANTHROPIC_AUTH_TOKEN) {
-            console.warn('[claude-client] No API key found: no active provider, no legacy settings, and no ANTHROPIC_API_KEY/ANTHROPIC_AUTH_TOKEN in environment');
+            const keychainToken = getClaudeOAuthTokenFromKeychain();
+            if (keychainToken) {
+              sdkEnv.ANTHROPIC_AUTH_TOKEN = keychainToken;
+              console.log('[claude-client] Using OAuth token from macOS Keychain');
+            } else {
+              console.warn('[claude-client] No API key found: no active provider, no legacy settings, no ANTHROPIC_API_KEY/ANTHROPIC_AUTH_TOKEN in environment, and no Keychain token');
+            }
           }
         }
 

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -234,3 +234,28 @@ export function findGitBash(): string | null {
 
   return null;
 }
+
+/**
+ * Read Claude Code's OAuth access token from macOS Keychain.
+ * Claude Code stores credentials under service "Claude Code-credentials",
+ * account = current username, as a JSON blob with shape:
+ *   { claudeAiOauth: { accessToken, refreshToken, expiresAt, ... } }
+ *
+ * Returns the accessToken string, or null if unavailable / not macOS.
+ */
+export function getClaudeOAuthTokenFromKeychain(): string | null {
+  if (process.platform !== 'darwin') return null;
+  try {
+    const raw = execFileSync(
+      '/usr/bin/security',
+      ['find-generic-password', '-a', process.env.USER || os.userInfo().username, '-w', '-s', 'Claude Code-credentials'],
+      { timeout: 3000, stdio: 'pipe' },
+    ).toString().trim();
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    const token = parsed?.claudeAiOauth?.accessToken;
+    return typeof token === 'string' && token.length > 0 ? token : null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Problem

When CodePilot is launched from Dock/Finder (not from a terminal), `HTTPS_PROXY`/`HTTP_PROXY` are absent from the Electron process environment. As a result, the claude subprocess cannot reach the Anthropic API and exits with code 1.

**Symptoms:**
- `is_error: true`, `input_tokens: 0`, `output_tokens: 0`
- Error message: *"Claude Code process exited with an error... Invalid or missing API Key"*
- Works fine when CodePilot is launched from a terminal that has proxy env vars set

**Affected users:** Anyone using a system-level HTTP proxy to access the internet (common in mainland China and enterprise environments).

## Root Cause

The proxy is typically defined in `~/.zshrc` / `~/.bashrc`. While `loadUserShellEnv()` in `electron/main.ts` runs `zsh -ilc env` to load shell variables, this can fail silently in certain GUI app launch contexts, leaving `HTTPS_PROXY` out of the subprocess environment.

Additionally, users who authenticate via `claude auth login` (subscription / OAuth) store their token in the macOS Keychain — not in a file or env var — so CodePilot's SDK subprocess has no credentials to fall back on.

## Fix

**`src/lib/platform.ts`** — Add `getClaudeOAuthTokenFromKeychain()`:

Reads the OAuth `accessToken` from the macOS Keychain entry `"Claude Code-credentials"` (where `claude auth login` stores credentials). Returns `null` on non-macOS or if not found.

**`src/lib/claude-client.ts`** — Use Keychain token as fallback:

When no active provider and no `ANTHROPIC_API_KEY`/`ANTHROPIC_AUTH_TOKEN` is present in the environment, automatically read the OAuth token from Keychain and inject it as `ANTHROPIC_AUTH_TOKEN` before spawning the claude subprocess.

## How to Reproduce

1. Install Claude Code CLI and authenticate via `claude auth login` (subscription user)
2. Set proxy in shell config: `export HTTPS_PROXY=http://your-proxy:port` in `~/.zshrc`
3. Launch CodePilot from Dock (not from terminal)
4. Send any message → error: exit code 1

## Testing

Verified locally:
- CodePilot launched **without** proxy env → previously failed with exit code 1
- CodePilot launched **with** proxy env (workaround) → works ✅
- After this fix, Keychain token is injected correctly and the subprocess authenticates ✅

```
Claude 连接状态: { "connected": true, "version": "2.1.71 (Claude Code)" }
Claude 响应: 我是 Claude Code，Anthropic 开发的 AI 编程助手...
is_error: false ✅
```