### PR TITLE
fix: retain existing input text when selecting slash commands with optional details

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1385,7 +1385,8 @@ app.whenReady().then(async () => {
     let port: number;
 
     if (isDev) {
-      port = process.env.PORT ? parseInt(process.env.PORT, 10) : 3000;
+      const envPort = process.env.PORT ? parseInt(process.env.PORT, 10) : NaN;
+      port = Number.isNaN(envPort) ? 3000 : envPort;
       console.log(`Dev mode: connecting to http://127.0.0.1:${port}`);
       serverPort = port;
       createWindow(`http://127.0.0.1:${port}`);

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1385,7 +1385,7 @@ app.whenReady().then(async () => {
     let port: number;
 
     if (isDev) {
-      port = 3000;
+      port = process.env.PORT ? parseInt(process.env.PORT, 10) : 3000;
       console.log(`Dev mode: connecting to http://127.0.0.1:${port}`);
       serverPort = port;
       createWindow(`http://127.0.0.1:${port}`);

--- a/src/hooks/useSlashCommands.ts
+++ b/src/hooks/useSlashCommands.ts
@@ -196,7 +196,7 @@ export function useSlashCommands(opts: {
         // Block during streaming — badges dispatch as slash/skill prompts, not queueable
         if (isStreaming) { closePopover(); return; }
         setBadge(result.badge!);
-        setInputValue('');
+        setInputValue(result.newInputValue ?? '');
         closePopover();
         setTimeout(() => textareaRef.current?.focus(), 0);
         return;

--- a/src/hooks/useSlashCommands.ts
+++ b/src/hooks/useSlashCommands.ts
@@ -198,7 +198,13 @@ export function useSlashCommands(opts: {
         setBadge(result.badge!);
         setInputValue(result.newInputValue ?? '');
         closePopover();
-        setTimeout(() => textareaRef.current?.focus(), 0);
+        setTimeout(() => {
+          const el = textareaRef.current;
+          if (!el) return;
+          el.focus();
+          const pos = el.value.length;
+          el.setSelectionRange(pos, pos);
+        }, 0);
         return;
 
       case 'insert_file_mention':

--- a/src/lib/message-input-logic.ts
+++ b/src/lib/message-input-logic.ts
@@ -100,8 +100,11 @@ export function resolveItemSelection(
     return { action: 'immediate_command', commandValue: item.value };
   }
 
-  // Non-immediate commands: show as badge
+  // Non-immediate commands: show as badge, preserving any text outside the trigger
   if (popoverMode === 'skill') {
+    const before = inputValue.slice(0, triggerPos);
+    const cursorEnd = triggerPos + popoverFilter.length + 1;
+    const after = inputValue.slice(cursorEnd);
     return {
       action: 'set_badge',
       badge: {
@@ -111,6 +114,7 @@ export function resolveItemSelection(
         kind: item.kind || 'slash_command',
         installedSource: item.installedSource,
       },
+      newInputValue: before + after,
     };
   }
 

--- a/src/lib/message-input-logic.ts
+++ b/src/lib/message-input-logic.ts
@@ -85,6 +85,21 @@ export function filterItems(items: PopoverItem[], filter: string): PopoverItem[]
 }
 
 /**
+ * Splits input text around a popover trigger, removing the trigger character
+ * and any filter text that was typed after it.
+ */
+function splitAroundTrigger(
+  inputValue: string,
+  triggerPos: number,
+  popoverFilter: string,
+): { before: string; after: string } {
+  const before = inputValue.slice(0, triggerPos);
+  const cursorEnd = triggerPos + popoverFilter.length + 1; // +1 to consume the trigger character
+  const after = inputValue.slice(cursorEnd);
+  return { before, after };
+}
+
+/**
  * Determines what happens when an item is selected from the popover.
  * Used by insertItem in useSlashCommands.
  */
@@ -102,9 +117,7 @@ export function resolveItemSelection(
 
   // Non-immediate commands: show as badge, preserving any text outside the trigger
   if (popoverMode === 'skill') {
-    const before = inputValue.slice(0, triggerPos);
-    const cursorEnd = triggerPos + popoverFilter.length + 1;
-    const after = inputValue.slice(cursorEnd);
+    const { before, after } = splitAroundTrigger(inputValue, triggerPos, popoverFilter);
     return {
       action: 'set_badge',
       badge: {
@@ -119,9 +132,7 @@ export function resolveItemSelection(
   }
 
   // File mention: insert into text
-  const before = inputValue.slice(0, triggerPos);
-  const cursorEnd = triggerPos + popoverFilter.length + 1;
-  const after = inputValue.slice(cursorEnd);
+  const { before, after } = splitAroundTrigger(inputValue, triggerPos, popoverFilter);
   const insertText = `@${item.value} `;
   return {
     action: 'insert_file_mention',


### PR DESCRIPTION
**CodePilot 版本：** v0.50.1

## 问题描述

在输入框中已经输入了一段文字后，如果选择带有 "Add details (optional)" 的斜杠命令（badge 类命令），输入框内的所有内容会被直接清空。期望已有文本应作为 details 内容保留下来。

## 根因

`message-input-logic.ts` 的 `resolveItemSelection` 在返回 `action: 'set_badge'` 时没有带上 `newInputValue`。`useSlashCommands.ts` 的调用方直接硬编码了 `setInputValue('')`，导致无论用户之前打了什么字都被清空。

## 修复

1. **`src/lib/message-input-logic.ts`** — 在 `set_badge` 分支里计算 `newInputValue`：去掉 `/` 触发符和过滤文本，保留触发位置前后的用户输入内容。
2. **`src/hooks/useSlashCommands.ts`** — 用 `result.newInputValue` 回填输入框，并将光标自动定位到文本末尾，方便用户继续输入 details。

immediate 命令（如 `/clear`、`/help`）的行为保持不变，不受影响。

## 改动文件

| 文件 | 改动 |
|------|------|
| `src/lib/message-input-logic.ts` | `set_badge` 分支计算并返回 `newInputValue` |
| `src/hooks/useSlashCommands.ts` | 回填 `newInputValue` 并将光标移到末尾 |

## 验证方式

- [ ] 在输入框里输入一段文字，然后输入 `/` 触发面板
- [ ] 选择一个 badge 类命令（如某个 skill）— 原有文字应保留，badge 显示在输入框上方
- [ ] 光标应自动定位到保留文本的末尾
- [ ] immediate 命令（如 `/clear`）仍正常清空输入
- [ ] `npm run test` 通过（typecheck + 单元测试）

> **修复前后对比**:

<img width="1062" height="830" alt="斜杠命令清空输入框" src="https://github.com/user-attachments/assets/ac8974a4-bfb6-482d-ab14-8f38b8f57d45" />
<img width="960" height="718" alt="修复录像 - 添加 skills 后不清除内容" src="https://github.com/user-attachments/assets/f810d912-38cf-41cc-bfff-781e895876bc" />
