### PR TITLE
fix: enforce requireMention setting for Feishu group chats

### DIFF
--- a/src/lib/channels/feishu/inbound.ts
+++ b/src/lib/channels/feishu/inbound.ts
@@ -9,10 +9,20 @@ import type { FeishuConfig } from './types';
 
 const LOG_TAG = '[feishu/inbound]';
 
+/** Find the bot's mention entry in the Feishu mentions array, if present. */
+function findBotMention(
+  mentions: any[] | undefined,
+  botOpenId: string,
+): { key?: string } | undefined {
+  if (!mentions || !botOpenId) return undefined;
+  return mentions.find((m: any) => m?.id?.open_id === botOpenId);
+}
+
 /** Parse a raw Feishu im.message.receive_v1 event into an InboundMessage. */
 export function parseInboundMessage(
   eventData: any,
-  _config: FeishuConfig,
+  config: FeishuConfig,
+  botOpenId?: string,
 ): InboundMessage | null {
   try {
     const event = eventData?.event ?? eventData;
@@ -24,7 +34,16 @@ export function parseInboundMessage(
     const sender = event.sender?.sender_id?.open_id || '';
     const msgType = message.message_type;
 
-    // Only handle text messages for now
+    const isGroupChat = chatId.startsWith('oc_');
+    const botMention = isGroupChat && botOpenId
+      ? findBotMention(message.mentions, botOpenId)
+      : undefined;
+
+    // When requireMention is enabled, drop group messages that don't @mention the bot.
+    if (isGroupChat && config.requireMention && !botMention) {
+      return null;
+    }
+
     let text = '';
     if (msgType === 'text') {
       try {
@@ -34,13 +53,16 @@ export function parseInboundMessage(
         text = message.content || '';
       }
     } else {
-      // Non-text messages — skip silently
       return null;
     }
 
     if (!text.trim()) return null;
 
-    // Build thread-session address if applicable
+    // Strip the @bot placeholder so the LLM sees clean input.
+    if (botMention?.key) {
+      text = text.replaceAll(botMention.key, '').trim();
+    }
+
     const rootId = message.root_id || '';
     const effectiveChatId = rootId ? `${chatId}:thread:${rootId}` : chatId;
 

--- a/src/lib/channels/feishu/index.ts
+++ b/src/lib/channels/feishu/index.ts
@@ -11,6 +11,7 @@ import type { FeishuConfig } from './types';
 import { loadFeishuConfig, validateFeishuConfig } from './config';
 import { FeishuGateway } from './gateway';
 import { parseInboundMessage } from './inbound';
+import { getBotInfo } from './identity';
 import { sendMessage, addReaction, removeReaction } from './outbound';
 import { isUserAuthorized } from './policy';
 import { createCardStreamController } from './card-controller';
@@ -23,6 +24,7 @@ export class FeishuChannelPlugin implements ChannelPlugin<FeishuConfig> {
 
   private config: FeishuConfig | null = null;
   private gateway: FeishuGateway | null = null;
+  private botOpenId: string = '';
   private messageQueue: InboundMessage[] = [];
   private waitResolve: ((msg: InboundMessage | null) => void) | null = null;
   /** Track last received messageId per chatId for reaction acknowledgment. */
@@ -64,9 +66,11 @@ export class FeishuChannelPlugin implements ChannelPlugin<FeishuConfig> {
 
     this.gateway = new FeishuGateway(this.config);
 
-    // Register message handler — pushes to internal queue
+    // Register message handler — pushes to internal queue.
+    // Reads this.botOpenId at call time, so mention checks activate
+    // once resolveBotIdentity() completes after gateway.start().
     this.gateway.registerMessageHandler((data: unknown) => {
-      const msg = parseInboundMessage(data, this.config!);
+      const msg = parseInboundMessage(data, this.config!, this.botOpenId);
       if (!msg) return;
       this.enqueueMessage(msg);
     });
@@ -148,6 +152,29 @@ export class FeishuChannelPlugin implements ChannelPlugin<FeishuConfig> {
     });
 
     await this.gateway.start();
+
+    // Resolve bot identity so mention checks work.
+    // Handler reads this.botOpenId dynamically — once resolved, all
+    // subsequent messages get proper mention filtering.
+    await this.resolveBotIdentity();
+  }
+
+  /** Fetch bot open_id with retry so mention features degrade gracefully. */
+  private async resolveBotIdentity(maxRetries = 3): Promise<void> {
+    const client = this.gateway?.getRestClient();
+    if (!client) return;
+    for (let attempt = 1; attempt <= maxRetries; attempt++) {
+      const info = await getBotInfo(client);
+      if (info?.openId) {
+        this.botOpenId = info.openId;
+        return;
+      }
+      console.warn('[feishu/plugin]', `Bot identity attempt ${attempt}/${maxRetries} failed`);
+      if (attempt < maxRetries) {
+        await new Promise((r) => setTimeout(r, 2000 * attempt));
+      }
+    }
+    console.error('[feishu/plugin]', 'Could not resolve bot identity — mention features disabled');
   }
 
   async stop(): Promise<void> {


### PR DESCRIPTION
## Problem

The `bridge_feishu_require_mention` setting exists in the config UI and is loaded from the database, but it was never actually checked in the message handling pipeline. This means the bot responds to **all** messages in group chats, even when "Require @mention" is enabled.

The Discord adapter correctly implements this check, but the Feishu adapter was missing the equivalent logic.

## Changes

**`src/lib/channels/feishu/inbound.ts`**
- Added `isBotMentioned()` helper that checks `message.mentions` array for the bot's `open_id`
- When `config.requireMention` is `true` and the message is from a group chat (`oc_` prefix), skip messages where the bot is not @mentioned
- Strip the `@bot` mention placeholder (e.g. `@_user_1`) from message text so the LLM receives clean input

**`src/lib/channels/feishu/index.ts`**
- Fetch bot identity via `getBotInfo()` after gateway starts, storing `botOpenId`
- Pass `botOpenId` to `parseInboundMessage()` for mention detection

## How it works

Feishu includes a `mentions` array in `im.message.receive_v1` events:
```json
{
  "message": {
    "mentions": [
      { "key": "@_user_1", "id": { "open_id": "ou_xxx" }, "name": "MyBot" }
    ]
  }
}
```

The fix checks this array against the bot's `open_id` (fetched at startup) when `requireMention` is enabled.

## Test plan

- [ ] Enable "Require @mention" in Feishu settings
- [ ] Send a message in a group chat **without** @mentioning the bot → bot should **not** respond
- [ ] Send a message in a group chat **with** @mention → bot should respond, and the `@bot` placeholder should be stripped from the input
- [ ] Send a DM → bot should respond regardless of the setting
- [ ] Disable "Require @mention" → bot should respond to all group messages again