### PR TITLE
fix: persist elapsed timer across session switches

### DIFF
--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -651,6 +651,7 @@ export function ChatView({ sessionId, initialMessages = [], initialHasMore = fal
         onLoadMore={loadEarlierMessages}
         rewindPoints={rewindPoints}
         sessionId={sessionId}
+        startedAt={streamSnapshot?.startedAt}
         isAssistantProject={isAssistantProject}
         assistantName={assistantName}
       />

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -317,7 +317,7 @@ export function MessageList({
             content={streamingContent}
             isStreaming={isStreaming}
             sessionId={sessionId}
-            startedAt={startedAt}
+            startedAt={startedAt!}
             toolUses={toolUses}
             toolResults={toolResults}
             streamingToolOutput={streamingToolOutput}

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -172,6 +172,7 @@ interface MessageListProps {
   /** SDK rewind points — only emitted for visible prompt-level user messages (not tool results or auto-triggers), mapped by position */
   rewindPoints?: RewindPoint[];
   sessionId?: string;
+  startedAt?: number;
   /** Whether this is an assistant workspace project */
   isAssistantProject?: boolean;
   /** Assistant name for avatar display */
@@ -193,6 +194,7 @@ export function MessageList({
   onLoadMore,
   rewindPoints = [],
   sessionId,
+  startedAt,
   isAssistantProject,
   assistantName,
 }: MessageListProps) {
@@ -315,6 +317,7 @@ export function MessageList({
             content={streamingContent}
             isStreaming={isStreaming}
             sessionId={sessionId}
+            startedAt={startedAt}
             toolUses={toolUses}
             toolResults={toolResults}
             streamingToolOutput={streamingToolOutput}

--- a/src/components/chat/StreamingMessage.tsx
+++ b/src/components/chat/StreamingMessage.tsx
@@ -106,7 +106,7 @@ interface StreamingMessageProps {
   content: string;
   isStreaming: boolean;
   sessionId?: string;
-  startedAt?: number;
+  startedAt: number;
   toolUses?: ToolUseInfo[];
   toolResults?: ToolResultInfo[];
   streamingToolOutput?: string;
@@ -200,6 +200,11 @@ function ThinkingPhaseLabel() {
 function ElapsedTimer({ startedAt }: { startedAt: number }) {
   const [elapsed, setElapsed] = useState(() => Math.floor((Date.now() - startedAt) / 1000));
 
+  // Reset elapsed when the stream start time changes (e.g. new turn or session switch)
+  useEffect(() => {
+    setElapsed(Math.floor((Date.now() - startedAt) / 1000));
+  }, [startedAt]);
+
   useEffect(() => {
     const interval = setInterval(() => {
       setElapsed(Math.floor((Date.now() - startedAt) / 1000));
@@ -217,7 +222,7 @@ function ElapsedTimer({ startedAt }: { startedAt: number }) {
   );
 }
 
-function StreamingStatusBar({ statusText, onForceStop, startedAt }: { statusText?: string; onForceStop?: () => void; startedAt?: number }) {
+function StreamingStatusBar({ statusText, onForceStop, startedAt }: { statusText?: string; onForceStop?: () => void; startedAt: number }) {
   const displayText = statusText || 'Thinking';
 
   // Parse elapsed seconds from statusText like "Running bash... (45s)"
@@ -240,7 +245,7 @@ function StreamingStatusBar({ statusText, onForceStop, startedAt }: { statusText
         )}
       </div>
       <span className="text-muted-foreground/50">|</span>
-      <ElapsedTimer startedAt={startedAt ?? Date.now()} />
+      <ElapsedTimer startedAt={startedAt} />
       {isCritical && onForceStop && (
         <Button
           variant="outline"

--- a/src/components/chat/StreamingMessage.tsx
+++ b/src/components/chat/StreamingMessage.tsx
@@ -106,6 +106,7 @@ interface StreamingMessageProps {
   content: string;
   isStreaming: boolean;
   sessionId?: string;
+  startedAt?: number;
   toolUses?: ToolUseInfo[];
   toolResults?: ToolResultInfo[];
   streamingToolOutput?: string;
@@ -196,17 +197,15 @@ function ThinkingPhaseLabel() {
   return <Shimmer>{text}</Shimmer>;
 }
 
-function ElapsedTimer() {
-  const [elapsed, setElapsed] = useState(0);
-  const startRef = useRef(0);
+function ElapsedTimer({ startedAt }: { startedAt: number }) {
+  const [elapsed, setElapsed] = useState(() => Math.floor((Date.now() - startedAt) / 1000));
 
   useEffect(() => {
-    startRef.current = Date.now();
     const interval = setInterval(() => {
-      setElapsed(Math.floor((Date.now() - startRef.current) / 1000));
+      setElapsed(Math.floor((Date.now() - startedAt) / 1000));
     }, 1000);
     return () => clearInterval(interval);
-  }, []);
+  }, [startedAt]);
 
   const mins = Math.floor(elapsed / 60);
   const secs = elapsed % 60;
@@ -218,7 +217,7 @@ function ElapsedTimer() {
   );
 }
 
-function StreamingStatusBar({ statusText, onForceStop }: { statusText?: string; onForceStop?: () => void }) {
+function StreamingStatusBar({ statusText, onForceStop, startedAt }: { statusText?: string; onForceStop?: () => void; startedAt?: number }) {
   const displayText = statusText || 'Thinking';
 
   // Parse elapsed seconds from statusText like "Running bash... (45s)"
@@ -241,7 +240,7 @@ function StreamingStatusBar({ statusText, onForceStop }: { statusText?: string; 
         )}
       </div>
       <span className="text-muted-foreground/50">|</span>
-      <ElapsedTimer />
+      <ElapsedTimer startedAt={startedAt ?? Date.now()} />
       {isCritical && onForceStop && (
         <Button
           variant="outline"
@@ -260,6 +259,7 @@ export function StreamingMessage({
   content,
   isStreaming,
   sessionId,
+  startedAt,
   toolUses = [],
   toolResults = [],
   streamingToolOutput,
@@ -542,7 +542,7 @@ export function StreamingMessage({
             return t('widget.streaming');
           })() : undefined)
           || (content && content.length > 0 ? t('streaming.generating') : undefined)
-        } onForceStop={onForceStop} />}
+        } onForceStop={onForceStop} startedAt={startedAt} />}
       </MessageContent>
     </AIMessage>
   );


### PR DESCRIPTION
**CodePilot 版本：** v0.50.1

## 问题描述

在侧边栏切换 Session 后再切回来，底部流式回复的计时器会从 `0s` 重新开始计数。期望它应该基于真实的流累计时长展示，不因切换而重置。

## 根因

`ElapsedTimer` 在 `StreamingMessage.tsx` 里 mount 时用本地 `Date.now()` 记录开始时间。切换 Session 导致 `ChatView`（连带 `StreamingMessage`）unmount/remount，计时器就归零了。

## 修复

`stream-session-manager` 的 `SessionStreamSnapshot` 已包含 `startedAt` 字段，记录流的真实开始时间。现在把它从组件树顶层一路透传到底层：

`ChatView` → `MessageList` → `StreamingMessage` → `StreamingStatusBar` → `ElapsedTimer`

`ElapsedTimer` 改为基于传入的 `startedAt` 计算 elapsed，组件 remount 后仍能恢复正确的累计时长。

## 改动文件

| 文件 | 改动 |
|------|------|
| `src/components/chat/ChatView.tsx` | 将 `streamSnapshot.startedAt` 传给 `MessageList` |
| `src/components/chat/MessageList.tsx` | 新增 `startedAt` prop 并透传给 `StreamingMessage` |
| `src/components/chat/StreamingMessage.tsx` | `StreamingStatusBar` / `ElapsedTimer` 接收 `startedAt` 并基于它计算 |

## 验证方式

- [ ] 进入某个 Session 开始流式回复，等底部计时器走几秒
- [ ] 切换到另一个 Session，再切回来
- [ ] 计时器应从之前的累计时间继续，而不是从 0 重置
- [ ] 单 Session 内的正常流式行为无变化
- [ ] `npm run test` 通过（typecheck + 单元测试）

> **修复前后对比**：

<img width="1100" height="949" alt="切换会话后，计时器重新归零" src="https://github.com/user-attachments/assets/74175e93-c6f4-4b02-ba7f-0004e3544b46" />
<img width="960" height="629" alt="修复录像 - 计时器正确显示" src="https://github.com/user-attachments/assets/16b1b574-e4ce-4629-99c6-947ab422ca69" />


