### PR TITLE
feat: Discord bridge adapter with slash command support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
+        "discord.js": "^14.25.1",
         "electron-updater": "^6.8.3",
         "lucide-react": "^0.563.0",
         "markdown-it": "^14.1.1",
@@ -767,6 +768,136 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/@discordjs/builders": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.13.1.tgz",
+      "integrity": "sha512-cOU0UDHc3lp/5nKByDxkmRiNZBpdp0kx55aarbiAfakfKJHlxv/yFW1zmIqCAmwH5CRlrH9iMFKJMpvW4DPB+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/formatters": "^0.6.2",
+        "@discordjs/util": "^1.2.0",
+        "@sapphire/shapeshift": "^4.0.0",
+        "discord-api-types": "^0.38.33",
+        "fast-deep-equal": "^3.1.3",
+        "ts-mixer": "^6.0.4",
+        "tslib": "^2.6.3"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/collection": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.5.3.tgz",
+      "integrity": "sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.11.0"
+      }
+    },
+    "node_modules/@discordjs/formatters": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.6.2.tgz",
+      "integrity": "sha512-y4UPwWhH6vChKRkGdMB4odasUbHOUwy7KL+OVwF86PvT6QVOwElx+TiI1/6kcmcEe+g5YRXJFiXSXUdabqZOvQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "discord-api-types": "^0.38.33"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/rest": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.6.0.tgz",
+      "integrity": "sha512-RDYrhmpB7mTvmCKcpj+pc5k7POKszS4E2O9TYc+U+Y4iaCP+r910QdO43qmpOja8LRr1RJ0b3U+CqVsnPqzf4w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/collection": "^2.1.1",
+        "@discordjs/util": "^1.1.1",
+        "@sapphire/async-queue": "^1.5.3",
+        "@sapphire/snowflake": "^3.5.3",
+        "@vladfrangu/async_event_emitter": "^2.4.6",
+        "discord-api-types": "^0.38.16",
+        "magic-bytes.js": "^1.10.0",
+        "tslib": "^2.6.3",
+        "undici": "6.21.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/rest/node_modules/@discordjs/collection": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+      "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/util": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.2.0.tgz",
+      "integrity": "sha512-3LKP7F2+atl9vJFhaBjn4nOaSWahZ/yWjOvA4e5pnXkt2qyXRCHLxoBQy81GFtLGCq7K9lPm9R517M1U+/90Qg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "discord-api-types": "^0.38.33"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/ws": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.2.3.tgz",
+      "integrity": "sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/collection": "^2.1.0",
+        "@discordjs/rest": "^2.5.1",
+        "@discordjs/util": "^1.1.0",
+        "@sapphire/async-queue": "^1.5.2",
+        "@types/ws": "^8.5.10",
+        "@vladfrangu/async_event_emitter": "^2.2.4",
+        "discord-api-types": "^0.38.1",
+        "tslib": "^2.6.2",
+        "ws": "^8.17.0"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/ws/node_modules/@discordjs/collection": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+      "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
     "node_modules/@dnd-kit/accessibility": {
@@ -6023,6 +6154,39 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@sapphire/async-queue": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.5.tgz",
+      "integrity": "sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@sapphire/shapeshift": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-4.0.0.tgz",
+      "integrity": "sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "lodash": "^4.17.21"
+      },
+      "engines": {
+        "node": ">=v16"
+      }
+    },
+    "node_modules/@sapphire/snowflake": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.3.tgz",
+      "integrity": "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/@shikijs/core": {
       "version": "3.22.0",
       "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.22.0.tgz",
@@ -7113,6 +7277,15 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/yauzl": {
       "version": "2.10.3",
       "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
@@ -7695,6 +7868,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 20"
+      }
+    },
+    "node_modules/@vladfrangu/async_event_emitter": {
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.4.7.tgz",
+      "integrity": "sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/@xmldom/xmldom": {
@@ -10286,6 +10469,42 @@
       "dependencies": {
         "minimatch": "^3.0.5",
         "p-limit": "^3.1.0 "
+      }
+    },
+    "node_modules/discord-api-types": {
+      "version": "0.38.42",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.42.tgz",
+      "integrity": "sha512-qs1kya7S84r5RR8m9kgttywGrmmoHaRifU1askAoi+wkoSefLpZP6aGXusjNw5b0jD3zOg3LTwUa3Tf2iHIceQ==",
+      "license": "MIT",
+      "workspaces": [
+        "scripts/actions/documentation"
+      ]
+    },
+    "node_modules/discord.js": {
+      "version": "14.25.1",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.25.1.tgz",
+      "integrity": "sha512-2l0gsPOLPs5t6GFZfQZKnL1OJNYFcuC/ETWsW4VtKVD/tg4ICa9x+jb9bkPffkMdRpRpuUaO/fKkHCBeiCKh8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/builders": "^1.13.0",
+        "@discordjs/collection": "1.5.3",
+        "@discordjs/formatters": "^0.6.2",
+        "@discordjs/rest": "^2.6.0",
+        "@discordjs/util": "^1.2.0",
+        "@discordjs/ws": "^1.2.3",
+        "@sapphire/snowflake": "3.5.3",
+        "discord-api-types": "^0.38.33",
+        "fast-deep-equal": "3.1.3",
+        "lodash.snakecase": "4.1.1",
+        "magic-bytes.js": "^1.10.0",
+        "tslib": "^2.6.3",
+        "undici": "6.21.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
     "node_modules/dmg-builder": {
@@ -14638,6 +14857,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.snakecase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
+      "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
+      "license": "MIT"
+    },
     "node_modules/log-symbols": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
@@ -14732,6 +14957,12 @@
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
+    },
+    "node_modules/magic-bytes.js": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.13.0.tgz",
+      "integrity": "sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg==",
+      "license": "MIT"
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
@@ -20602,6 +20833,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/ts-mixer": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
+      "integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==",
+      "license": "MIT"
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -20828,6 +21065,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.21.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
+      "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
+    "discord.js": "^14.25.1",
     "electron-updater": "^6.8.3",
     "lucide-react": "^0.563.0",
     "markdown-it": "^14.1.1",

--- a/src/lib/bridge/adapters/discord-adapter.ts
+++ b/src/lib/bridge/adapters/discord-adapter.ts
@@ -1,0 +1,538 @@
+/**
+ * Discord Adapter — implements BaseChannelAdapter for Discord via discord.js Gateway.
+ *
+ * Uses discord.js Client to connect via WebSocket Gateway, register application
+ * commands (slash commands), and handle both interactions and regular messages.
+ *
+ * Key differences from Telegram adapter:
+ * - Discord interactions must be acknowledged within 3 seconds (deferReply)
+ * - Uses Gateway WebSocket (suitable for desktop app — no public URL needed)
+ * - Message limit is 2000 characters (vs 4096 for Telegram)
+ * - Discord natively supports Markdown (not HTML)
+ */
+
+import {
+  Client,
+  GatewayIntentBits,
+  REST,
+  Routes,
+  Events,
+  SlashCommandBuilder,
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  type ChatInputCommandInteraction,
+  type ButtonInteraction,
+  type Message as DiscordMessage,
+  type TextChannel,
+} from 'discord.js';
+import type {
+  ChannelType,
+  InboundMessage,
+  OutboundMessage,
+  SendResult,
+} from '../types';
+import { BaseChannelAdapter, registerAdapterFactory } from '../channel-adapter';
+import { getSetting, insertAuditLog } from '../../db';
+
+// ── Helpers ─────────────────────────────────────────────────────
+
+/**
+ * Convert simple HTML (from bridge-manager command responses) to Discord Markdown.
+ * Bridge-manager sends command responses as HTML; Discord uses its own Markdown.
+ */
+function htmlToDiscordMarkdown(html: string): string {
+  return html
+    .replace(/<b>([\s\S]*?)<\/b>/g, '**$1**')
+    .replace(/<i>([\s\S]*?)<\/i>/g, '*$1*')
+    .replace(/<code>([\s\S]*?)<\/code>/g, '`$1`')
+    .replace(/<pre>([\s\S]*?)<\/pre>/g, '```\n$1\n```')
+    .replace(/<br\s*\/?>/g, '\n')
+    .replace(/<[^>]+>/g, '') // Strip remaining HTML tags
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&amp;/g, '&')
+    .replace(/&quot;/g, '"');
+}
+
+/** Build the slash command definitions to register with Discord API. */
+function buildSlashCommands(): SlashCommandBuilder[] {
+  return [
+    new SlashCommandBuilder()
+      .setName('new')
+      .setDescription('Start a new CodePilot session')
+      .addStringOption(opt =>
+        opt.setName('path').setDescription('Working directory path').setRequired(false),
+      ) as SlashCommandBuilder,
+    new SlashCommandBuilder()
+      .setName('bind')
+      .setDescription('Bind to an existing session')
+      .addStringOption(opt =>
+        opt.setName('session_id').setDescription('Session ID to bind to').setRequired(true),
+      ) as SlashCommandBuilder,
+    new SlashCommandBuilder()
+      .setName('cwd')
+      .setDescription('Change working directory')
+      .addStringOption(opt =>
+        opt.setName('path').setDescription('New working directory').setRequired(true),
+      ) as SlashCommandBuilder,
+    new SlashCommandBuilder()
+      .setName('mode')
+      .setDescription('Switch mode')
+      .addStringOption(opt =>
+        opt.setName('mode').setDescription('Mode: plan, code, or ask').setRequired(true)
+          .addChoices(
+            { name: 'plan', value: 'plan' },
+            { name: 'code', value: 'code' },
+            { name: 'ask', value: 'ask' },
+          ),
+      ) as SlashCommandBuilder,
+    new SlashCommandBuilder().setName('status').setDescription('Show current session status'),
+    new SlashCommandBuilder().setName('sessions').setDescription('List recent sessions'),
+    new SlashCommandBuilder().setName('stop').setDescription('Stop the current task'),
+    new SlashCommandBuilder().setName('help').setDescription('Show available commands'),
+  ];
+}
+
+// ── Adapter ─────────────────────────────────────────────────────
+
+export class DiscordAdapter extends BaseChannelAdapter {
+  readonly channelType: ChannelType = 'discord';
+
+  private client: Client | null = null;
+  private running = false;
+  private queue: InboundMessage[] = [];
+  private waiters: Array<(msg: InboundMessage | null) => void> = [];
+  /** Pending deferred slash command interactions awaiting response (channelId → interaction). */
+  private pendingInteractions = new Map<string, ChatInputCommandInteraction>();
+  /** Typing indicator intervals per channel. */
+  private typingIntervals = new Map<string, ReturnType<typeof setInterval>>();
+
+  get botToken(): string {
+    return getSetting('discord_bot_token') || '';
+  }
+
+  // ── Lifecycle ───────────────────────────────────────────────
+
+  async start(): Promise<void> {
+    if (this.running) return;
+
+    const configError = this.validateConfig();
+    if (configError) {
+      console.warn('[discord-adapter] Cannot start:', configError);
+      return;
+    }
+
+    const token = this.botToken;
+
+    // Register slash commands via REST API
+    await this.registerCommands(token);
+
+    // Create discord.js client with required Gateway intents
+    this.client = new Client({
+      intents: [
+        GatewayIntentBits.Guilds,
+        GatewayIntentBits.GuildMessages,
+        GatewayIntentBits.MessageContent,
+      ],
+    });
+
+    // Set up event handlers
+    this.client.on(Events.InteractionCreate, (interaction) => {
+      this.handleInteraction(interaction).catch(err => {
+        console.error('[discord-adapter] Interaction error:', err);
+      });
+    });
+
+    this.client.on(Events.MessageCreate, (message) => {
+      this.handleMessageCreate(message);
+    });
+
+    // Login and wait for ready
+    await new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error('Discord login timeout (30s)')), 30_000);
+      this.client!.once(Events.ClientReady, () => {
+        clearTimeout(timeout);
+        console.log(`[discord-adapter] Logged in as ${this.client!.user?.tag}`);
+        resolve();
+      });
+      this.client!.login(token).catch(err => {
+        clearTimeout(timeout);
+        reject(err);
+      });
+    });
+
+    this.running = true;
+    console.log('[discord-adapter] Started');
+  }
+
+  async stop(): Promise<void> {
+    if (!this.running) return;
+    this.running = false;
+
+    // Clear typing indicators
+    for (const [, interval] of this.typingIntervals) {
+      clearInterval(interval);
+    }
+    this.typingIntervals.clear();
+
+    // Reject all waiting consumers
+    for (const waiter of this.waiters) {
+      waiter(null);
+    }
+    this.waiters = [];
+
+    // Destroy the client connection
+    if (this.client) {
+      this.client.destroy();
+      this.client = null;
+    }
+
+    this.pendingInteractions.clear();
+    console.log('[discord-adapter] Stopped');
+  }
+
+  isRunning(): boolean {
+    return this.running;
+  }
+
+  // ── Message Queue ───────────────────────────────────────────
+
+  consumeOne(): Promise<InboundMessage | null> {
+    const queued = this.queue.shift();
+    if (queued) return Promise.resolve(queued);
+    if (!this.running) return Promise.resolve(null);
+    return new Promise<InboundMessage | null>((resolve) => {
+      this.waiters.push(resolve);
+    });
+  }
+
+  // ── Outbound ────────────────────────────────────────────────
+
+  async send(message: OutboundMessage): Promise<SendResult> {
+    if (!this.client) return { ok: false, error: 'Discord client not connected' };
+
+    const chatId = message.address.chatId;
+
+    // Convert HTML to Discord Markdown when bridge-manager sends HTML
+    const text = message.parseMode === 'HTML'
+      ? htmlToDiscordMarkdown(message.text)
+      : message.text;
+
+    try {
+      // Check for pending deferred slash command interaction
+      const pending = this.pendingInteractions.get(chatId);
+      if (pending) {
+        this.pendingInteractions.delete(chatId);
+        await pending.editReply({ content: text.slice(0, 2000) });
+        return { ok: true, messageId: pending.id };
+      }
+
+      // Regular message: send to channel
+      const channel = await this.client.channels.fetch(chatId);
+      if (!channel || !('send' in channel)) {
+        return { ok: false, error: `Channel ${chatId} not found or not text-based` };
+      }
+
+      const textChannel = channel as TextChannel;
+
+      // Build Discord button components from inlineButtons (for permission prompts)
+      const components = this.buildButtonComponents(message);
+
+      // Try to reply to a specific message if requested
+      if (message.replyToMessageId && 'messages' in textChannel) {
+        try {
+          const target = await (textChannel as any).messages.fetch(message.replyToMessageId);
+          const sent = await target.reply({
+            content: text.slice(0, 2000),
+            ...(components.length > 0 ? { components } : {}),
+          });
+          return { ok: true, messageId: sent.id };
+        } catch {
+          // Original message not found — fall through to regular send
+        }
+      }
+
+      const sent = await textChannel.send({
+        content: text.slice(0, 2000),
+        ...(components.length > 0 ? { components } : {}),
+      });
+      return { ok: true, messageId: sent.id };
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : 'Discord send error';
+      return { ok: false, error: errMsg };
+    }
+  }
+
+  // ── Config & Auth ───────────────────────────────────────────
+
+  validateConfig(): string | null {
+    const token = getSetting('discord_bot_token');
+    if (!token) return 'discord_bot_token not configured';
+
+    const enabled = getSetting('bridge_discord_enabled');
+    if (enabled !== 'true') return 'bridge_discord_enabled is not true';
+
+    return null;
+  }
+
+  isAuthorized(userId: string, chatId: string): boolean {
+    // Check bridge-specific allowed users
+    const allowedUsers = getSetting('discord_bridge_allowed_users') || '';
+    if (allowedUsers) {
+      const allowed = allowedUsers.split(',').map(s => s.trim()).filter(Boolean);
+      if (allowed.length > 0) {
+        return allowed.includes(userId) || allowed.includes(chatId);
+      }
+    }
+
+    // Fallback: check allowed channel
+    const allowedChannel = getSetting('discord_bridge_channel_id') || '';
+    if (allowedChannel) {
+      return chatId === allowedChannel;
+    }
+
+    // No auth configured — deny by default
+    return false;
+  }
+
+  // ── Lifecycle Hooks ─────────────────────────────────────────
+
+  onMessageStart(chatId: string): void {
+    this.startTyping(chatId);
+  }
+
+  onMessageEnd(chatId: string): void {
+    this.stopTyping(chatId);
+  }
+
+  // ── Private: Command Registration ───────────────────────────
+
+  /**
+   * Register slash commands with Discord REST API.
+   * Guild-specific commands are available instantly; global commands take up to 1 hour.
+   */
+  private async registerCommands(token: string): Promise<void> {
+    const rest = new REST({ version: '10' }).setToken(token);
+    const commandData = buildSlashCommands().map(cmd => cmd.toJSON());
+
+    try {
+      // Fetch application ID from the current bot token
+      const appInfo = await rest.get(Routes.oauth2CurrentApplication()) as { id: string };
+      const appId = appInfo.id;
+
+      const guildId = getSetting('discord_guild_id') || '';
+      if (guildId) {
+        // Guild commands: available instantly
+        await rest.put(Routes.applicationGuildCommands(appId, guildId), {
+          body: commandData,
+        });
+        console.log(`[discord-adapter] Registered ${commandData.length} guild commands for guild ${guildId}`);
+      } else {
+        // Global commands: may take up to 1 hour to propagate
+        await rest.put(Routes.applicationCommands(appId), {
+          body: commandData,
+        });
+        console.log(`[discord-adapter] Registered ${commandData.length} global commands (propagation may take up to 1h)`);
+      }
+    } catch (err) {
+      console.error('[discord-adapter] Failed to register commands:', err);
+      throw err;
+    }
+  }
+
+  // ── Private: Inbound Handling ───────────────────────────────
+
+  private enqueue(msg: InboundMessage): void {
+    const waiter = this.waiters.shift();
+    if (waiter) {
+      waiter(msg);
+    } else {
+      this.queue.push(msg);
+    }
+  }
+
+  /**
+   * Handle Discord interactions: slash commands and button clicks.
+   */
+  private async handleInteraction(interaction: import('discord.js').Interaction): Promise<void> {
+    // ── Slash Commands ──
+    if (interaction.isChatInputCommand()) {
+      await this.handleSlashCommand(interaction);
+      return;
+    }
+
+    // ── Button Clicks (permission prompts) ──
+    if (interaction.isButton()) {
+      await this.handleButtonClick(interaction);
+      return;
+    }
+  }
+
+  private async handleSlashCommand(interaction: ChatInputCommandInteraction): Promise<void> {
+    const chatId = interaction.channelId;
+    const userId = interaction.user.id;
+    const displayName = interaction.user.username;
+
+    if (!this.isAuthorized(userId, chatId)) {
+      await interaction.reply({
+        content: 'You are not authorized to use this bot.',
+        ephemeral: true,
+      });
+      return;
+    }
+
+    // Defer reply to avoid the 3-second interaction timeout
+    await interaction.deferReply();
+    this.pendingInteractions.set(chatId, interaction);
+
+    // Convert interaction to text command (bridge-manager expects `/command args` format)
+    const commandName = interaction.commandName;
+    let args = '';
+    switch (commandName) {
+      case 'new':
+        args = interaction.options.getString('path') || '';
+        break;
+      case 'bind':
+        args = interaction.options.getString('session_id') || '';
+        break;
+      case 'cwd':
+        args = interaction.options.getString('path') || '';
+        break;
+      case 'mode':
+        args = interaction.options.getString('mode') || '';
+        break;
+    }
+
+    const text = args ? `/${commandName} ${args}` : `/${commandName}`;
+
+    try {
+      insertAuditLog({
+        channelType: 'discord',
+        chatId,
+        direction: 'inbound',
+        messageId: interaction.id,
+        summary: text.slice(0, 200),
+      });
+    } catch { /* best effort */ }
+
+    this.enqueue({
+      messageId: interaction.id,
+      address: { channelType: 'discord', chatId, userId, displayName },
+      text,
+      timestamp: Date.now(),
+      raw: interaction,
+    });
+  }
+
+  private async handleButtonClick(interaction: ButtonInteraction): Promise<void> {
+    const chatId = interaction.channelId;
+    const userId = interaction.user.id;
+    const displayName = interaction.user.username;
+
+    if (!this.isAuthorized(userId, chatId)) {
+      await interaction.reply({ content: 'Not authorized.', ephemeral: true });
+      return;
+    }
+
+    // Acknowledge the button click without editing the message
+    await interaction.deferUpdate();
+
+    this.enqueue({
+      messageId: interaction.id,
+      address: { channelType: 'discord', chatId, userId, displayName },
+      text: '',
+      timestamp: Date.now(),
+      callbackData: interaction.customId,
+      callbackMessageId: interaction.message.id,
+      raw: interaction,
+    });
+  }
+
+  /**
+   * Handle regular Discord messages (non-interaction).
+   */
+  private handleMessageCreate(message: DiscordMessage): void {
+    // Ignore bot messages (including our own)
+    if (message.author.bot) return;
+
+    const chatId = message.channelId;
+    const userId = message.author.id;
+    const displayName = message.author.username;
+
+    if (!this.isAuthorized(userId, chatId)) return;
+
+    const text = message.content || '';
+    if (!text.trim()) return;
+
+    try {
+      insertAuditLog({
+        channelType: 'discord',
+        chatId,
+        direction: 'inbound',
+        messageId: message.id,
+        summary: text.slice(0, 200),
+      });
+    } catch { /* best effort */ }
+
+    this.enqueue({
+      messageId: message.id,
+      address: { channelType: 'discord', chatId, userId, displayName },
+      text,
+      timestamp: message.createdTimestamp,
+      raw: message,
+    });
+  }
+
+  // ── Private: UI Helpers ─────────────────────────────────────
+
+  /**
+   * Convert bridge InlineButton definitions to Discord ActionRow components.
+   */
+  private buildButtonComponents(
+    message: OutboundMessage,
+  ): ActionRowBuilder<ButtonBuilder>[] {
+    if (!message.inlineButtons || message.inlineButtons.length === 0) return [];
+
+    return message.inlineButtons.map(row =>
+      new ActionRowBuilder<ButtonBuilder>().addComponents(
+        ...row.map(btn =>
+          new ButtonBuilder()
+            .setCustomId(btn.callbackData)
+            .setLabel(btn.text)
+            .setStyle(ButtonStyle.Primary),
+        ),
+      ),
+    );
+  }
+
+  private startTyping(chatId: string): void {
+    this.stopTyping(chatId);
+    if (!this.client) return;
+
+    const sendTyping = async () => {
+      try {
+        const channel = await this.client?.channels.fetch(chatId);
+        if (channel && channel.isTextBased()) {
+          await (channel as TextChannel).sendTyping();
+        }
+      } catch { /* best effort */ }
+    };
+
+    // Send immediately, then repeat every 8s (Discord typing indicator lasts ~10s)
+    sendTyping();
+    const interval = setInterval(sendTyping, 8000);
+    this.typingIntervals.set(chatId, interval);
+  }
+
+  private stopTyping(chatId: string): void {
+    const interval = this.typingIntervals.get(chatId);
+    if (interval) {
+      clearInterval(interval);
+      this.typingIntervals.delete(chatId);
+    }
+  }
+}
+
+// Self-register so bridge-manager can create DiscordAdapter via the registry.
+registerAdapterFactory('discord', () => new DiscordAdapter());

