### PR TITLE
fix: Remove pathToClaudeCodeExecutable to support native Claude CLI on Windows

### DIFF
--- a/src/lib/claude-client.ts
+++ b/src/lib/claude-client.ts
@@ -20,7 +20,7 @@ import { registerConversation, unregisterConversation } from './conversation-reg
 import { captureCapabilities, isCacheFresh, setCachedPlugins } from './agent-sdk-capabilities';
 import { getSetting, updateSdkSessionId, createPermissionRequest } from './db';
 import { resolveForClaudeCode, toClaudeCodeEnv } from './provider-resolver';
-import { findClaudeBinary, findGitBash, getExpandedPath, invalidateClaudePathCache } from './platform';
+import { findGitBash, getExpandedPath } from './platform';
 import { notifyPermissionRequest, notifyGeneric } from './telegram-bot';
 import { classifyError, formatClassifiedError } from './error-classifier';
 import { resolveWorkingDirectory } from './working-directory';
@@ -53,49 +53,8 @@ function sanitizeEnv(env: Record<string, string>): Record<string, string> {
   return clean;
 }
 
-/**
- * On Windows, npm installs CLI tools as .cmd wrappers that can't be
- * spawned without shell:true. Parse the wrapper to extract the real
- * .js script path so we can pass it to the SDK directly.
- */
-function resolveScriptFromCmd(cmdPath: string): string | undefined {
-  try {
-    const content = fs.readFileSync(cmdPath, 'utf-8');
-    const cmdDir = path.dirname(cmdPath);
-
-    // npm .cmd wrappers typically contain a line like:
-    //   "%~dp0\node_modules\@anthropic-ai\claude-code\cli.js" %*
-    // Match paths containing claude-code or claude-agent and ending in .js
-    const patterns = [
-      // Quoted: "%~dp0\...\cli.js"
-      /"%~dp0\\([^"]*claude[^"]*\.js)"/i,
-      // Unquoted: %~dp0\...\cli.js
-      /%~dp0\\(\S*claude\S*\.js)/i,
-      // Quoted with %dp0%: "%dp0%\...\cli.js"
-      /"%dp0%\\([^"]*claude[^"]*\.js)"/i,
-    ];
-
-    for (const re of patterns) {
-      const m = content.match(re);
-      if (m) {
-        const resolved = path.normalize(path.join(cmdDir, m[1]));
-        if (fs.existsSync(resolved)) return resolved;
-      }
-    }
-  } catch {
-    // ignore read errors
-  }
-  return undefined;
-}
-
-let cachedClaudePath: string | null | undefined;
-
-function findClaudePath(): string | undefined {
-  if (cachedClaudePath !== undefined) return cachedClaudePath || undefined;
-  const found = findClaudeBinary();
-  cachedClaudePath = found ?? null;
-  return found;
-}
+// Removed resolveScriptFromCmd() and findClaudePath() — let SDK use its built-in cli.js
+// with expanded PATH from getExpandedPath() which includes all Claude installation paths.
 
 /**
  * Invalidate the cached Claude binary path in this module AND in platform.ts.
@@ -329,16 +288,7 @@ export async function generateTextViaSdk(params: {
     queryOptions.model = params.model;
   }
 
-  const claudePath = findClaudePath();
-  if (claudePath) {
-    const ext = path.extname(claudePath).toLowerCase();
-    if (ext === '.cmd' || ext === '.bat') {
-      const scriptPath = resolveScriptFromCmd(claudePath);
-      if (scriptPath) queryOptions.pathToClaudeCodeExecutable = scriptPath;
-    } else {
-      queryOptions.pathToClaudeCodeExecutable = claudePath;
-    }
-  }
+  // Let SDK use its built-in cli.js with expanded PATH from getExpandedPath()
 
   const conversation = query({
     prompt: params.prompt,
@@ -481,24 +431,7 @@ export function streamClaude(options: ClaudeStreamOptions): ReadableStream<strin
           queryOptions.allowDangerouslySkipPermissions = true;
         }
 
-        // Find claude binary for packaged app where PATH is limited.
-        // On Windows, npm installs Claude CLI as a .cmd wrapper which cannot
-        // be spawned directly without shell:true. Parse the wrapper to
-        // extract the real .js script path and pass that to the SDK instead.
-        const claudePath = findClaudePath();
-        if (claudePath) {
-          const ext = path.extname(claudePath).toLowerCase();
-          if (ext === '.cmd' || ext === '.bat') {
-            const scriptPath = resolveScriptFromCmd(claudePath);
-            if (scriptPath) {
-              queryOptions.pathToClaudeCodeExecutable = scriptPath;
-            } else {
-              console.warn('[claude-client] Could not resolve .js path from .cmd wrapper, falling back to SDK resolution:', claudePath);
-            }
-          } else {
-            queryOptions.pathToClaudeCodeExecutable = claudePath;
-          }
-        }
+        // Let SDK use its built-in cli.js with expanded PATH from getExpandedPath()
 
         if (model) {
           queryOptions.model = model;

--- a/src/lib/provider-doctor.ts
+++ b/src/lib/provider-doctor.ts
@@ -6,7 +6,6 @@
  */
 
 import {
-  findClaudeBinary,
   getClaudeVersion,
   findAllClaudeBinaries,
   isWindows,
@@ -664,30 +663,7 @@ function sanitizeEnvForProbe(env: Record<string, string>): Record<string, string
   return clean;
 }
 
