### PR TITLE
feat: global search panel with sessions/messages/files support

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1385,7 +1385,8 @@ app.whenReady().then(async () => {
     let port: number;
 
     if (isDev) {
-      port = process.env.PORT ? parseInt(process.env.PORT, 10) : 3000;
+      const envPort = process.env.PORT ? parseInt(process.env.PORT, 10) : NaN;
+      port = Number.isNaN(envPort) ? 3000 : envPort;
       console.log(`Dev mode: connecting to http://127.0.0.1:${port}`);
       serverPort = port;
       createWindow(`http://127.0.0.1:${port}`);

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1385,7 +1385,7 @@ app.whenReady().then(async () => {
     let port: number;
 
     if (isDev) {
-      port = 3000;
+      port = process.env.PORT ? parseInt(process.env.PORT, 10) : 3000;
       console.log(`Dev mode: connecting to http://127.0.0.1:${port}`);
       serverPort = port;
       createWindow(`http://127.0.0.1:${port}`);

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -1,0 +1,144 @@
+import { NextRequest } from 'next/server';
+import { getAllSessions, searchMessages } from '@/lib/db';
+import { scanDirectory } from '@/lib/files';
+import type { ChatSession, FileTreeNode } from '@/types';
+
+const FILE_SCAN_DEPTH = 2;
+const MAX_RESULTS_PER_TYPE = 10;
+
+interface SearchResultSession {
+  type: 'session';
+  id: string;
+  title: string;
+  projectName: string;
+  updatedAt: string;
+}
+
+interface SearchResultMessage {
+  type: 'message';
+  sessionId: string;
+  sessionTitle: string;
+  messageId: string;
+  role: 'user' | 'assistant';
+  snippet: string;
+  createdAt: string;
+}
+
+interface SearchResultFile {
+  type: 'file';
+  sessionId: string;
+  sessionTitle: string;
+  path: string;
+  name: string;
+}
+
+export interface SearchResponse {
+  sessions: SearchResultSession[];
+  messages: SearchResultMessage[];
+  files: SearchResultFile[];
+}
+
+function parseQuery(raw: string): { scope: 'all' | 'sessions' | 'messages' | 'files'; query: string } {
+  const trimmed = raw.trim();
+  if (trimmed.toLowerCase().startsWith('sessions:')) {
+    return { scope: 'sessions', query: trimmed.slice(9).trim() };
+  }
+  if (trimmed.toLowerCase().startsWith('messages:')) {
+    return { scope: 'messages', query: trimmed.slice(9).trim() };
+  }
+  if (trimmed.toLowerCase().startsWith('files:')) {
+    return { scope: 'files', query: trimmed.slice(6).trim() };
+  }
+  return { scope: 'all', query: trimmed };
+}
+
+function filterSessions(sessions: ChatSession[], query: string): SearchResultSession[] {
+  const q = query.toLowerCase();
+  return sessions
+    .filter(
+      (s) =>
+        s.title.toLowerCase().includes(q) ||
+        s.project_name.toLowerCase().includes(q),
+    )
+    .slice(0, MAX_RESULTS_PER_TYPE)
+    .map((s) => ({
+      type: 'session' as const,
+      id: s.id,
+      title: s.title,
+      projectName: s.project_name,
+      updatedAt: s.updated_at,
+    }));
+}
+
+function collectFiles(
+  tree: FileTreeNode[],
+  sessionId: string,
+  sessionTitle: string,
+  query: string,
+  results: SearchResultFile[],
+): void {
+  if (results.length >= MAX_RESULTS_PER_TYPE) return;
+  const q = query.toLowerCase();
+  for (const node of tree) {
+    if (results.length >= MAX_RESULTS_PER_TYPE) break;
+    if (node.type === 'file' && node.name.toLowerCase().includes(q)) {
+      results.push({
+        type: 'file',
+        sessionId,
+        sessionTitle,
+        path: node.path,
+        name: node.name,
+      });
+    }
+    if (node.type === 'directory' && node.children) {
+      collectFiles(node.children, sessionId, sessionTitle, query, results);
+    }
+  }
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const rawQuery = searchParams.get('q') || '';
+    const { scope, query } = parseQuery(rawQuery);
+
+    if (!query) {
+      return Response.json({ sessions: [], messages: [], files: [] });
+    }
+
+    const allSessions = getAllSessions();
+    const result: SearchResponse = { sessions: [], messages: [], files: [] };
+
+    if (scope === 'all' || scope === 'sessions') {
+      result.sessions = filterSessions(allSessions, query);
+    }
+
+    if (scope === 'all' || scope === 'messages') {
+      const messageRows = searchMessages(query, { limit: MAX_RESULTS_PER_TYPE });
+      result.messages = messageRows.map((r) => ({
+        type: 'message' as const,
+        sessionId: r.sessionId,
+        sessionTitle: r.sessionTitle,
+        messageId: r.messageId,
+        role: r.role,
+        snippet: r.snippet,
+        createdAt: r.createdAt,
+      }));
+    }
+
+    if (scope === 'files') {
+      for (const session of allSessions) {
+        if (!session.working_directory) continue;
+        const tree = await scanDirectory(session.working_directory, FILE_SCAN_DEPTH);
+        collectFiles(tree, session.id, session.title, query, result.files);
+        if (result.files.length >= MAX_RESULTS_PER_TYPE) break;
+      }
+    }
+
+    return Response.json(result);
+  } catch (error) {
+    const message = error instanceof Error ? error.stack || error.message : String(error);
+    console.error('[GET /api/search] Error:', message);
+    return Response.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -651,6 +651,7 @@ export function ChatView({ sessionId, initialMessages = [], initialHasMore = fal
         onLoadMore={loadEarlierMessages}
         rewindPoints={rewindPoints}
         sessionId={sessionId}
+        startedAt={streamSnapshot?.startedAt}
         isAssistantProject={isAssistantProject}
         assistantName={assistantName}
       />

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -317,7 +317,7 @@ export function MessageList({
             content={streamingContent}
             isStreaming={isStreaming}
             sessionId={sessionId}
-            startedAt={startedAt}
+            startedAt={startedAt!}
             toolUses={toolUses}
             toolResults={toolResults}
             streamingToolOutput={streamingToolOutput}

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -172,6 +172,7 @@ interface MessageListProps {
   /** SDK rewind points — only emitted for visible prompt-level user messages (not tool results or auto-triggers), mapped by position */
   rewindPoints?: RewindPoint[];
   sessionId?: string;
+  startedAt?: number;
   /** Whether this is an assistant workspace project */
   isAssistantProject?: boolean;
   /** Assistant name for avatar display */
@@ -193,6 +194,7 @@ export function MessageList({
   onLoadMore,
   rewindPoints = [],
   sessionId,
+  startedAt,
   isAssistantProject,
   assistantName,
 }: MessageListProps) {
@@ -315,6 +317,7 @@ export function MessageList({
             content={streamingContent}
             isStreaming={isStreaming}
             sessionId={sessionId}
+            startedAt={startedAt}
             toolUses={toolUses}
             toolResults={toolResults}
             streamingToolOutput={streamingToolOutput}

--- a/src/components/chat/StreamingMessage.tsx
+++ b/src/components/chat/StreamingMessage.tsx
@@ -106,7 +106,7 @@ interface StreamingMessageProps {
   content: string;
   isStreaming: boolean;
   sessionId?: string;
-  startedAt?: number;
+  startedAt: number;
   toolUses?: ToolUseInfo[];
   toolResults?: ToolResultInfo[];
   streamingToolOutput?: string;
@@ -200,6 +200,11 @@ function ThinkingPhaseLabel() {
 function ElapsedTimer({ startedAt }: { startedAt: number }) {
   const [elapsed, setElapsed] = useState(() => Math.floor((Date.now() - startedAt) / 1000));
 
+  // Reset elapsed when the stream start time changes (e.g. new turn or session switch)
+  useEffect(() => {
+    setElapsed(Math.floor((Date.now() - startedAt) / 1000));
+  }, [startedAt]);
+
   useEffect(() => {
     const interval = setInterval(() => {
       setElapsed(Math.floor((Date.now() - startedAt) / 1000));
@@ -217,7 +222,7 @@ function ElapsedTimer({ startedAt }: { startedAt: number }) {
   );
 }
 
-function StreamingStatusBar({ statusText, onForceStop, startedAt }: { statusText?: string; onForceStop?: () => void; startedAt?: number }) {
+function StreamingStatusBar({ statusText, onForceStop, startedAt }: { statusText?: string; onForceStop?: () => void; startedAt: number }) {
   const displayText = statusText || 'Thinking';
 
   // Parse elapsed seconds from statusText like "Running bash... (45s)"
@@ -240,7 +245,7 @@ function StreamingStatusBar({ statusText, onForceStop, startedAt }: { statusText
         )}
       </div>
       <span className="text-muted-foreground/50">|</span>
-      <ElapsedTimer startedAt={startedAt ?? Date.now()} />
+      <ElapsedTimer startedAt={startedAt} />
       {isCritical && onForceStop && (
         <Button
           variant="outline"

--- a/src/components/chat/StreamingMessage.tsx
+++ b/src/components/chat/StreamingMessage.tsx
@@ -106,6 +106,7 @@ interface StreamingMessageProps {
   content: string;
   isStreaming: boolean;
   sessionId?: string;
+  startedAt?: number;
   toolUses?: ToolUseInfo[];
   toolResults?: ToolResultInfo[];
   streamingToolOutput?: string;
@@ -196,17 +197,15 @@ function ThinkingPhaseLabel() {
   return <Shimmer>{text}</Shimmer>;
 }
 
-function ElapsedTimer() {
-  const [elapsed, setElapsed] = useState(0);
-  const startRef = useRef(0);
+function ElapsedTimer({ startedAt }: { startedAt: number }) {
+  const [elapsed, setElapsed] = useState(() => Math.floor((Date.now() - startedAt) / 1000));
 
   useEffect(() => {
-    startRef.current = Date.now();
     const interval = setInterval(() => {
-      setElapsed(Math.floor((Date.now() - startRef.current) / 1000));
+      setElapsed(Math.floor((Date.now() - startedAt) / 1000));
     }, 1000);
     return () => clearInterval(interval);
-  }, []);
+  }, [startedAt]);
 
   const mins = Math.floor(elapsed / 60);
   const secs = elapsed % 60;
@@ -218,7 +217,7 @@ function ElapsedTimer() {
   );
 }
 
-function StreamingStatusBar({ statusText, onForceStop }: { statusText?: string; onForceStop?: () => void }) {
+function StreamingStatusBar({ statusText, onForceStop, startedAt }: { statusText?: string; onForceStop?: () => void; startedAt?: number }) {
   const displayText = statusText || 'Thinking';
 
   // Parse elapsed seconds from statusText like "Running bash... (45s)"
@@ -241,7 +240,7 @@ function StreamingStatusBar({ statusText, onForceStop }: { statusText?: string; 
         )}
       </div>
       <span className="text-muted-foreground/50">|</span>
-      <ElapsedTimer />
+      <ElapsedTimer startedAt={startedAt ?? Date.now()} />
       {isCritical && onForceStop && (
         <Button
           variant="outline"
@@ -260,6 +259,7 @@ export function StreamingMessage({
   content,
   isStreaming,
   sessionId,
+  startedAt,
   toolUses = [],
   toolResults = [],
   streamingToolOutput,
@@ -542,7 +542,7 @@ export function StreamingMessage({
             return t('widget.streaming');
           })() : undefined)
           || (content && content.length > 0 ? t('streaming.generating') : undefined)
-        } onForceStop={onForceStop} />}
+        } onForceStop={onForceStop} startedAt={startedAt} />}
       </MessageContent>
     </AIMessage>
   );

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -25,6 +25,8 @@ import { useGitStatus } from "@/hooks/useGitStatus";
 import { SetupCenter } from '@/components/setup/SetupCenter';
 import { Toaster } from '@/components/ui/toast';
 import { useNotificationPoll } from '@/hooks/useNotificationPoll';
+import { useGlobalSearchShortcut } from '@/hooks/useGlobalSearchShortcut';
+import { GlobalSearchDialog } from './GlobalSearchDialog';
 
 const SPLIT_SESSIONS_KEY = "codepilot:split-sessions";
 const SPLIT_ACTIVE_COLUMN_KEY = "codepilot:split-active-column";
@@ -76,6 +78,9 @@ export function AppShell({ children }: { children: React.ReactNode }) {
   const [chatListOpenRaw, setChatListOpenRaw] = useState(false);
   const [setupOpen, setSetupOpen] = useState(false);
   const [setupInitialCard, setSetupInitialCard] = useState<'claude' | 'provider' | 'project' | undefined>();
+  const [searchOpen, setSearchOpen] = useState(false);
+
+  useGlobalSearchShortcut(() => setSearchOpen(true));
 
   // Poll server-side notification queue and display as toasts
   useNotificationPoll();
@@ -101,6 +106,13 @@ export function AppShell({ children }: { children: React.ReactNode }) {
     };
     window.addEventListener('open-setup-center', handler);
     return () => window.removeEventListener('open-setup-center', handler);
+  }, []);
+
+  // Listen for open-global-search events from ChatListPanel
+  useEffect(() => {
+    const handler = () => setSearchOpen(true);
+    window.addEventListener('open-global-search', handler);
+    return () => window.removeEventListener('open-global-search', handler);
   }, []);
 
   // Sync with viewport after hydration to avoid SSR mismatch
@@ -463,6 +475,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
           <UpdateDialog />
           <FeatureAnnouncementDialog />
           <Toaster />
+          <GlobalSearchDialog open={searchOpen} onOpenChange={setSearchOpen} />
           {setupOpen && (
             <SetupCenter
               onClose={() => setSetupOpen(false)}

--- a/src/components/layout/ChatListPanel.tsx
+++ b/src/components/layout/ChatListPanel.tsx
@@ -17,12 +17,7 @@ import {
   Gear,
 } from "@/components/ui/icon";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import {
-  Dialog,
-  DialogContent,
-} from "@/components/ui/dialog";
 import {
   Tooltip,
   TooltipContent,
@@ -68,8 +63,6 @@ export function ChatListPanel({ open, width, hasUpdate, readyToInstall }: ChatLi
   const [sessions, setSessions] = useState<ChatSession[]>([]);
   const [hoveredSession, setHoveredSession] = useState<string | null>(null);
   const [deletingSession, setDeletingSession] = useState<string | null>(null);
-  const [searchQuery, setSearchQuery] = useState("");
-  const [searchDialogOpen, setSearchDialogOpen] = useState(false);
   const [expandedSessionGroups, setExpandedSessionGroups] = useState<Set<string>>(new Set());
   const SESSION_TRUNCATE_LIMIT = 10;
   // importDialogOpen removed — Import CLI moved to Settings
@@ -376,29 +369,18 @@ export function ChatListPanel({ open, width, hasUpdate, readyToInstall }: ChatLi
     }
   };
 
-  const isSearching = searchQuery.length > 0;
-
   const splitSessionIds = useMemo(
     () => new Set(splitSessions.map((s) => s.sessionId)),
     [splitSessions]
   );
 
   const filteredSessions = useMemo(() => {
-    let result = sessions;
-    if (searchQuery) {
-      result = result.filter(
-        (s) =>
-          s.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
-          (s.project_name &&
-            s.project_name.toLowerCase().includes(searchQuery.toLowerCase()))
-      );
-    }
     // Exclude sessions in split group (they are shown in the split section)
     if (isSplitActive) {
-      result = result.filter((s) => !splitSessionIds.has(s.id));
+      return sessions.filter((s) => !splitSessionIds.has(s.id));
     }
-    return result;
-  }, [sessions, searchQuery, isSplitActive, splitSessionIds]);
+    return sessions;
+  }, [sessions, isSplitActive, splitSessionIds]);
 
   const projectGroups = useMemo(() => {
     const groups = groupSessionsByProject(filteredSessions);
@@ -473,7 +455,7 @@ export function ChatListPanel({ open, width, hasUpdate, readyToInstall }: ChatLi
               variant="outline"
               size="icon-sm"
               className="h-8 w-8 shrink-0"
-              onClick={() => setSearchDialogOpen(true)}
+              onClick={() => window.dispatchEvent(new CustomEvent('open-global-search'))}
             >
               <MagnifyingGlass size={14} />
               <span className="sr-only">{t('chatList.searchSessions')}</span>
@@ -556,12 +538,12 @@ export function ChatListPanel({ open, width, hasUpdate, readyToInstall }: ChatLi
 
           {filteredSessions.length === 0 && (!isSplitActive || splitSessions.length === 0) ? (
             <p className="px-2.5 py-3 text-[11px] text-muted-foreground/60">
-              {searchQuery ? "No matching threads" : t('chatList.noSessions')}
+              {t('chatList.noSessions')}
             </p>
           ) : (
             projectGroups.map((group) => {
               const isCollapsed =
-                !isSearching && collapsedProjects.has(group.workingDirectory);
+                collapsedProjects.has(group.workingDirectory);
               const isFolderHovered =
                 hoveredFolder === group.workingDirectory;
 
@@ -697,61 +679,6 @@ export function ChatListPanel({ open, width, hasUpdate, readyToInstall }: ChatLi
           </Button>
         </Link>
       </div>
-
-      {/* Search Dialog */}
-      <Dialog open={searchDialogOpen} onOpenChange={(open) => { setSearchDialogOpen(open); if (!open) setSearchQuery(""); }}>
-        <DialogContent className="sm:max-w-md p-0 max-h-[60vh] flex flex-col overflow-hidden" showCloseButton={false}>
-          <div className="p-3 shrink-0">
-            <div className="relative">
-              <MagnifyingGlass
-                size={14}
-                className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground"
-              />
-              <Input
-                placeholder={t('chatList.searchSessions')}
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
-                className="pl-9"
-                autoFocus
-              />
-            </div>
-          </div>
-          {searchQuery && (
-            <div className="overflow-y-auto px-3 pb-3 flex-1 min-h-0">
-              {filteredSessions.length === 0 ? (
-                <p className="text-sm text-muted-foreground py-3 text-center">
-                  {t('chatList.noSessions')}
-                </p>
-              ) : (
-                <div className="flex flex-col gap-0.5">
-                  {filteredSessions.slice(0, 20).map((session) => (
-                    <button
-                      key={session.id}
-                      className="flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm hover:bg-accent transition-colors"
-                      onClick={() => {
-                        router.push(`/chat/${session.id}`);
-                        setSearchDialogOpen(false);
-                        setSearchQuery("");
-                      }}
-                    >
-                      <div className="flex-1 min-w-0">
-                        <p className="truncate text-sm">{session.title}</p>
-                        {session.project_name && (
-                          <p className="truncate text-xs text-muted-foreground">{session.project_name}</p>
-                        )}
-                      </div>
-                      <span className="text-xs text-muted-foreground shrink-0">
-                        {formatRelativeTime(session.updated_at, t)}
-                      </span>
-                    </button>
-                  ))}
-                </div>
-              )}
-            </div>
-          )}
-        </DialogContent>
-      </Dialog>
-
 
       {/* Folder Picker Dialog */}
       <FolderPicker

--- a/src/components/layout/GlobalSearchDialog.tsx
+++ b/src/components/layout/GlobalSearchDialog.tsx
@@ -52,15 +52,15 @@ interface GlobalSearchDialogProps {
 }
 
 const TYPE_ICONS: Record<string, IconComponent> = {
-  session: ChatCircleText,
-  message: NotePencil,
-  file: Folder,
+  sessions: ChatCircleText,
+  messages: NotePencil,
+  files: Folder,
 };
 
 const TYPE_LABELS: Record<string, string> = {
-  session: 'Sessions',
-  message: 'Messages',
-  file: 'Files',
+  sessions: 'Sessions',
+  messages: 'Messages',
+  files: 'Files',
 };
 
 export function GlobalSearchDialog({ open, onOpenChange }: GlobalSearchDialogProps) {

--- a/src/components/layout/GlobalSearchDialog.tsx
+++ b/src/components/layout/GlobalSearchDialog.tsx
@@ -1,0 +1,226 @@
+'use client';
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { useRouter } from 'next/navigation';
+import { useTranslation } from '@/hooks/useTranslation';
+import {
+  CommandDialog,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+} from '@/components/ui/command';
+import { MagnifyingGlass, ChatCircleText, NotePencil, Folder } from '@/components/ui/icon';
+import type { IconComponent } from '@/types';
+
+interface SearchResultSession {
+  type: 'session';
+  id: string;
+  title: string;
+  projectName: string;
+  updatedAt: string;
+}
+
+interface SearchResultMessage {
+  type: 'message';
+  sessionId: string;
+  sessionTitle: string;
+  messageId: string;
+  role: 'user' | 'assistant';
+  snippet: string;
+  createdAt: string;
+}
+
+interface SearchResultFile {
+  type: 'file';
+  sessionId: string;
+  sessionTitle: string;
+  path: string;
+  name: string;
+}
+
+interface SearchResponse {
+  sessions: SearchResultSession[];
+  messages: SearchResultMessage[];
+  files: SearchResultFile[];
+}
+
+interface GlobalSearchDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+const TYPE_ICONS: Record<string, IconComponent> = {
+  session: ChatCircleText,
+  message: NotePencil,
+  file: Folder,
+};
+
+const TYPE_LABELS: Record<string, string> = {
+  session: 'Sessions',
+  message: 'Messages',
+  file: 'Files',
+};
+
+export function GlobalSearchDialog({ open, onOpenChange }: GlobalSearchDialogProps) {
+  const { t } = useTranslation();
+  const router = useRouter();
+  const [query, setQuery] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [results, setResults] = useState<SearchResponse>({ sessions: [], messages: [], files: [] });
+  const abortRef = useRef<AbortController | null>(null);
+
+  const performSearch = useCallback(async (q: string) => {
+    if (abortRef.current) {
+      abortRef.current.abort();
+    }
+    if (!q.trim()) {
+      setResults({ sessions: [], messages: [], files: [] });
+      setLoading(false);
+      return;
+    }
+
+    const controller = new AbortController();
+    abortRef.current = controller;
+    setLoading(true);
+
+    try {
+      const res = await fetch(`/api/search?q=${encodeURIComponent(q)}`, {
+        signal: controller.signal,
+      });
+      if (!res.ok) throw new Error('Search failed');
+      const data: SearchResponse = await res.json();
+      if (!controller.signal.aborted) {
+        setResults(data);
+      }
+    } catch {
+      if (!controller.signal.aborted) {
+        setResults({ sessions: [], messages: [], files: [] });
+      }
+    } finally {
+      if (!controller.signal.aborted) {
+        setLoading(false);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      performSearch(query);
+    }, 150);
+    return () => clearTimeout(timer);
+  }, [query, performSearch]);
+
+  useEffect(() => {
+    if (!open) {
+      setQuery('');
+      setResults({ sessions: [], messages: [], files: [] });
+    }
+  }, [open]);
+
+  const handleSelect = useCallback(
+    (item: SearchResultSession | SearchResultMessage | SearchResultFile) => {
+      onOpenChange(false);
+      if (item.type === 'session') {
+        router.push(`/chat/${item.id}`);
+      } else if (item.type === 'message') {
+        router.push(`/chat/${item.sessionId}`);
+      } else if (item.type === 'file') {
+        // For files, navigate to the session and let the file tree show it
+        router.push(`/chat/${item.sessionId}`);
+      }
+    },
+    [router, onOpenChange],
+  );
+
+  const hasResults =
+    results.sessions.length > 0 ||
+    results.messages.length > 0 ||
+    results.files.length > 0;
+
+  const renderGroup = (
+    key: keyof SearchResponse,
+    items: (SearchResultSession | SearchResultMessage | SearchResultFile)[],
+  ) => {
+    if (items.length === 0) return null;
+    const Icon = TYPE_ICONS[key];
+    return (
+      <CommandGroup key={key} heading={TYPE_LABELS[key]}>
+        {items.map((item, idx) => (
+          <CommandItem
+            key={`${key}-${idx}`}
+            value={`${key}-${idx}-${item.type === 'session' ? item.id : item.type === 'message' ? item.messageId : item.path}`}
+            onSelect={() => handleSelect(item)}
+            className="flex items-start gap-2 py-2"
+          >
+            <Icon size={16} className="mt-0.5 shrink-0 text-muted-foreground" />
+            <div className="min-w-0 flex-1">
+              {item.type === 'session' && (
+                <>
+                  <p className="truncate text-sm">{item.title}</p>
+                  {item.projectName && (
+                    <p className="truncate text-xs text-muted-foreground">{item.projectName}</p>
+                  )}
+                </>
+              )}
+              {item.type === 'message' && (
+                <>
+                  <p className="truncate text-xs text-muted-foreground">
+                    {item.sessionTitle} · {item.role === 'user' ? 'User' : 'Assistant'}
+                  </p>
+                  <p className="truncate text-sm">{item.snippet}</p>
+                </>
+              )}
+              {item.type === 'file' && (
+                <>
+                  <p className="truncate text-sm">{item.name}</p>
+                  <p className="truncate text-xs text-muted-foreground">{item.sessionTitle}</p>
+                </>
+              )}
+            </div>
+          </CommandItem>
+        ))}
+      </CommandGroup>
+    );
+  };
+
+  return (
+    <CommandDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Global Search"
+      description="Search across sessions, messages, and files"
+      className="sm:max-w-lg"
+      showCloseButton={false}
+    >
+      <CommandInput
+        placeholder="Search... (try sessions:, messages:, files:)"
+        value={query}
+        onValueChange={setQuery}
+        className="h-12"
+      />
+      <CommandList className="max-h-[60vh]">
+        {!query && !loading && (
+          <div className="py-6 text-center text-sm text-muted-foreground">
+            <p>Type to search across sessions and messages</p>
+            <p className="mt-1 text-xs">
+              Prefix with <code className="rounded bg-muted px-1">sessions:</code>{' '}
+              <code className="rounded bg-muted px-1">messages:</code>{' '}
+              <code className="rounded bg-muted px-1">files:</code> to narrow scope
+            </p>
+          </div>
+        )}
+        {query && !loading && !hasResults && (
+          <CommandEmpty>No results found</CommandEmpty>
+        )}
+        {renderGroup('sessions', results.sessions)}
+        {renderGroup('messages', results.messages)}
+        {renderGroup('files', results.files)}
+        {loading && (
+          <div className="py-4 text-center text-sm text-muted-foreground">Searching...</div>
+        )}
+      </CommandList>
+    </CommandDialog>
+  );
+}

--- a/src/hooks/useGlobalSearchShortcut.ts
+++ b/src/hooks/useGlobalSearchShortcut.ts
@@ -1,0 +1,28 @@
+import { useEffect, useCallback } from 'react';
+
+export function useGlobalSearchShortcut(onOpen: () => void) {
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      const isModifier = e.metaKey || e.ctrlKey;
+      if (isModifier && e.key.toLowerCase() === 'k') {
+        // Avoid intercepting when an input/textarea is focused
+        const active = document.activeElement;
+        const isEditing =
+          active instanceof HTMLInputElement ||
+          active instanceof HTMLTextAreaElement ||
+          active?.getAttribute('contenteditable') === 'true';
+        // Still allow shortcut when focus is on body or non-editable elements
+        if (!isEditing) {
+          e.preventDefault();
+          onOpen();
+        }
+      }
+    },
+    [onOpen],
+  );
+
+  useEffect(() => {
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [handleKeyDown]);
+}

--- a/src/hooks/useSlashCommands.ts
+++ b/src/hooks/useSlashCommands.ts
@@ -196,7 +196,7 @@ export function useSlashCommands(opts: {
         // Block during streaming — badges dispatch as slash/skill prompts, not queueable
         if (isStreaming) { closePopover(); return; }
         setBadge(result.badge!);
-        setInputValue('');
+        setInputValue(result.newInputValue ?? '');
         closePopover();
         setTimeout(() => textareaRef.current?.focus(), 0);
         return;

--- a/src/hooks/useSlashCommands.ts
+++ b/src/hooks/useSlashCommands.ts
@@ -198,7 +198,13 @@ export function useSlashCommands(opts: {
         setBadge(result.badge!);
         setInputValue(result.newInputValue ?? '');
         closePopover();
-        setTimeout(() => textareaRef.current?.focus(), 0);
+        setTimeout(() => {
+          const el = textareaRef.current;
+          if (!el) return;
+          el.focus();
+          const pos = el.value.length;
+          el.setSelectionRange(pos, pos);
+        }, 0);
         return;
 
       case 'insert_file_mention':

--- a/src/lib/message-input-logic.ts
+++ b/src/lib/message-input-logic.ts
@@ -100,8 +100,11 @@ export function resolveItemSelection(
     return { action: 'immediate_command', commandValue: item.value };
   }
 
-  // Non-immediate commands: show as badge
+  // Non-immediate commands: show as badge, preserving any text outside the trigger
   if (popoverMode === 'skill') {
+    const before = inputValue.slice(0, triggerPos);
+    const cursorEnd = triggerPos + popoverFilter.length + 1;
+    const after = inputValue.slice(cursorEnd);
     return {
       action: 'set_badge',
       badge: {
@@ -111,6 +114,7 @@ export function resolveItemSelection(
         kind: item.kind || 'slash_command',
         installedSource: item.installedSource,
       },
+      newInputValue: before + after,
     };
   }
 

--- a/src/lib/message-input-logic.ts
+++ b/src/lib/message-input-logic.ts
@@ -85,6 +85,21 @@ export function filterItems(items: PopoverItem[], filter: string): PopoverItem[]
 }
 
 /**
+ * Splits input text around a popover trigger, removing the trigger character
+ * and any filter text that was typed after it.
+ */
+function splitAroundTrigger(
+  inputValue: string,
+  triggerPos: number,
+  popoverFilter: string,
+): { before: string; after: string } {
+  const before = inputValue.slice(0, triggerPos);
+  const cursorEnd = triggerPos + popoverFilter.length + 1; // +1 to consume the trigger character
+  const after = inputValue.slice(cursorEnd);
+  return { before, after };
+}
+
+/**
  * Determines what happens when an item is selected from the popover.
  * Used by insertItem in useSlashCommands.
  */
@@ -102,9 +117,7 @@ export function resolveItemSelection(
 
   // Non-immediate commands: show as badge, preserving any text outside the trigger
   if (popoverMode === 'skill') {
-    const before = inputValue.slice(0, triggerPos);
-    const cursorEnd = triggerPos + popoverFilter.length + 1;
-    const after = inputValue.slice(cursorEnd);
+    const { before, after } = splitAroundTrigger(inputValue, triggerPos, popoverFilter);
     return {
       action: 'set_badge',
       badge: {
@@ -119,9 +132,7 @@ export function resolveItemSelection(
   }
 
   // File mention: insert into text
-  const before = inputValue.slice(0, triggerPos);
-  const cursorEnd = triggerPos + popoverFilter.length + 1;
-  const after = inputValue.slice(cursorEnd);
+  const { before, after } = splitAroundTrigger(inputValue, triggerPos, popoverFilter);
   const insertText = `@${item.value} `;
   return {
     action: 'insert_file_mention',


### PR DESCRIPTION
**CodePilot 版本：** v0.50.1

## 功能描述

新增全局搜索面板，支持跨 Session 标题、历史消息内容、工程文件名的快速定位。默认按 `sessions` + `messages` 联合搜索，也可通过限定语法精确指定维度。

## 搜索语法

- `sessions: xxx` — 仅搜索会话标题
- `messages: xxx` — 仅搜索人和 AI 的问答内容
- `files: xxx` — 仅搜索 Session 关联工程目录下的文件名
- 直接输入关键字 — 同时搜索 sessions 和 messages

## 交互方式

- `Cmd/Ctrl + K` 全局唤起搜索面板（非编辑态下）
- 左侧边栏原有的搜索按钮现在也会打开全局搜索面板
- 回车或点击结果项直接跳转到对应 Session

## 实现概要

| 新增/修改 | 说明 |
|-----------|------|
| `src/app/api/search/route.ts` | 统一搜索 API，解析查询前缀并聚合 sessions / messages / files 三类结果 |
| `src/components/layout/GlobalSearchDialog.tsx` | 基于 `cmdk` `CommandDialog` 的搜索浮层，按类型分组展示 |
| `src/hooks/useGlobalSearchShortcut.ts` | `Cmd/Ctrl+K` 快捷键监听 hook |
| `src/components/layout/AppShell.tsx` | 挂载搜索面板和快捷键监听 |
| `src/components/layout/ChatListPanel.tsx` | 搜索按钮切到全局搜索；移除旧的本地 session-only 搜索弹窗 |

## 性能考虑

- messages 搜索复用已有的 `searchMessages()`（SQLite `LIKE`）
- files 搜索限制扫描深度为 2，且仅在被显式请求时执行（`files:` 前缀），避免大工程默认扫盘
- 输入防抖 150ms，减少无意义的请求

## 验证方式

- [ ] 按 `Cmd/Ctrl+K` 唤出搜索面板
- [ ] 输入关键字，确认 sessions 和 messages 结果能正常返回并分组显示
- [ ] 输入 `sessions: xxx` / `messages: xxx` / `files: xxx` 验证限定搜索
- [ ] 点击结果项，正常跳转到对应 Session
- [ ] `npm run test` 通过（typecheck + 单元测试）

🤖 Generated with [Claude Code](https://claude.com/code)