--- a/src/lib/bridge/adapters/index.ts
+++ b/src/lib/bridge/adapters/index.ts
@@ -10,3 +10,4 @@
  */
 
 import './telegram-adapter';
+import './discord-adapter';

--- a/src/lib/bridge/bridge-manager.ts
+++ b/src/lib/bridge/bridge-manager.ts
@@ -383,13 +383,23 @@ async function handleMessage(
       );
     }, taskAbort.signal, hasAttachments ? msg.attachments : undefined);
 
-    // Send response text — render Markdown to Telegram HTML
+    // Send response text back to the IM channel.
+    // Telegram needs Markdown→HTML conversion; other platforms receive raw Markdown.
     if (result.responseText) {
-      const chunks = markdownToTelegramChunks(result.responseText, 4096);
-      if (chunks.length > 0) {
-        await deliverRendered(adapter, msg.address, chunks, {
-          sessionId: binding.codepilotSessionId,
-        });
+      if (adapter.channelType === 'telegram') {
+        const chunks = markdownToTelegramChunks(result.responseText, 4096);
+        if (chunks.length > 0) {
+          await deliverRendered(adapter, msg.address, chunks, {
+            sessionId: binding.codepilotSessionId,
+          });
+        }
+      } else {
+        // Discord and other platforms: send raw Markdown, let deliver() handle chunking
+        await deliver(adapter, {
+          address: msg.address,
+          text: result.responseText,
+          parseMode: 'plain',
+        }, { sessionId: binding.codepilotSessionId });
       }
     } else if (result.hasError) {
       const errorResponse: OutboundMessage = {


### PR DESCRIPTION
## Summary
- Implements `DiscordAdapter` for the bridge system, fixing the "Unknown Application" error when using `/new`, `/stop` and other slash commands on Discord
- Uses discord.js Gateway WebSocket connection (suitable for desktop app — no public URL needed)
- Registers slash commands via Discord REST API with proper Application ID resolution
- Handles interactions with `deferReply()`/`editReply()` pattern to avoid 3-second timeout
- Includes button components for permission prompts, HTML→Discord Markdown conversion, typing indicators

## Root Cause
Discord slash commands returned "Unknown Application" because no Discord adapter was implemented. The bridge system only supported Telegram. Additionally, Discord blocks requests with Python `urllib` default User-Agent — this implementation uses Node.js `discord.js` which is fully compatible.

## Files Changed
- **`discord-adapter.ts`** (new): Full Discord adapter — Gateway connection, slash commands, interactions, buttons, typing
- **`adapters/index.ts`**: Register Discord adapter via side-effect import
- **`bridge-manager.ts`**: Dispatch response rendering by adapter type (Telegram→HTML, Discord→raw Markdown)
- **`package.json`**: Add `discord.js` dependency

## Configuration
Required settings (in Bridge Settings UI):
| Key | Description |
|-----|-------------|
| `discord_bot_token` | Discord bot token |
| `bridge_discord_enabled` | Set to `"true"` |
| `discord_guild_id` | (optional) For instant command registration |
| `discord_bridge_allowed_users` | Comma-separated authorized user/channel IDs |
| `discord_bridge_channel_id` | (optional) Restrict bot to specific channel |

## Test Plan
- [ ] Configure Discord bot token and enable bridge
- [ ] Verify slash commands (`/new`, `/stop`, `/status`, `/help`, etc.) register and respond correctly
- [ ] Verify regular text messages are processed through Claude
- [ ] Verify typing indicator shows during processing
- [ ] Verify permission prompt buttons work
- [ ] Verify unauthorized users are rejected
- [ ] Verify Telegram adapter continues to work unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)