### PR TITLE
fix: broaden Claude CLI discovery paths

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -484,19 +484,14 @@ function findGitBashSync(): boolean {
  */
 function getExpandedShellPath(): string {
   const home = os.homedir();
-  const shellPath = userShellEnv.PATH || process.env.PATH || '';
+  const shellEnv = { ...process.env, ...userShellEnv };
+  const shellPath = shellEnv.PATH || process.env.PATH || '';
   const sep = path.delimiter;
-  const pnpmHome = process.env.PNPM_HOME;
-  const voltaHome = process.env.VOLTA_HOME ? path.join(process.env.VOLTA_HOME, 'bin') : '';
+  const pnpmHome = shellEnv.PNPM_HOME;
+  const voltaHome = shellEnv.VOLTA_HOME ? path.join(shellEnv.VOLTA_HOME, 'bin') : '';
 
   const extraDirs = process.platform === 'win32'
     ? [
-        path.join(process.env.APPDATA || path.join(home, 'AppData', 'Roaming'), 'npm'),
-        path.join(process.env.LOCALAPPDATA || path.join(home, 'AppData', 'Local'), 'npm'),
-        path.join(process.env.APPDATA || path.join(home, 'AppData', 'Roaming'), 'pnpm'),
-        path.join(process.env.LOCALAPPDATA || path.join(home, 'AppData', 'Local'), 'pnpm'),
-        pnpmHome,
-        path.join(home, '.npm-global', 'bin'),
         path.join(home, '.local', 'bin'),
         path.join(home, '.claude', 'bin'),
         path.join(home, '.claude', 'local'),
@@ -507,17 +502,23 @@ function getExpandedShellPath(): string {
         path.join(home, '.fnm', 'current', 'bin'),
         path.join(home, '.nvm', 'current', 'bin'),
         path.join(home, '.asdf', 'shims'),
+        path.join(shellEnv.APPDATA || path.join(home, 'AppData', 'Roaming'), 'npm'),
+        path.join(shellEnv.LOCALAPPDATA || path.join(home, 'AppData', 'Local'), 'npm'),
+        path.join(shellEnv.APPDATA || path.join(home, 'AppData', 'Roaming'), 'pnpm'),
+        path.join(shellEnv.LOCALAPPDATA || path.join(home, 'AppData', 'Local'), 'pnpm'),
+        pnpmHome,
+        path.join(home, '.npm-global', 'bin'),
       ]
     : [
-        '/usr/local/bin',
-        '/opt/homebrew/bin',
-        '/usr/bin',
-        '/bin',
-        path.join(home, '.npm-global', 'bin'),
         path.join(home, '.local', 'bin'),
         path.join(home, '.claude', 'bin'),
         path.join(home, '.claude', 'local'),
         path.join(home, '.bun', 'bin'),
+        '/opt/homebrew/bin',
+        '/usr/local/bin',
+        '/usr/bin',
+        '/bin',
+        path.join(home, '.npm-global', 'bin'),
         path.join(home, '.yarn', 'bin'),
         path.join(home, '.config', 'yarn', 'global', 'node_modules', '.bin'),
         path.join(home, '.volta', 'bin'),
@@ -796,6 +797,7 @@ app.whenReady().then(async () => {
   ipcMain.handle('install:check-prerequisites', async () => {
     const expandedPath = getExpandedShellPath();
     const execEnv = { ...sanitizedProcessEnv(), ...userShellEnv, PATH: expandedPath };
+    const shellEnv = { ...process.env, ...userShellEnv };
 
     // Candidate paths — native first, then bun, then homebrew, then npm
     const home = os.homedir();
@@ -805,24 +807,26 @@ app.whenReady().then(async () => {
           path.join(home, '.claude', 'bin'),
           path.join(home, '.claude', 'local'),
           path.join(home, '.bun', 'bin'),
-          path.join(process.env.APPDATA || path.join(home, 'AppData', 'Roaming'), 'npm'),
-          path.join(process.env.LOCALAPPDATA || path.join(home, 'AppData', 'Local'), 'npm'),
-          path.join(process.env.APPDATA || path.join(home, 'AppData', 'Roaming'), 'pnpm'),
-          path.join(process.env.LOCALAPPDATA || path.join(home, 'AppData', 'Local'), 'pnpm'),
-          process.env.PNPM_HOME || '',
-          path.join(home, '.npm-global', 'bin'),
           path.join(home, '.yarn', 'bin'),
           path.join(home, '.config', 'yarn', 'global', 'node_modules', '.bin'),
-          process.env.VOLTA_HOME ? path.join(process.env.VOLTA_HOME, 'bin') : '',
+          shellEnv.VOLTA_HOME ? path.join(shellEnv.VOLTA_HOME, 'bin') : '',
           path.join(home, '.fnm', 'current', 'bin'),
           path.join(home, '.nvm', 'current', 'bin'),
           path.join(home, '.asdf', 'shims'),
+          path.join(shellEnv.APPDATA || path.join(home, 'AppData', 'Roaming'), 'npm'),
+          path.join(shellEnv.LOCALAPPDATA || path.join(home, 'AppData', 'Local'), 'npm'),
+          path.join(shellEnv.APPDATA || path.join(home, 'AppData', 'Roaming'), 'pnpm'),
+          path.join(shellEnv.LOCALAPPDATA || path.join(home, 'AppData', 'Local'), 'pnpm'),
+          shellEnv.PNPM_HOME || '',
+          path.join(home, '.npm-global', 'bin'),
         ]
       : [
           path.join(home, '.local', 'bin'),
           path.join(home, '.claude', 'bin'),
           path.join(home, '.claude', 'local'),
           path.join(home, '.bun', 'bin'),
+          '/opt/homebrew/bin',
+          '/usr/local/bin',
           path.join(home, '.npm-global', 'bin'),
           path.join(home, '.yarn', 'bin'),
           path.join(home, '.config', 'yarn', 'global', 'node_modules', '.bin'),
@@ -830,11 +834,9 @@ app.whenReady().then(async () => {
           path.join(home, '.fnm', 'current', 'bin'),
           path.join(home, '.nvm', 'current', 'bin'),
           path.join(home, '.asdf', 'shims'),
-          process.env.PNPM_HOME || '',
+          shellEnv.PNPM_HOME || '',
           path.join(home, '.local', 'share', 'pnpm'),
           ...(process.platform === 'darwin' ? [path.join(home, 'Library', 'pnpm')] : []),
-          '/opt/homebrew/bin',
-          '/usr/local/bin',
         ];
 
     const candidatePaths = process.platform === 'win32'
@@ -848,9 +850,17 @@ app.whenReady().then(async () => {
 
     function classifyPath(p: string): 'native' | 'homebrew' | 'npm' | 'bun' | 'unknown' {
       const n = p.replace(/\\/g, '/');
-      if (n.includes('/.local/bin/') || n.includes('/.claude/bin/')) return 'native';
+      if (n.includes('/.local/bin/') || n.includes('/.claude/bin/') || n.includes('/.claude/local/')) return 'native';
       if (n.includes('/.bun/bin/') || n.includes('/.bun/install/')) return 'bun';
       if (n.includes('/homebrew/') || n.includes('/Cellar/')) return 'homebrew';
+      if (n.includes('/Library/pnpm/')
+        || n.includes('/.local/share/pnpm/')
+        || n.includes('/.config/yarn/')
+        || n.includes('/.yarn/bin/')
+        || n.includes('/.volta/bin/')
+        || n.includes('/.fnm/current/bin/')
+        || n.includes('/.asdf/shims/')
+        || n.includes('/.nvm/current/bin/')) return 'npm';
       if (n.includes('/npm')) return 'npm';
       if (n === '/usr/local/bin/claude') {
         try {
@@ -860,6 +870,14 @@ app.whenReady().then(async () => {
           if (real.includes('.bun')) return 'bun';
         } catch { /* ignore */ }
         return 'unknown';
+      }
+      if (process.platform === 'win32') {
+        const appData = (shellEnv.APPDATA || '').replace(/\\/g, '/');
+        const localAppData = (shellEnv.LOCALAPPDATA || '').replace(/\\/g, '/');
+        if (appData && n.startsWith(appData + '/npm')) return 'npm';
+        if (localAppData && n.startsWith(localAppData + '/npm')) return 'npm';
+        if (appData && n.startsWith(appData + '/pnpm')) return 'npm';
+        if (localAppData && n.startsWith(localAppData + '/pnpm')) return 'npm';
       }
       return 'unknown';
     }

--- a/src/__tests__/unit/platform-claude-paths.test.ts
+++ b/src/__tests__/unit/platform-claude-paths.test.ts
@@ -23,6 +23,14 @@ describe('Claude path discovery helpers', () => {
 
     assert.ok(candidates.includes('/Users/tester/Library/pnpm/claude'));
     assert.ok(candidates.includes('/Users/tester/.claude/local/claude'));
+    assert.ok(
+      candidates.indexOf('/opt/homebrew/bin/claude') < candidates.indexOf('/Users/tester/Library/pnpm/claude'),
+      'homebrew candidates should stay ahead of npm-family shims',
+    );
+    assert.ok(
+      candidates.indexOf('/Users/tester/.claude/local/claude') < candidates.indexOf('/Users/tester/Library/pnpm/claude'),
+      'native compatibility wrappers should stay ahead of pnpm shims',
+    );
   });
 
   it('win32 search dirs include pnpm and claude local compatibility paths', () => {
@@ -47,5 +55,10 @@ describe('Claude path discovery helpers', () => {
 
     assert.ok(candidates.includes('C:\\Users\\tester\\AppData\\Local\\pnpm\\claude.cmd'));
     assert.ok(candidates.includes('C:\\Users\\tester\\.claude\\local\\claude.cmd'));
+    assert.ok(
+      candidates.indexOf('C:\\Users\\tester\\.claude\\local\\claude.cmd') <
+        candidates.indexOf('C:\\Users\\tester\\AppData\\Local\\pnpm\\claude.cmd'),
+      'native compatibility wrappers should stay ahead of pnpm shims on Windows',
+    );
   });
 });

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -65,23 +65,21 @@ export function getExtraPathDirs(): string[] {
   return getExtraPathDirsFor(process.platform, os.homedir(), process.env);
 }
 
-export function getExtraPathDirsFor(
+function getPathApiForPlatform(platform: NodeJS.Platform): typeof path.posix | typeof path.win32 {
+  return platform === 'win32' ? path.win32 : path.posix;
+}
+
+export function getClaudeSearchDirsFor(
   platform: NodeJS.Platform,
   home: string,
   env: NodeJS.ProcessEnv = process.env,
 ): string[] {
-  const pathApi = platform === 'win32' ? path.win32 : path.posix;
+  const pathApi = getPathApiForPlatform(platform);
   const pnpmHome = env.PNPM_HOME;
   const voltaHome = env.VOLTA_HOME ? pathApi.join(env.VOLTA_HOME, 'bin') : undefined;
 
-  const extras = platform === 'win32'
+  const dirs = platform === 'win32'
     ? [
-        pathApi.join(env.APPDATA || pathApi.join(home, 'AppData', 'Roaming'), 'npm'),
-        pathApi.join(env.LOCALAPPDATA || pathApi.join(home, 'AppData', 'Local'), 'npm'),
-        pathApi.join(env.APPDATA || pathApi.join(home, 'AppData', 'Roaming'), 'pnpm'),
-        pathApi.join(env.LOCALAPPDATA || pathApi.join(home, 'AppData', 'Local'), 'pnpm'),
-        pnpmHome,
-        pathApi.join(home, '.npm-global', 'bin'),
         pathApi.join(home, '.local', 'bin'),
         pathApi.join(home, '.claude', 'bin'),
         pathApi.join(home, '.claude', 'local'),
@@ -92,12 +90,22 @@ export function getExtraPathDirsFor(
         pathApi.join(home, '.fnm', 'current', 'bin'),
         pathApi.join(home, '.nvm', 'current', 'bin'),
         pathApi.join(home, '.asdf', 'shims'),
+        pathApi.join(env.APPDATA || pathApi.join(home, 'AppData', 'Roaming'), 'npm'),
+        pathApi.join(env.LOCALAPPDATA || pathApi.join(home, 'AppData', 'Local'), 'npm'),
+        pathApi.join(env.APPDATA || pathApi.join(home, 'AppData', 'Roaming'), 'pnpm'),
+        pathApi.join(env.LOCALAPPDATA || pathApi.join(home, 'AppData', 'Local'), 'pnpm'),
+        pnpmHome,
+        pathApi.join(home, '.npm-global', 'bin'),
       ]
     : [
         pathApi.join(home, '.local', 'bin'),
         pathApi.join(home, '.claude', 'bin'),
         pathApi.join(home, '.claude', 'local'),
         pathApi.join(home, '.bun', 'bin'),
+        '/opt/homebrew/bin',
+        '/usr/local/bin',
+        '/usr/bin',
+        '/bin',
         pathApi.join(home, '.npm-global', 'bin'),
         pathApi.join(home, '.yarn', 'bin'),
         pathApi.join(home, '.config', 'yarn', 'global', 'node_modules', '.bin'),
@@ -108,13 +116,17 @@ export function getExtraPathDirsFor(
         pnpmHome,
         pathApi.join(home, '.local', 'share', 'pnpm'),
         ...(platform === 'darwin' ? [pathApi.join(home, 'Library', 'pnpm')] : []),
-        '/usr/local/bin',
-        '/opt/homebrew/bin',
-        '/usr/bin',
-        '/bin',
       ];
 
-  return [...new Set(extras.filter((dir): dir is string => !!dir))];
+  return [...new Set(dirs.filter((dir): dir is string => !!dir))];
+}
+
+export function getExtraPathDirsFor(
+  platform: NodeJS.Platform,
+  home: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string[] {
+  return getClaudeSearchDirsFor(platform, home, env);
 }
 
 export function getClaudeCandidatePathsFor(
@@ -122,8 +134,8 @@ export function getClaudeCandidatePathsFor(
   home: string,
   env: NodeJS.ProcessEnv = process.env,
 ): string[] {
-  const pathApi = platform === 'win32' ? path.win32 : path.posix;
-  const dirs = getExtraPathDirsFor(platform, home, env);
+  const pathApi = getPathApiForPlatform(platform);
+  const dirs = getClaudeSearchDirsFor(platform, home, env);
   if (platform === 'win32') {
     const exts = ['.cmd', '.exe', '.bat', ''];
     const candidates: string[] = [];


### PR DESCRIPTION
关联 Issue / Related Issue: closes #432

## Summary / 概述

This PR broadens Claude CLI discovery so CodePilot can find installations that come from pnpm-style wrappers and other compatibility locations, instead of only a smaller hard-coded path set.

这个 PR 扩展了 Claude CLI 的查找逻辑，让 CodePilot 能识别 pnpm 风格包装路径和其他兼容安装位置，而不再只依赖较少的一组硬编码路径。

## Root cause / 根因

CodePilot previously checked only a subset of native, bun, homebrew, and npm paths. That missed several directories that are now common in real user environments, especially on macOS.

之前 CodePilot 只检查了部分 native、bun、homebrew、npm 路径，因此遗漏了如今用户环境里常见的若干目录，尤其是 macOS。

## Changes / 修改内容

- expand shared PATH helper coverage to include `~/.claude/local`, pnpm home directories, Yarn global bins, and Node manager shims
- add a reusable `getClaudeCandidatePathsFor()` helper to make path generation easier to test across platforms
- update Electron-side install detection to use the broader search directories and candidate executable list
- classify pnpm/yarn/manager shim installs as the npm-family channel for UI reporting consistency
- add focused unit tests covering macOS and Windows candidate generation

- 扩展共享 PATH 辅助逻辑，纳入 `~/.claude/local`、pnpm 目录、Yarn 全局 bin 与 Node 管理器 shim
- 新增可复用的 `getClaudeCandidatePathsFor()`，便于跨平台测试候选路径生成
- 更新 Electron 侧安装检测逻辑，使用更完整的搜索目录与候选可执行文件集合
- 将 pnpm/yarn/管理器 shim 安装统一归类到 npm-family，保持 UI 展示一致
- 增加针对 macOS 和 Windows 的聚焦单元测试

## Test plan / 测试情况

- [x] `npm run typecheck`
- [x] `npx tsx --test src/__tests__/unit/platform-claude-paths.test.ts`
- [ ] manual verification on a real macOS pnpm environment

## Notes / 说明

- I also checked `npm run test:unit` locally on Windows, but there are existing unrelated `ERR_UNSUPPORTED_ESM_URL_SCHEME` failures in other test files. This PR does not change that behavior.
- 我也在 Windows 上额外检查了 `npm run test:unit`，但当前仓库里还有与本 PR 无关的 `ERR_UNSUPPORTED_ESM_URL_SCHEME` 旧失败，本 PR 未涉及该问题。
