### PR TITLE
feat: add Shiki syntax highlighting to file preview panel

### DIFF
--- a/src/components/ai-elements/code-block.tsx
+++ b/src/components/ai-elements/code-block.tsx
@@ -444,7 +444,7 @@ export const CodeBlockActions = ({
 );
 
 /** Resolve Shiki theme pair from the current theme family. */
-function useShikiThemes(): { light: BundledTheme; dark: BundledTheme } {
+export function useShikiThemes(): { light: BundledTheme; dark: BundledTheme } {
   const { family, families } = useThemeFamily();
   const shikiTheme = resolveShikiTheme(families, family);
   return resolveShikiThemes(shikiTheme);

--- a/src/components/layout/panels/PreviewPanel.tsx
+++ b/src/components/layout/panels/PreviewPanel.tsx
@@ -1,12 +1,11 @@
 "use client";
 
 import { useState, useEffect, useMemo, useCallback } from "react";
-import { useTheme } from "next-themes";
 import { X, Copy, Check, SpinnerGap } from "@/components/ui/icon";
 import { Button } from "@/components/ui/button";
-import { Light as SyntaxHighlighter } from "react-syntax-highlighter";
-import { useThemeFamily } from "@/lib/theme/context";
-import { resolveCodeTheme, resolveHljsStyle } from "@/lib/theme/code-themes";
+import { highlightCode, useShikiThemes } from "@/components/ai-elements/code-block";
+import type { BundledLanguage } from "shiki";
+import { bundledLanguages } from "shiki";
 import { Streamdown } from "streamdown";
 import { cjk } from "@streamdown/cjk";
 import { code } from "@streamdown/code";
@@ -64,9 +63,7 @@ const PREVIEW_MAX_WIDTH = 800;
 const PREVIEW_DEFAULT_WIDTH = 480;
 
 export function PreviewPanel() {
-  const { resolvedTheme } = useTheme();
   const { workingDirectory, sessionId, previewFile, setPreviewFile, previewViewMode, setPreviewViewMode, setPreviewOpen } = usePanel();
-  const isDark = resolvedTheme === "dark";
   const [preview, setPreview] = useState<FilePreviewType | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -211,7 +208,7 @@ export function PreviewPanel() {
           previewViewMode === "rendered" && canRender ? (
             <RenderedView content={preview.content} filePath={filePath} />
           ) : (
-            <SourceView preview={preview} isDark={isDark} />
+            <SourceView preview={preview} />
           )
         ) : null}
       </div>
@@ -258,41 +255,90 @@ function ViewModeToggle({
   );
 }
 
-/** Resolve hljs style from the current theme family + mode. */
-function useDocCodeTheme(isDark: boolean) {
-  const { family, families } = useThemeFamily();
-  const codeTheme = resolveCodeTheme(families, family);
-  return resolveHljsStyle(codeTheme, isDark);
+/** Check if a language string is a known Shiki bundled language */
+const isBundledLanguage = (lang: string): lang is BundledLanguage =>
+  lang in bundledLanguages || lang === "text" || lang === "plaintext";
+
+/** Tokenized code result type */
+interface TokenizedCode {
+  tokens: import("shiki").ThemedToken[][];
+  fg: string;
+  bg: string;
 }
 
-/** Source code view using react-syntax-highlighter */
-function SourceView({ preview, isDark }: { preview: FilePreviewType; isDark: boolean }) {
-  const hljsStyle = useDocCodeTheme(isDark);
+/** Create raw (unhighlighted) tokens for immediate display */
+const createRawTokens = (code: string): TokenizedCode => ({
+  bg: "transparent",
+  fg: "inherit",
+  tokens: code.split("\n").map((line) =>
+    line === ""
+      ? []
+      : [{ color: "inherit", content: line } as import("shiki").ThemedToken]
+  ),
+});
+
+/** Source code view using Shiki syntax highlighting */
+function SourceView({ preview }: { preview: FilePreviewType }) {
+  const { light: lightTheme, dark: darkTheme } = useShikiThemes();
+  const language = isBundledLanguage(preview.language)
+    ? preview.language
+    : ("text" as BundledLanguage);
+
+  const rawTokens = useMemo(() => createRawTokens(preview.content), [preview.content]);
+
+  const syncTokenized = useMemo(
+    () => highlightCode(preview.content, language, undefined, lightTheme, darkTheme) ?? rawTokens,
+    [preview.content, language, rawTokens, lightTheme, darkTheme]
+  );
+
+  const [asyncResult, setAsyncResult] = useState<{ key: string; tokens: TokenizedCode } | null>(null);
+  const resultKey = `${preview.content}:${language}:${lightTheme}:${darkTheme}`;
+
+  useEffect(() => {
+    let cancelled = false;
+    highlightCode(preview.content, language, (result) => {
+      if (!cancelled) {
+        setAsyncResult({ key: `${preview.content}:${language}:${lightTheme}:${darkTheme}`, tokens: result });
+      }
+    }, lightTheme, darkTheme);
+    return () => { cancelled = true; };
+  }, [preview.content, language, lightTheme, darkTheme]);
+
+  const tokenized = (asyncResult && asyncResult.key === resultKey) ? asyncResult.tokens : syncTokenized;
+
   return (
-    <div className="text-xs">
-      <SyntaxHighlighter
-        language={preview.language}
-        style={hljsStyle}
-        showLineNumbers
-        customStyle={{
-          margin: 0,
-          padding: "8px",
-          borderRadius: 0,
-          fontSize: "11px",
-          lineHeight: "1.5",
-          background: "transparent",
-        }}
-        lineNumberStyle={{
-          minWidth: "2.5em",
-          paddingRight: "8px",
-          color: "var(--muted-foreground)",
-          opacity: 0.5,
-          userSelect: "none",
-        }}
-      >
-        {preview.content}
-      </SyntaxHighlighter>
-    </div>
+    <pre
+      className="m-0 px-2 py-2 text-[11px] leading-relaxed dark:!bg-[var(--shiki-dark-bg)] dark:!text-[var(--shiki-dark)]"
+      style={{ backgroundColor: tokenized.bg === "transparent" ? undefined : tokenized.bg, color: tokenized.fg }}
+    >
+      <code className="font-mono [counter-increment:line_0] [counter-reset:line]">
+        {tokenized.tokens.map((line, lineIdx) => (
+          <span
+            key={lineIdx}
+            className="block before:content-[counter(line)] before:inline-block before:[counter-increment:line] before:w-8 before:mr-3 before:text-right before:text-muted-foreground/50 before:font-mono before:select-none"
+          >
+            {line.length === 0
+              ? "\n"
+              : line.map((token, tokenIdx) => (
+                  <span
+                    key={tokenIdx}
+                    className="dark:!bg-[var(--shiki-dark-bg)] dark:!text-[var(--shiki-dark)]"
+                    style={{
+                      backgroundColor: token.bgColor,
+                      color: token.color,
+                      fontStyle: token.fontStyle && token.fontStyle & 1 ? "italic" : undefined,
+                      fontWeight: token.fontStyle && token.fontStyle & 2 ? "bold" : undefined,
+                      textDecoration: token.fontStyle && token.fontStyle & 4 ? "underline" : undefined,
+                      ...token.htmlStyle,
+                    } as React.CSSProperties}
+                  >
+                    {token.content}
+                  </span>
+                ))}
+          </span>
+        ))}
+      </code>
+    </pre>
   );
 }
 


### PR DESCRIPTION
## Problem

文件预览面板打开 Python、TypeScript、JavaScript 等代码文件时，代码没有语法高亮，全部以单色纯文本显示。

**根因**：`SourceView` 使用了 `react-syntax-highlighter` 的 `Light` 轻量版本，但从未调用 `registerLanguage()` 注册任何语言，导致所有代码都被当作纯文本渲染。

## Solution

将 `SourceView` 的高亮引擎从无效的 `react-syntax-highlighter Light` 替换为项目已有的 Shiki，与聊天代码块使用同一套高亮基础设施。

- 支持 Shiki 全部 bundled languages（Python、TypeScript、Go、Rust 等 200+ 语言）
- 复用现有的高亮缓存、异步加载、light/dark 双主题机制
- 未知语言自动降级为纯文本显示
- Markdown/HTML 渲染（RenderedView）和媒体预览（MediaView）不受影响

## Changes

- `PreviewPanel.tsx`：重写 `SourceView`，用 Shiki token 渲染替代 `<SyntaxHighlighter>`
- `code-block.tsx`：导出 `useShikiThemes` hook 供文件预览复用

## Before / After

| Before | After |
|--------|-------|
| 所有代码文件单色纯文本 | 关键词、字符串、变量名等语法元素正确着色 |

## Test plan

- [x] TypeScript 类型检查通过
- [x] Dev server 启动正常
- [x] 文件预览面板打开 JSON 文件，语法高亮正确显示
- [x] 文件预览面板打开 TypeScript 文件，关键词/字符串/变量名颜色区分正确
- [x] 切换 light/dark 主题，高亮颜色跟随切换
- [x] Markdown 文件的 Source/Preview 切换正常