-/**
- * On Windows, resolve .cmd wrapper to the underlying .js script.
- */
-function resolveScriptFromCmd(cmdPath: string): string | undefined {
-  try {
-    const content = fs.readFileSync(cmdPath, 'utf-8');
-    const cmdDir = path.dirname(cmdPath);
-    const patterns = [
-      /"%~dp0\\([^"]*claude[^"]*\.js)"/i,
-      /%~dp0\\(\S*claude\S*\.js)/i,
-      /"%dp0%\\([^"]*claude[^"]*\.js)"/i,
-    ];
-    for (const re of patterns) {
-      const m = content.match(re);
-      if (m) {
-        const resolved = path.normalize(path.join(cmdDir, m[1]));
-        if (fs.existsSync(resolved)) return resolved;
-      }
-    }
-  } catch {
-    // ignore read errors
-  }
-  return undefined;
-}
+// Removed resolveScriptFromCmd() — let SDK use built-in cli.js with expanded PATH
 
 /**
  * Live probe — spawns a minimal Claude Code process to verify the
@@ -771,14 +747,7 @@ async function runLiveProbe(): Promise<ProbeResult> {
     stderr: stderrCallback,
   };
 
-  // Resolve executable path (handle Windows .cmd wrappers)
-  const ext = path.extname(claudePath).toLowerCase();
-  if (ext === '.cmd' || ext === '.bat') {
-    const scriptPath = resolveScriptFromCmd(claudePath);
-    if (scriptPath) queryOptions.pathToClaudeCodeExecutable = scriptPath;
-  } else {
-    queryOptions.pathToClaudeCodeExecutable = claudePath;
-  }
+  // Let SDK use its built-in cli.js with expanded PATH from getExpandedPath()
 
   // 6. Run the probe
   try {


### PR DESCRIPTION
## Problem

CodePilot on Windows fails with `spawn EINVAL` when using native Claude CLI installer. The root cause: setting `pathToClaudeCodeExecutable` to a `.cmd` path causes SDK to execute `node claude.cmd`, which Windows cannot handle.

## Solution

Remove all `pathToClaudeCodeExecutable` settings. Let SDK use its built-in `cli.js`, which correctly:
- Uses PATH to find `claude` command
- Executes `.cmd` files with proper shell handling

The `getExpandedPath()` function already extends PATH to include:
- `~/.local/bin` (native install)
- `~/.claude/bin` (native alt)
- `~/.bun/bin` (bun)
- `APPDATA/npm` (npm)

## Changes

- Delete `resolveScriptFromCmd()`, `findClaudePath()` functions
- Remove `pathToClaudeCodeExecutable` option from all SDK call sites
- ~100 lines removed, simpler and more reliable

## Verification

- ✅ PATH lookup finds `claude.cmd` at `~/.local/bin`
- ✅ Claude CLI v2.1.90 executes correctly
- ✅ SDK cli.js exists and will use PATH

Fixes #410
