### PR TITLE
fix: remove empty auth env placeholders from anthropic-thirdparty and openrouter presets

### DIFF
--- a/src/components/settings/ProviderForm.tsx
+++ b/src/components/settings/ProviderForm.tsx
@@ -27,7 +27,7 @@ import { useTranslation } from "@/hooks/useTranslation";
 
 const PROVIDER_PRESETS: Record<string, { base_url: string; extra_env: string; protocol: string }> = {
   anthropic: { base_url: "https://api.anthropic.com", extra_env: "{}", protocol: "anthropic" },
-  openrouter: { base_url: "https://openrouter.ai/api", extra_env: '{"ANTHROPIC_API_KEY":""}', protocol: "openrouter" },
+  openrouter: { base_url: "https://openrouter.ai/api", extra_env: '{}', protocol: "openrouter" },
   bedrock: { base_url: "", extra_env: '{"CLAUDE_CODE_USE_BEDROCK":"1","AWS_REGION":"us-east-1","CLAUDE_CODE_SKIP_BEDROCK_AUTH":"1"}', protocol: "bedrock" },
   vertex: { base_url: "", extra_env: '{"CLAUDE_CODE_USE_VERTEX":"1","CLOUD_ML_REGION":"us-east5","CLAUDE_CODE_SKIP_VERTEX_AUTH":"1"}', protocol: "vertex" },
   custom: { base_url: "", extra_env: "{}", protocol: "openai-compatible" },

--- a/src/components/settings/ProviderManager.tsx
+++ b/src/components/settings/ProviderManager.tsx
@@ -130,7 +130,7 @@ const QUICK_PRESETS: QuickPreset[] = [
     provider_type: "anthropic",
     protocol: "anthropic",
     base_url: "",
-    extra_env: '{"ANTHROPIC_API_KEY":""}',
+    extra_env: "{}",
     fields: ["name", "api_key", "base_url", "model_mapping"],
   },
   {
@@ -458,26 +458,19 @@ function PresetConnectDialog({
       return;
     }
 
-    // For anthropic-thirdparty, inject the correct auth key into extra_env
-    // while preserving any other user-specified env vars (e.g. API_TIMEOUT_MS)
+    // For anthropic-thirdparty, strip auth key placeholders from extra_env.
+    // Auth is handled via the api_key field — storing empty ANTHROPIC_API_KEY /
+    // ANTHROPIC_AUTH_TOKEN placeholders in extra_env causes toClaudeCodeEnv()
+    // to infer the wrong authStyle and can override freshly-injected credentials.
     let finalExtraEnv = extraEnv;
     if (preset.key === "anthropic-thirdparty") {
       try {
         const parsed = JSON.parse(extraEnv || "{}");
-        // Remove both auth keys, then set the correct one
         delete parsed["ANTHROPIC_API_KEY"];
         delete parsed["ANTHROPIC_AUTH_TOKEN"];
-        if (authStyle === "auth_token") {
-          parsed["ANTHROPIC_AUTH_TOKEN"] = "";
-        } else {
-          parsed["ANTHROPIC_API_KEY"] = "";
-        }
         finalExtraEnv = JSON.stringify(parsed);
       } catch {
-        // If parse fails, fall back to simple replacement
-        finalExtraEnv = authStyle === "auth_token"
-          ? '{"ANTHROPIC_AUTH_TOKEN":""}'
-          : '{"ANTHROPIC_API_KEY":""}';
+        finalExtraEnv = "{}";
       }
     }
     // In edit mode, preserve existing role_models_json unless the user modifies mapping fields


### PR DESCRIPTION
Fixes #241

## Root Cause

`anthropic-thirdparty` and `openrouter` presets were storing empty auth key placeholders (`{"ANTHROPIC_API_KEY":""}` or `{"ANTHROPIC_AUTH_TOKEN":""}`) in `extra_env`. This caused two problems:

1. `inferAuthStyleFromLegacy()` in `provider-catalog.ts` detects auth style by checking if `ANTHROPIC_AUTH_TOKEN` key *exists* in `extra_env` (regardless of value), so an empty placeholder could cause the wrong auth style to be inferred.
2. The empty entries were persisted to DB and shown in the UI after save/reopen, confusing users into thinking their credentials were being cleared.

## Fix

- Remove the empty auth key placeholders from the preset definitions in `ProviderManager.tsx` and `ProviderForm.tsx`
- On save for `anthropic-thirdparty`, strip any `ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN` keys from `extra_env` instead of injecting empty ones — auth injection is already handled correctly via the `api_key` field in `toClaudeCodeEnv()`

## Testing

1. Add an Anthropic Third-party API provider with a valid base URL and API key
2. Save and reopen — no empty auth env vars should appear in the UI
3. Send a message — Claude Code subprocess should start successfully
