### PR TITLE
fix: SDK 模型列表应合并而非替换默认列表

### DIFF
--- a/src/app/api/providers/models/route.ts
+++ b/src/app/api/providers/models/route.ts
@@ -64,12 +64,15 @@ export async function GET() {
       }),
     });
 
-    // If SDK has discovered models, use them for the env group
+    // If SDK has discovered models, merge them into the default list.
+    // SDK models carry richer metadata (supportsEffort, etc.) so they take
+    // precedence, but default models missing from the SDK response are kept
+    // to avoid models disappearing when supportedModels() returns a partial list.
     try {
       const { getCachedModels } = await import('@/lib/agent-sdk-capabilities');
       const sdkModels = getCachedModels('env');
       if (sdkModels.length > 0) {
-        groups[0].models = sdkModels.map(m => {
+        const sdkEntries = sdkModels.map(m => {
           const cw = getContextWindow(m.value);
           return {
             value: m.value,
@@ -81,6 +84,10 @@ export async function GET() {
             ...(cw != null ? { contextWindow: cw } : {}),
           };
         });
+        // Append default models that the SDK didn't return
+        const sdkIds = new Set(sdkEntries.map(m => m.value));
+        const missing = groups[0].models.filter(m => !sdkIds.has(m.value));
+        groups[0].models = [...sdkEntries, ...missing];
       }
     } catch {
       // SDK capabilities not available, keep defaults


### PR DESCRIPTION
## 关联 Issue

Fixes #367

## 问题

`/api/providers/models` 的 env provider 处理逻辑中，`getCachedModels('env')` 返回的 SDK 模型列表会**完全替换** `DEFAULT_MODELS`。

如果 `supportedModels()` 只返回了部分模型（比如只有 Sonnet），其他模型（Opus、Haiku）就从选择器里消失了。重启后缓存为空，又会显示完整的默认列表，所以表现为"用着用着模型就少了，重启又好了"。

## 修复

把替换改为合并：SDK 返回的模型优先（带有 `supportsEffort` 等更丰富的元数据），但 SDK 没返回的默认模型保留在列表末尾。

```typescript
// 之前：直接替换
groups[0].models = sdkEntries;

// 之后：合并，保留 SDK 没覆盖到的默认模型
const sdkIds = new Set(sdkEntries.map(m => m.value));
const missing = groups[0].models.filter(m => !sdkIds.has(m.value));
groups[0].models = [...sdkEntries, ...missing];
```

改动很小，只动了 `route.ts` 一个文件，+9 -2 行。