### PR TITLE
feat(search): Obsidian-style global search with file/folder targeting

### DIFF
--- a/src/__tests__/e2e/global-search-file-seek.spec.ts
+++ b/src/__tests__/e2e/global-search-file-seek.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect, type Page } from '@playwright/test';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+async function createSession(page: Page, title: string, workingDirectory: string) {
+  const res = await page.request.post('/api/chat/sessions', {
+    data: { title, working_directory: workingDirectory },
+  });
+  expect(res.ok()).toBeTruthy();
+  const data = await res.json();
+  return data.session.id as string;
+}
+
+test.describe('Global Search file deep-link seek UX', () => {
+  test('same-session repeat seek and cross-session seek both locate target file', async ({ page }) => {
+    const suffix = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const rootA = path.join(os.tmpdir(), `codepilot-search-a-${suffix}`);
+    const rootB = path.join(os.tmpdir(), `codepilot-search-b-${suffix}`);
+    const fileA = path.join(rootA, 'src', 'feature-a', 'target-a.ts');
+    const fileB = path.join(rootB, 'src', 'feature-b', 'target-b.ts');
+
+    await fs.mkdir(path.dirname(fileA), { recursive: true });
+    await fs.mkdir(path.dirname(fileB), { recursive: true });
+    await fs.writeFile(fileA, 'export const targetA = 1;\n', 'utf8');
+    await fs.writeFile(fileB, 'export const targetB = 2;\n', 'utf8');
+
+    // Add filler files to make vertical scrolling observable.
+    for (let i = 0; i < 120; i++) {
+      const fillerA = path.join(rootA, 'src', `filler-a-${String(i).padStart(3, '0')}.ts`);
+      const fillerB = path.join(rootB, 'src', `filler-b-${String(i).padStart(3, '0')}.ts`);
+      await fs.writeFile(fillerA, `export const a${i} = ${i};\n`, 'utf8');
+      await fs.writeFile(fillerB, `export const b${i} = ${i};\n`, 'utf8');
+    }
+
+    const sessionA = await createSession(page, `E2E Search Session A ${suffix}`, rootA);
+    const sessionB = await createSession(page, `E2E Search Session B ${suffix}`, rootB);
+
+    try {
+      // 1) First locate in session A.
+      await page.goto(`/chat/${sessionA}?file=${encodeURIComponent(fileA)}&seek=seek1`);
+      const panel = page.locator('div[style*="width: 280"]');
+      await expect(panel).toBeVisible({ timeout: 15_000 });
+      await expect(page.locator('#file-tree-highlight')).toContainText('target-a.ts', { timeout: 15_000 });
+
+      // 2) Re-seek same file in same session; should remain stable and highlighted.
+      await page.goto(`/chat/${sessionA}?file=${encodeURIComponent(fileA)}&seek=seek2`);
+      await expect(page.locator('#file-tree-highlight')).toContainText('target-a.ts', { timeout: 15_000 });
+      await expect(page).toHaveURL(new RegExp(`/chat/${sessionA}\\?`));
+      await expect(page).toHaveURL(/seek=seek2/);
+
+      // 3) Cross-session locate should still work after previous seeks.
+      await page.goto(`/chat/${sessionB}?file=${encodeURIComponent(fileB)}&seek=seek3`);
+      await expect(page.locator('#file-tree-highlight')).toContainText('target-b.ts', { timeout: 15_000 });
+      await expect(page).toHaveURL(new RegExp(`/chat/${sessionB}\\?`));
+    } finally {
+      await fs.rm(rootA, { recursive: true, force: true });
+      await fs.rm(rootB, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/__tests__/e2e/global-search-modes.spec.ts
+++ b/src/__tests__/e2e/global-search-modes.spec.ts
@@ -86,6 +86,8 @@ test.describe('Global Search modes UX', () => {
       await page.getByRole('button', { name: /(搜索会话|Search sessions|Search)/i }).first().click();
       await expect(searchInput).toBeVisible({ timeout: 10_000 });
       await searchInput.fill(`file:${fileNameA}`);
+      await expect(page.getByText(/(Searching in|当前搜索范围)/)).toBeVisible({ timeout: 10_000 });
+      await expect(page.getByText('file:')).toBeVisible({ timeout: 10_000 });
       await expect(page.getByText(fileNameA)).toBeVisible({ timeout: 10_000 });
       await page.getByText(fileNameA).first().click();
       await expect(page).toHaveURL(new RegExp(`/chat/${sessionA}\\?file=`), { timeout: 10_000 });

--- a/src/__tests__/e2e/global-search-modes.spec.ts
+++ b/src/__tests__/e2e/global-search-modes.spec.ts
@@ -1,0 +1,99 @@
+import { test, expect, type Page } from '@playwright/test';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import Database from 'better-sqlite3';
+
+function getDbPath() {
+  const dataDir = process.env.CLAUDE_GUI_DATA_DIR || path.join(os.homedir(), '.codepilot');
+  return path.join(dataDir, 'codepilot.db');
+}
+
+function addMessage(sessionId: string, role: 'user' | 'assistant', content: string) {
+  const db = new Database(getDbPath());
+  try {
+    const id = crypto.randomBytes(16).toString('hex');
+    const now = new Date().toISOString().replace('T', ' ').split('.')[0];
+    db.prepare(
+      'INSERT INTO messages (id, session_id, role, content, created_at, token_usage) VALUES (?, ?, ?, ?, ?, ?)'
+    ).run(id, sessionId, role, content, now, null);
+    db.prepare('UPDATE chat_sessions SET updated_at = ? WHERE id = ?').run(now, sessionId);
+  } finally {
+    db.close();
+  }
+}
+
+async function createSession(page: Page, title: string, workingDirectory: string) {
+  const res = await page.request.post('/api/chat/sessions', {
+    data: { title, working_directory: workingDirectory },
+  });
+  expect(res.ok()).toBeTruthy();
+  const data = await res.json();
+  return data.session.id as string;
+}
+
+test.describe('Global Search modes UX', () => {
+  test('supports all/session/message/file modes and keyboard open', async ({ page }) => {
+    const suffix = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const rootA = path.join(os.tmpdir(), `codepilot-search-modes-a-${suffix}`);
+    const rootB = path.join(os.tmpdir(), `codepilot-search-modes-b-${suffix}`);
+    const fileNameA = `alpha-${suffix}.ts`;
+    const filePathA = path.join(rootA, 'src', fileNameA);
+    const sessionTitleA = `Search Session Alpha ${suffix}`;
+    const sessionTitleB = `Search Session Beta ${suffix}`;
+    const messageTokenA = `message-token-alpha-${suffix}`;
+    const messageTokenB = `message-token-beta-${suffix}`;
+
+    await fs.mkdir(path.dirname(filePathA), { recursive: true });
+    await fs.mkdir(rootB, { recursive: true });
+    await fs.writeFile(filePathA, 'export const alpha = true;\n', 'utf8');
+
+    const sessionA = await createSession(page, sessionTitleA, rootA);
+    const sessionB = await createSession(page, sessionTitleB, rootB);
+    addMessage(sessionA, 'user', `User says ${messageTokenA}`);
+    addMessage(sessionB, 'assistant', `Assistant says ${messageTokenB}`);
+
+    const searchInput = page.locator(
+      'input[data-slot="command-input"], input[placeholder*="Search"], input[placeholder*="搜索"]'
+    ).first();
+
+    try {
+      await page.goto(`/chat/${sessionA}`);
+
+      // Open global search from the sidebar trigger (language-agnostic fallback).
+      await page.getByRole('button', { name: /(搜索会话|Search sessions|Search)/i }).first().click();
+      await expect(searchInput).toBeVisible({ timeout: 10_000 });
+
+      // Default all-mode can find sessions, messages and files.
+      await searchInput.fill(suffix);
+      await expect(page.getByText(sessionTitleA).first()).toBeVisible();
+      await expect(page.getByText(fileNameA).first()).toBeVisible();
+      await expect(page.getByText(messageTokenA).first()).toBeVisible();
+
+      // session: prefix narrows to session result.
+      await searchInput.fill(`session:${sessionTitleA}`);
+      await expect(page.getByText(sessionTitleA).first()).toBeVisible();
+      await expect(page.getByText(fileNameA)).toHaveCount(0);
+
+      // message: prefix narrows to message snippets and supports navigation to target session.
+      await searchInput.fill(`message:${messageTokenB}`);
+      await expect(page.getByText(messageTokenB)).toBeVisible({ timeout: 10_000 });
+      await page.getByText(messageTokenB).first().click();
+      await expect(page).toHaveURL(new RegExp(`/chat/${sessionB}\\?message=`), { timeout: 10_000 });
+
+      // Re-open and verify file: prefix still works in the same UX flow.
+      await page.getByRole('button', { name: /(搜索会话|Search sessions|Search)/i }).first().click();
+      await expect(searchInput).toBeVisible({ timeout: 10_000 });
+      await searchInput.fill(`file:${fileNameA}`);
+      await expect(page.getByText(fileNameA)).toBeVisible({ timeout: 10_000 });
+      await page.getByText(fileNameA).first().click();
+      await expect(page).toHaveURL(new RegExp(`/chat/${sessionA}\\?file=`), { timeout: 10_000 });
+    } finally {
+      await page.request.delete(`/api/chat/sessions/${sessionA}`, { timeout: 5_000 }).catch(() => {});
+      await page.request.delete(`/api/chat/sessions/${sessionB}`, { timeout: 5_000 }).catch(() => {});
+      await fs.rm(rootA, { recursive: true, force: true });
+      await fs.rm(rootB, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/app/api/app/updates/route.ts
+++ b/src/app/api/app/updates/route.ts
@@ -4,6 +4,24 @@ import { selectRecommendedReleaseAsset, type ReleaseAsset } from "@/lib/update-r
 
 const GITHUB_REPO = "op7418/CodePilot";
 
+function noUpdatePayload(currentVersion: string, runtimeInfo: ReturnType<typeof getRuntimeArchitectureInfo>) {
+  return {
+    latestVersion: currentVersion,
+    currentVersion,
+    updateAvailable: false,
+    releaseName: "",
+    releaseNotes: "",
+    publishedAt: "",
+    releaseUrl: "",
+    downloadUrl: "",
+    downloadAssetName: "",
+    detectedPlatform: runtimeInfo.platform,
+    detectedArch: runtimeInfo.processArch,
+    hostArch: runtimeInfo.hostArch,
+    runningUnderRosetta: runtimeInfo.runningUnderRosetta,
+  };
+}
+
 function compareSemver(a: string, b: string): number {
   const pa = a.replace(/^v/, "").split(".").map(Number);
   const pb = b.replace(/^v/, "").split(".").map(Number);
@@ -28,10 +46,7 @@ export async function GET() {
     );
 
     if (!res.ok) {
-      return NextResponse.json(
-        { error: "Failed to fetch release info" },
-        { status: 502 }
-      );
+      return NextResponse.json(noUpdatePayload(currentVersion, runtimeInfo));
     }
 
     const release = await res.json();
@@ -58,9 +73,8 @@ export async function GET() {
       runningUnderRosetta: runtimeInfo.runningUnderRosetta,
     });
   } catch {
-    return NextResponse.json(
-      { error: "Failed to check for updates" },
-      { status: 500 }
-    );
+    const currentVersion = process.env.NEXT_PUBLIC_APP_VERSION || "0.0.0";
+    const runtimeInfo = getRuntimeArchitectureInfo();
+    return NextResponse.json(noUpdatePayload(currentVersion, runtimeInfo));
   }
 }

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -137,9 +137,14 @@ export async function GET(request: NextRequest) {
     if (scope === 'all' || scope === 'files') {
       for (const session of allSessions) {
         if (!session.working_directory) continue;
-        const tree = await scanDirectory(session.working_directory, FILE_SCAN_DEPTH);
-        collectNodes(tree, session.id, session.title, query, result.files);
-        if (result.files.length >= MAX_RESULTS_PER_TYPE) break;
+        try {
+          const tree = await scanDirectory(session.working_directory, FILE_SCAN_DEPTH);
+          collectNodes(tree, session.id, session.title, query, result.files);
+          if (result.files.length >= MAX_RESULTS_PER_TYPE) break;
+        } catch {
+          // Skip inaccessible/invalid session directories instead of failing the whole search.
+          continue;
+        }
       }
     }
 

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -22,6 +22,7 @@ interface SearchResultMessage {
   role: 'user' | 'assistant';
   snippet: string;
   createdAt: string;
+  contentType: 'user' | 'assistant' | 'tool';
 }
 
 interface SearchResultFile {
@@ -30,6 +31,7 @@ interface SearchResultFile {
   sessionTitle: string;
   path: string;
   name: string;
+  nodeType: 'file' | 'directory';
 }
 
 export interface SearchResponse {
@@ -40,14 +42,18 @@ export interface SearchResponse {
 
 function parseQuery(raw: string): { scope: 'all' | 'sessions' | 'messages' | 'files'; query: string } {
   const trimmed = raw.trim();
-  if (trimmed.toLowerCase().startsWith('sessions:')) {
-    return { scope: 'sessions', query: trimmed.slice(9).trim() };
+  const lower = trimmed.toLowerCase();
+  if (lower.startsWith('session:') || lower.startsWith('sessions:')) {
+    const prefixLen = lower.startsWith('session:') ? 8 : 9;
+    return { scope: 'sessions', query: trimmed.slice(prefixLen).trim() };
   }
-  if (trimmed.toLowerCase().startsWith('messages:')) {
-    return { scope: 'messages', query: trimmed.slice(9).trim() };
+  if (lower.startsWith('message:') || lower.startsWith('messages:')) {
+    const prefixLen = lower.startsWith('message:') ? 8 : 9;
+    return { scope: 'messages', query: trimmed.slice(prefixLen).trim() };
   }
-  if (trimmed.toLowerCase().startsWith('files:')) {
-    return { scope: 'files', query: trimmed.slice(6).trim() };
+  if (lower.startsWith('file:') || lower.startsWith('files:')) {
+    const prefixLen = lower.startsWith('file:') ? 5 : 6;
+    return { scope: 'files', query: trimmed.slice(prefixLen).trim() };
   }
   return { scope: 'all', query: trimmed };
 }
@@ -70,7 +76,7 @@ function filterSessions(sessions: ChatSession[], query: string): SearchResultSes
     }));
 }
 
-function collectFiles(
+function collectNodes(
   tree: FileTreeNode[],
   sessionId: string,
   sessionTitle: string,
@@ -81,17 +87,18 @@ function collectFiles(
   const q = query.toLowerCase();
   for (const node of tree) {
     if (results.length >= MAX_RESULTS_PER_TYPE) break;
-    if (node.type === 'file' && node.name.toLowerCase().includes(q)) {
+    if (node.name.toLowerCase().includes(q)) {
       results.push({
         type: 'file',
         sessionId,
         sessionTitle,
         path: node.path,
         name: node.name,
+        nodeType: node.type,
       });
     }
     if (node.type === 'directory' && node.children) {
-      collectFiles(node.children, sessionId, sessionTitle, query, results);
+      collectNodes(node.children, sessionId, sessionTitle, query, results);
     }
   }
 }
@@ -123,6 +130,7 @@ export async function GET(request: NextRequest) {
         role: r.role,
         snippet: r.snippet,
         createdAt: r.createdAt,
+        contentType: r.contentType,
       }));
     }
 
@@ -130,7 +138,7 @@ export async function GET(request: NextRequest) {
       for (const session of allSessions) {
         if (!session.working_directory) continue;
         const tree = await scanDirectory(session.working_directory, FILE_SCAN_DEPTH);
-        collectFiles(tree, session.id, session.title, query, result.files);
+        collectNodes(tree, session.id, session.title, query, result.files);
         if (result.files.length >= MAX_RESULTS_PER_TYPE) break;
       }
     }

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -1,0 +1,144 @@
+import { NextRequest } from 'next/server';
+import { getAllSessions, searchMessages } from '@/lib/db';
+import { scanDirectory } from '@/lib/files';
+import type { ChatSession, FileTreeNode } from '@/types';
+
+const FILE_SCAN_DEPTH = 2;
+const MAX_RESULTS_PER_TYPE = 10;
+
+interface SearchResultSession {
+  type: 'session';
+  id: string;
+  title: string;
+  projectName: string;
+  updatedAt: string;
+}
+
+interface SearchResultMessage {
+  type: 'message';
+  sessionId: string;
+  sessionTitle: string;
+  messageId: string;
+  role: 'user' | 'assistant';
+  snippet: string;
+  createdAt: string;
+}
+
+interface SearchResultFile {
+  type: 'file';
+  sessionId: string;
+  sessionTitle: string;
+  path: string;
+  name: string;
+}
+
+export interface SearchResponse {
+  sessions: SearchResultSession[];
+  messages: SearchResultMessage[];
+  files: SearchResultFile[];
+}
+
+function parseQuery(raw: string): { scope: 'all' | 'sessions' | 'messages' | 'files'; query: string } {
+  const trimmed = raw.trim();
+  if (trimmed.toLowerCase().startsWith('sessions:')) {
+    return { scope: 'sessions', query: trimmed.slice(9).trim() };
+  }
+  if (trimmed.toLowerCase().startsWith('messages:')) {
+    return { scope: 'messages', query: trimmed.slice(9).trim() };
+  }
+  if (trimmed.toLowerCase().startsWith('files:')) {
+    return { scope: 'files', query: trimmed.slice(6).trim() };
+  }
+  return { scope: 'all', query: trimmed };
+}
+
+function filterSessions(sessions: ChatSession[], query: string): SearchResultSession[] {
+  const q = query.toLowerCase();
+  return sessions
+    .filter(
+      (s) =>
+        s.title.toLowerCase().includes(q) ||
+        s.project_name.toLowerCase().includes(q),
+    )
+    .slice(0, MAX_RESULTS_PER_TYPE)
+    .map((s) => ({
+      type: 'session' as const,
+      id: s.id,
+      title: s.title,
+      projectName: s.project_name,
+      updatedAt: s.updated_at,
+    }));
+}
+
+function collectFiles(
+  tree: FileTreeNode[],
+  sessionId: string,
+  sessionTitle: string,
+  query: string,
+  results: SearchResultFile[],
+): void {
+  if (results.length >= MAX_RESULTS_PER_TYPE) return;
+  const q = query.toLowerCase();
+  for (const node of tree) {
+    if (results.length >= MAX_RESULTS_PER_TYPE) break;
+    if (node.type === 'file' && node.name.toLowerCase().includes(q)) {
+      results.push({
+        type: 'file',
+        sessionId,
+        sessionTitle,
+        path: node.path,
+        name: node.name,
+      });
+    }
+    if (node.type === 'directory' && node.children) {
+      collectFiles(node.children, sessionId, sessionTitle, query, results);
+    }
+  }
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const rawQuery = searchParams.get('q') || '';
+    const { scope, query } = parseQuery(rawQuery);
+
+    if (!query) {
+      return Response.json({ sessions: [], messages: [], files: [] });
+    }
+
+    const allSessions = getAllSessions();
+    const result: SearchResponse = { sessions: [], messages: [], files: [] };
+
+    if (scope === 'all' || scope === 'sessions') {
+      result.sessions = filterSessions(allSessions, query);
+    }
+
+    if (scope === 'all' || scope === 'messages') {
+      const messageRows = searchMessages(query, { limit: MAX_RESULTS_PER_TYPE });
+      result.messages = messageRows.map((r) => ({
+        type: 'message' as const,
+        sessionId: r.sessionId,
+        sessionTitle: r.sessionTitle,
+        messageId: r.messageId,
+        role: r.role,
+        snippet: r.snippet,
+        createdAt: r.createdAt,
+      }));
+    }
+
+    if (scope === 'files') {
+      for (const session of allSessions) {
+        if (!session.working_directory) continue;
+        const tree = await scanDirectory(session.working_directory, FILE_SCAN_DEPTH);
+        collectFiles(tree, session.id, session.title, query, result.files);
+        if (result.files.length >= MAX_RESULTS_PER_TYPE) break;
+      }
+    }
+
+    return Response.json(result);
+  } catch (error) {
+    const message = error instanceof Error ? error.stack || error.message : String(error);
+    console.error('[GET /api/search] Error:', message);
+    return Response.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -134,7 +134,7 @@ export async function GET(request: NextRequest) {
       }));
     }
 
-    if (scope === 'files') {
+    if (scope === 'all' || scope === 'files') {
       for (const session of allSessions) {
         if (!session.working_directory) continue;
         const tree = await scanDirectory(session.working_directory, FILE_SCAN_DEPTH);

--- a/src/app/chat/[id]/page.tsx
+++ b/src/app/chat/[id]/page.tsx
@@ -25,6 +25,9 @@ export default function ChatSessionPage({ params }: ChatSessionPageProps) {
   const [sessionMode, setSessionMode] = useState<'code' | 'plan'>('code');
   const [sessionHasSummary, setSessionHasSummary] = useState(false);
   const { setWorkingDirectory, setSessionId, setSessionTitle: setPanelSessionTitle, setFileTreeOpen, setGitPanelOpen, setDashboardPanelOpen } = usePanel();
+  const targetFilePath = typeof window !== 'undefined'
+    ? new URLSearchParams(window.location.search).get('file') || undefined
+    : undefined;
   const { t } = useTranslation();
   const defaultPanelAppliedRef = useRef(false);
 
@@ -112,6 +115,13 @@ export default function ChatSessionPage({ params }: ChatSessionPageProps) {
 
     return () => { cancelled = true; };
   }, [id]);
+
+  // Auto-open file tree when jumping from a file search result
+  useEffect(() => {
+    if (targetFilePath) {
+      setFileTreeOpen(true);
+    }
+  }, [targetFilePath, setFileTreeOpen]);
 
   // Auto-open default panel the first time a session is ever opened.
   // Uses sessionStorage to track which sessions have already been initialized,

--- a/src/app/chat/[id]/page.tsx
+++ b/src/app/chat/[id]/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, useRef, use } from 'react';
 import Link from 'next/link';
+import { useSearchParams } from 'next/navigation';
 import type { Message, MessagesResponse, ChatSession } from '@/types';
 import { ChatView } from '@/components/chat/ChatView';
 import { SpinnerGap } from "@/components/ui/icon";
@@ -14,6 +15,7 @@ interface ChatSessionPageProps {
 
 export default function ChatSessionPage({ params }: ChatSessionPageProps) {
   const { id } = use(params);
+  const searchParams = useSearchParams();
   const [messages, setMessages] = useState<Message[]>([]);
   const [hasMore, setHasMore] = useState(false);
   const [loading, setLoading] = useState(true);
@@ -25,9 +27,7 @@ export default function ChatSessionPage({ params }: ChatSessionPageProps) {
   const [sessionMode, setSessionMode] = useState<'code' | 'plan'>('code');
   const [sessionHasSummary, setSessionHasSummary] = useState(false);
   const { setWorkingDirectory, setSessionId, setSessionTitle: setPanelSessionTitle, setFileTreeOpen, setGitPanelOpen, setDashboardPanelOpen } = usePanel();
-  const targetFilePath = typeof window !== 'undefined'
-    ? new URLSearchParams(window.location.search).get('file') || undefined
-    : undefined;
+  const targetFilePath = searchParams.get('file') || undefined;
   const { t } = useTranslation();
   const defaultPanelAppliedRef = useRef(false);
 

--- a/src/app/chat/[id]/page.tsx
+++ b/src/app/chat/[id]/page.tsx
@@ -139,6 +139,11 @@ export default function ChatSessionPage({ params }: ChatSessionPageProps) {
 
     (async () => {
       try {
+        if (targetFilePath) {
+          // Preserve explicit deep-link intent from global search.
+          setFileTreeOpen(true);
+          return;
+        }
         const res = await fetch('/api/settings/app');
         if (!res.ok) return;
         const data = await res.json();
@@ -156,7 +161,7 @@ export default function ChatSessionPage({ params }: ChatSessionPageProps) {
         setFileTreeOpen(true);
       }
     })();
-  }, [id, setFileTreeOpen, setGitPanelOpen, setDashboardPanelOpen]);
+  }, [id, targetFilePath, setFileTreeOpen, setGitPanelOpen, setDashboardPanelOpen]);
 
   if (loading || !sessionInfoLoaded) {
     return (

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -269,6 +269,43 @@
   }
 }
 
+/* Search result highlight flash animation for messages */
+@keyframes search-highlight-pulse {
+  0% {
+    background-color: color-mix(in oklch, var(--primary) 40%, transparent);
+  }
+  50% {
+    background-color: color-mix(in oklch, var(--primary) 20%, transparent);
+  }
+  100% {
+    background-color: transparent;
+  }
+}
+
+@utility search-highlight-flash {
+  animation: search-highlight-pulse 2s ease-in-out 1;
+  border-radius: 2px;
+  padding: 0 2px;
+  margin: 0 -2px;
+}
+
+/* File tree item flash animation */
+@keyframes file-tree-pulse {
+  0% {
+    background-color: color-mix(in oklch, var(--primary) 35%, transparent);
+  }
+  50% {
+    background-color: color-mix(in oklch, var(--primary) 15%, transparent);
+  }
+  100% {
+    background-color: transparent;
+  }
+}
+
+@utility file-tree-flash {
+  animation: file-tree-pulse 2s ease-in-out 1;
+}
+
 /* Widget skeleton shimmer animation */
 @keyframes widget-shimmer {
   0% {

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -25,6 +25,8 @@ import { useGitStatus } from "@/hooks/useGitStatus";
 import { SetupCenter } from '@/components/setup/SetupCenter';
 import { Toaster } from '@/components/ui/toast';
 import { useNotificationPoll } from '@/hooks/useNotificationPoll';
+import { useGlobalSearchShortcut } from '@/hooks/useGlobalSearchShortcut';
+import { GlobalSearchDialog } from './GlobalSearchDialog';
 
 const SPLIT_SESSIONS_KEY = "codepilot:split-sessions";
 const SPLIT_ACTIVE_COLUMN_KEY = "codepilot:split-active-column";
@@ -76,6 +78,9 @@ export function AppShell({ children }: { children: React.ReactNode }) {
   const [chatListOpenRaw, setChatListOpenRaw] = useState(false);
   const [setupOpen, setSetupOpen] = useState(false);
   const [setupInitialCard, setSetupInitialCard] = useState<'claude' | 'provider' | 'project' | undefined>();
+  const [searchOpen, setSearchOpen] = useState(false);
+
+  useGlobalSearchShortcut(() => setSearchOpen(true));
 
   // Poll server-side notification queue and display as toasts
   useNotificationPoll();
@@ -121,6 +126,13 @@ export function AppShell({ children }: { children: React.ReactNode }) {
     maybeOpenFromHash();
     window.addEventListener('hashchange', maybeOpenFromHash);
     return () => window.removeEventListener('hashchange', maybeOpenFromHash);
+  }, []);
+
+  // Listen for open-global-search events from ChatListPanel
+  useEffect(() => {
+    const handler = () => setSearchOpen(true);
+    window.addEventListener('open-global-search', handler);
+    return () => window.removeEventListener('open-global-search', handler);
   }, []);
 
   // Sync with viewport after hydration to avoid SSR mismatch
@@ -483,6 +495,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
           <UpdateDialog />
           <FeatureAnnouncementDialog />
           <Toaster />
+          <GlobalSearchDialog open={searchOpen} onOpenChange={setSearchOpen} />
           {setupOpen && (
             <SetupCenter
               onClose={() => setSetupOpen(false)}

--- a/src/components/layout/ChatListPanel.tsx
+++ b/src/components/layout/ChatListPanel.tsx
@@ -17,12 +17,7 @@ import {
   Gear,
 } from "@/components/ui/icon";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import {
-  Dialog,
-  DialogContent,
-} from "@/components/ui/dialog";
 import {
   Tooltip,
   TooltipContent,
@@ -68,8 +63,6 @@ export function ChatListPanel({ open, width, hasUpdate, readyToInstall }: ChatLi
   const [sessions, setSessions] = useState<ChatSession[]>([]);
   const [hoveredSession, setHoveredSession] = useState<string | null>(null);
   const [deletingSession, setDeletingSession] = useState<string | null>(null);
-  const [searchQuery, setSearchQuery] = useState("");
-  const [searchDialogOpen, setSearchDialogOpen] = useState(false);
   const [expandedSessionGroups, setExpandedSessionGroups] = useState<Set<string>>(new Set());
   const SESSION_TRUNCATE_LIMIT = 10;
   // importDialogOpen removed — Import CLI moved to Settings
@@ -376,29 +369,18 @@ export function ChatListPanel({ open, width, hasUpdate, readyToInstall }: ChatLi
     }
   };
 
-  const isSearching = searchQuery.length > 0;
-
   const splitSessionIds = useMemo(
     () => new Set(splitSessions.map((s) => s.sessionId)),
     [splitSessions]
   );
 
   const filteredSessions = useMemo(() => {
-    let result = sessions;
-    if (searchQuery) {
-      result = result.filter(
-        (s) =>
-          s.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
-          (s.project_name &&
-            s.project_name.toLowerCase().includes(searchQuery.toLowerCase()))
-      );
-    }
     // Exclude sessions in split group (they are shown in the split section)
     if (isSplitActive) {
-      result = result.filter((s) => !splitSessionIds.has(s.id));
+      return sessions.filter((s) => !splitSessionIds.has(s.id));
     }
-    return result;
-  }, [sessions, searchQuery, isSplitActive, splitSessionIds]);
+    return sessions;
+  }, [sessions, isSplitActive, splitSessionIds]);
 
   const projectGroups = useMemo(() => {
     const groups = groupSessionsByProject(filteredSessions);
@@ -473,7 +455,7 @@ export function ChatListPanel({ open, width, hasUpdate, readyToInstall }: ChatLi
               variant="outline"
               size="icon-sm"
               className="h-8 w-8 shrink-0"
-              onClick={() => setSearchDialogOpen(true)}
+              onClick={() => window.dispatchEvent(new CustomEvent('open-global-search'))}
             >
               <MagnifyingGlass size={14} />
               <span className="sr-only">{t('chatList.searchSessions')}</span>
@@ -556,12 +538,12 @@ export function ChatListPanel({ open, width, hasUpdate, readyToInstall }: ChatLi
 
           {filteredSessions.length === 0 && (!isSplitActive || splitSessions.length === 0) ? (
             <p className="px-2.5 py-3 text-[11px] text-muted-foreground/60">
-              {searchQuery ? "No matching threads" : t('chatList.noSessions')}
+              {t('chatList.noSessions')}
             </p>
           ) : (
             projectGroups.map((group) => {
               const isCollapsed =
-                !isSearching && collapsedProjects.has(group.workingDirectory);
+                collapsedProjects.has(group.workingDirectory);
               const isFolderHovered =
                 hoveredFolder === group.workingDirectory;
 
@@ -697,61 +679,6 @@ export function ChatListPanel({ open, width, hasUpdate, readyToInstall }: ChatLi
           </Button>
         </Link>
       </div>
-
-      {/* Search Dialog */}
-      <Dialog open={searchDialogOpen} onOpenChange={(open) => { setSearchDialogOpen(open); if (!open) setSearchQuery(""); }}>
-        <DialogContent className="sm:max-w-md p-0 max-h-[60vh] flex flex-col overflow-hidden" showCloseButton={false}>
-          <div className="p-3 shrink-0">
-            <div className="relative">
-              <MagnifyingGlass
-                size={14}
-                className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground"
-              />
-              <Input
-                placeholder={t('chatList.searchSessions')}
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
-                className="pl-9"
-                autoFocus
-              />
-            </div>
-          </div>
-          {searchQuery && (
-            <div className="overflow-y-auto px-3 pb-3 flex-1 min-h-0">
-              {filteredSessions.length === 0 ? (
-                <p className="text-sm text-muted-foreground py-3 text-center">
-                  {t('chatList.noSessions')}
-                </p>
-              ) : (
-                <div className="flex flex-col gap-0.5">
-                  {filteredSessions.slice(0, 20).map((session) => (
-                    <button
-                      key={session.id}
-                      className="flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm hover:bg-accent transition-colors"
-                      onClick={() => {
-                        router.push(`/chat/${session.id}`);
-                        setSearchDialogOpen(false);
-                        setSearchQuery("");
-                      }}
-                    >
-                      <div className="flex-1 min-w-0">
-                        <p className="truncate text-sm">{session.title}</p>
-                        {session.project_name && (
-                          <p className="truncate text-xs text-muted-foreground">{session.project_name}</p>
-                        )}
-                      </div>
-                      <span className="text-xs text-muted-foreground shrink-0">
-                        {formatRelativeTime(session.updated_at, t)}
-                      </span>
-                    </button>
-                  ))}
-                </div>
-              )}
-            </div>
-          )}
-        </DialogContent>
-      </Dialog>
-
 
       {/* Folder Picker Dialog */}
       <FolderPicker

--- a/src/components/layout/GlobalSearchDialog.tsx
+++ b/src/components/layout/GlobalSearchDialog.tsx
@@ -244,7 +244,7 @@ export function GlobalSearchDialog({ open, onOpenChange }: GlobalSearchDialogPro
       onOpenChange={onOpenChange}
       title="Global Search"
       description="Search across sessions, messages, and files"
-      className="sm:max-w-3xl flex flex-col overflow-hidden overflow-y-hidden"
+      className="sm:max-w-3xl sm:h-[520px] h-[80vh] flex flex-col overflow-hidden"
       showCloseButton={false}
       shouldFilter={false}
     >
@@ -261,7 +261,7 @@ export function GlobalSearchDialog({ open, onOpenChange }: GlobalSearchDialogPro
           performSearch(value);
         }}
       />
-      <CommandList className="flex-1 min-h-0 overflow-y-auto max-h-[600px]">
+      <CommandList className="flex-1 min-h-0 overflow-y-auto">
         {!query && !loading && (
           <div className="py-6 text-center text-sm text-muted-foreground">
             <p>{t('globalSearch.hint')}</p>

--- a/src/components/layout/GlobalSearchDialog.tsx
+++ b/src/components/layout/GlobalSearchDialog.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { useRouter } from 'next/navigation';
 import { useTranslation } from '@/hooks/useTranslation';
 import {
@@ -11,8 +11,9 @@ import {
   CommandGroup,
   CommandItem,
 } from '@/components/ui/command';
-import { MagnifyingGlass, ChatCircleText, NotePencil, Folder } from '@/components/ui/icon';
+import { ChatCircleText, NotePencil, Folder, FolderOpen, File, UserCircle, Sparkle, Wrench, CaretDown, CaretRight } from '@/components/ui/icon';
 import type { IconComponent } from '@/types';
+import type { TranslationKey } from '@/i18n';
 
 interface SearchResultSession {
   type: 'session';
@@ -30,6 +31,7 @@ interface SearchResultMessage {
   role: 'user' | 'assistant';
   snippet: string;
   createdAt: string;
+  contentType: 'user' | 'assistant' | 'tool';
 }
 
 interface SearchResultFile {
@@ -38,6 +40,7 @@ interface SearchResultFile {
   sessionTitle: string;
   path: string;
   name: string;
+  nodeType: 'file' | 'directory';
 }
 
 interface SearchResponse {
@@ -57,10 +60,16 @@ const TYPE_ICONS: Record<string, IconComponent> = {
   files: Folder,
 };
 
-const TYPE_LABELS: Record<string, string> = {
-  sessions: 'Sessions',
-  messages: 'Messages',
-  files: 'Files',
+const TYPE_LABEL_KEYS: Record<keyof SearchResponse, TranslationKey> = {
+  sessions: 'globalSearch.sessions',
+  messages: 'globalSearch.messages',
+  files: 'globalSearch.files',
+};
+
+const CONTENT_TYPE_ICONS: Record<SearchResultMessage['contentType'], IconComponent> = {
+  user: UserCircle,
+  assistant: Sparkle,
+  tool: Wrench,
 };
 
 export function GlobalSearchDialog({ open, onOpenChange }: GlobalSearchDialogProps) {
@@ -69,9 +78,12 @@ export function GlobalSearchDialog({ open, onOpenChange }: GlobalSearchDialogPro
   const [query, setQuery] = useState('');
   const [loading, setLoading] = useState(false);
   const [results, setResults] = useState<SearchResponse>({ sessions: [], messages: [], files: [] });
+  const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set());
   const abortRef = useRef<AbortController | null>(null);
+  const composingRef = useRef(false);
 
   const performSearch = useCallback(async (q: string) => {
+    if (composingRef.current) return;
     if (abortRef.current) {
       abortRef.current.abort();
     }
@@ -116,22 +128,35 @@ export function GlobalSearchDialog({ open, onOpenChange }: GlobalSearchDialogPro
     if (!open) {
       setQuery('');
       setResults({ sessions: [], messages: [], files: [] });
+      setCollapsedGroups(new Set());
     }
   }, [open]);
+
+  const toggleGroup = useCallback((sessionId: string) => {
+    setCollapsedGroups(prev => {
+      const next = new Set(prev);
+      if (next.has(sessionId)) {
+        next.delete(sessionId);
+      } else {
+        next.add(sessionId);
+      }
+      return next;
+    });
+  }, []);
 
   const handleSelect = useCallback(
     (item: SearchResultSession | SearchResultMessage | SearchResultFile) => {
       onOpenChange(false);
+      const qParam = query.trim() ? `&q=${encodeURIComponent(query.trim())}` : '';
       if (item.type === 'session') {
         router.push(`/chat/${item.id}`);
       } else if (item.type === 'message') {
-        router.push(`/chat/${item.sessionId}`);
+        router.push(`/chat/${item.sessionId}?message=${item.messageId}${qParam}`);
       } else if (item.type === 'file') {
-        // For files, navigate to the session and let the file tree show it
-        router.push(`/chat/${item.sessionId}`);
+        router.push(`/chat/${item.sessionId}?file=${encodeURIComponent(item.path)}${qParam}`);
       }
     },
-    [router, onOpenChange],
+    [router, onOpenChange, query],
   );
 
   const hasResults =
@@ -139,43 +164,71 @@ export function GlobalSearchDialog({ open, onOpenChange }: GlobalSearchDialogPro
     results.messages.length > 0 ||
     results.files.length > 0;
 
+  const groupedMessages = useMemo(() => {
+    const groups: Record<string, { sessionTitle: string; messages: SearchResultMessage[] }> = {};
+    for (const msg of results.messages) {
+      if (!groups[msg.sessionId]) {
+        groups[msg.sessionId] = { sessionTitle: msg.sessionTitle, messages: [] };
+      }
+      groups[msg.sessionId].messages.push(msg);
+    }
+    return Object.values(groups);
+  }, [results.messages]);
+
+  const renderHighlightedSnippet = (snippet: string, searchTerm: string) => {
+    if (!searchTerm) return <span>{snippet}</span>;
+    const lowerSnippet = snippet.toLowerCase();
+    const lowerTerm = searchTerm.toLowerCase();
+    const idx = lowerSnippet.indexOf(lowerTerm);
+    if (idx === -1) return <span>{snippet}</span>;
+    return (
+      <span>
+        {snippet.slice(0, idx)}
+        <mark className="rounded bg-primary/25 px-0.5 text-foreground">
+          {snippet.slice(idx, idx + searchTerm.length)}
+        </mark>
+        {snippet.slice(idx + searchTerm.length)}
+      </span>
+    );
+  };
+
   const renderGroup = (
     key: keyof SearchResponse,
-    items: (SearchResultSession | SearchResultMessage | SearchResultFile)[],
+    items: (SearchResultSession | SearchResultFile)[],
   ) => {
     if (items.length === 0) return null;
     const Icon = TYPE_ICONS[key];
     return (
-      <CommandGroup key={key} heading={TYPE_LABELS[key]}>
+      <CommandGroup key={key} heading={t(TYPE_LABEL_KEYS[key])}>
         {items.map((item, idx) => (
           <CommandItem
             key={`${key}-${idx}`}
-            value={`${key}-${idx}-${item.type === 'session' ? item.id : item.type === 'message' ? item.messageId : item.path}`}
+            value={`${key}-${idx}-${item.type === 'session' ? item.id : item.path}`}
             onSelect={() => handleSelect(item)}
             className="flex items-start gap-2 py-2"
           >
-            <Icon size={16} className="mt-0.5 shrink-0 text-muted-foreground" />
+            {item.type === 'file' ? (
+              item.nodeType === 'directory' ? (
+                <Folder size={16} className="mt-0.5 shrink-0 text-muted-foreground" />
+              ) : (
+                <File size={16} className="mt-0.5 shrink-0 text-muted-foreground" />
+              )
+            ) : (
+              <Icon size={16} className="mt-0.5 shrink-0 text-muted-foreground" />
+            )}
             <div className="min-w-0 flex-1">
               {item.type === 'session' && (
                 <>
-                  <p className="truncate text-sm">{item.title}</p>
+                  <p className="truncate text-sm max-w-[360px]">{item.title}</p>
                   {item.projectName && (
-                    <p className="truncate text-xs text-muted-foreground">{item.projectName}</p>
+                    <p className="truncate text-xs text-muted-foreground max-w-[360px]">{item.projectName}</p>
                   )}
-                </>
-              )}
-              {item.type === 'message' && (
-                <>
-                  <p className="truncate text-xs text-muted-foreground">
-                    {item.sessionTitle} · {item.role === 'user' ? 'User' : 'Assistant'}
-                  </p>
-                  <p className="truncate text-sm">{item.snippet}</p>
                 </>
               )}
               {item.type === 'file' && (
                 <>
-                  <p className="truncate text-sm">{item.name}</p>
-                  <p className="truncate text-xs text-muted-foreground">{item.sessionTitle}</p>
+                  <p className="truncate text-sm max-w-[360px]">{item.name}</p>
+                  <p className="truncate text-xs text-muted-foreground max-w-[360px]">{item.sessionTitle}</p>
                 </>
               )}
             </div>
@@ -191,34 +244,102 @@ export function GlobalSearchDialog({ open, onOpenChange }: GlobalSearchDialogPro
       onOpenChange={onOpenChange}
       title="Global Search"
       description="Search across sessions, messages, and files"
-      className="sm:max-w-lg"
+      className="sm:max-w-3xl flex flex-col overflow-hidden overflow-y-hidden"
       showCloseButton={false}
+      shouldFilter={false}
     >
       <CommandInput
-        placeholder="Search... (try sessions:, messages:, files:)"
+        placeholder={t('globalSearch.placeholder')}
         value={query}
         onValueChange={setQuery}
-        className="h-12"
+        className="h-12 shrink-0"
+        onCompositionStart={() => { composingRef.current = true; }}
+        onCompositionEnd={(e) => {
+          composingRef.current = false;
+          const value = (e.target as HTMLInputElement).value;
+          setQuery(value);
+          performSearch(value);
+        }}
       />
-      <CommandList className="max-h-[60vh]">
+      <CommandList className="flex-1 min-h-0 overflow-y-auto max-h-[600px]">
         {!query && !loading && (
           <div className="py-6 text-center text-sm text-muted-foreground">
-            <p>Type to search across sessions and messages</p>
+            <p>{t('globalSearch.hint')}</p>
             <p className="mt-1 text-xs">
-              Prefix with <code className="rounded bg-muted px-1">sessions:</code>{' '}
-              <code className="rounded bg-muted px-1">messages:</code>{' '}
-              <code className="rounded bg-muted px-1">files:</code> to narrow scope
+              {t('globalSearch.hintPrefix')}{' '}
+              <code className="rounded bg-muted px-1">session:</code>{' '}
+              <code className="rounded bg-muted px-1">message:</code>{' '}
+              <code className="rounded bg-muted px-1">file:</code>{' '}
+              {t('globalSearch.toNarrowScope')}
             </p>
           </div>
         )}
         {query && !loading && !hasResults && (
-          <CommandEmpty>No results found</CommandEmpty>
+          <CommandEmpty>{t('globalSearch.noResults')}</CommandEmpty>
         )}
         {renderGroup('sessions', results.sessions)}
-        {renderGroup('messages', results.messages)}
+
+        {groupedMessages.map((group, groupIdx) => {
+          const isCollapsed = collapsedGroups.has(group.messages[0]?.sessionId || `group-${groupIdx}`);
+          const sessionId = group.messages[0]?.sessionId || `group-${groupIdx}`;
+          return (
+            <CommandGroup
+              key={`msg-group-${groupIdx}`}
+              heading={
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    toggleGroup(sessionId);
+                  }}
+                  className="flex w-full items-center gap-1.5 py-1 text-left outline-none"
+                >
+                  {isCollapsed ? (
+                    <CaretRight size={14} className="shrink-0 text-muted-foreground" />
+                  ) : (
+                    <CaretDown size={14} className="shrink-0 text-muted-foreground" />
+                  )}
+                  <NotePencil size={14} className="shrink-0 text-muted-foreground" />
+                  <span className="truncate max-w-[280px]" title={group.sessionTitle.replace(/\n/g, ' ')}>
+                    {group.sessionTitle.replace(/\n/g, ' ')}
+                  </span>
+                  <span className="ml-1 rounded-full bg-muted px-1.5 py-0 text-[10px] text-muted-foreground">
+                    {group.messages.length}
+                  </span>
+                </button>
+              }
+            >
+              {!isCollapsed && group.messages.map((item, idx) => {
+                const Icon = CONTENT_TYPE_ICONS[item.contentType];
+                const labelKey: TranslationKey =
+                  item.contentType === 'user'
+                    ? 'messageList.userLabel'
+                    : item.contentType === 'tool'
+                      ? ('globalSearch.toolLabel' as TranslationKey)
+                      : 'messageList.assistantLabel';
+                return (
+                  <CommandItem
+                    key={`message-${groupIdx}-${idx}`}
+                    value={`message-${groupIdx}-${idx}-${item.messageId}`}
+                    onSelect={() => handleSelect(item)}
+                    className="flex items-start gap-2 py-2"
+                  >
+                    <Icon size={16} className="mt-0.5 shrink-0 text-muted-foreground" />
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate text-sm">{renderHighlightedSnippet(item.snippet, query)}</p>
+                      <p className="truncate text-xs text-muted-foreground">{t(labelKey)}</p>
+                    </div>
+                  </CommandItem>
+                );
+              })}
+            </CommandGroup>
+          );
+        })}
+
         {renderGroup('files', results.files)}
         {loading && (
-          <div className="py-4 text-center text-sm text-muted-foreground">Searching...</div>
+          <div className="py-4 text-center text-sm text-muted-foreground">{t('globalSearch.searching')}</div>
         )}
       </CommandList>
     </CommandDialog>

--- a/src/components/layout/GlobalSearchDialog.tsx
+++ b/src/components/layout/GlobalSearchDialog.tsx
@@ -11,7 +11,7 @@ import {
   CommandGroup,
   CommandItem,
 } from '@/components/ui/command';
-import { ChatCircleText, NotePencil, Folder, FolderOpen, File, UserCircle, Sparkle, Wrench, CaretDown, CaretRight } from '@/components/ui/icon';
+import { ChatCircleText, NotePencil, Folder, File, UserCircle, Sparkle, Wrench, CaretDown, CaretRight } from '@/components/ui/icon';
 import type { IconComponent } from '@/types';
 import type { TranslationKey } from '@/i18n';
 
@@ -244,7 +244,7 @@ export function GlobalSearchDialog({ open, onOpenChange }: GlobalSearchDialogPro
       onOpenChange={onOpenChange}
       title="Global Search"
       description="Search across sessions, messages, and files"
-      className="sm:max-w-3xl sm:h-[520px] h-[80vh] flex flex-col overflow-hidden"
+      className="sm:max-w-3xl h-[min(80vh,520px)] flex flex-col overflow-hidden"
       showCloseButton={false}
       shouldFilter={false}
     >
@@ -261,7 +261,7 @@ export function GlobalSearchDialog({ open, onOpenChange }: GlobalSearchDialogPro
           performSearch(value);
         }}
       />
-      <CommandList className="flex-1 min-h-0 overflow-y-auto">
+      <CommandList className="flex-1 min-h-0 overflow-y-auto max-h-none">
         {!query && !loading && (
           <div className="py-6 text-center text-sm text-muted-foreground">
             <p>{t('globalSearch.hint')}</p>
@@ -286,14 +286,13 @@ export function GlobalSearchDialog({ open, onOpenChange }: GlobalSearchDialogPro
             <CommandGroup
               key={`msg-group-${groupIdx}`}
               heading={
-                <button
-                  type="button"
+                <div
                   onClick={(e) => {
                     e.preventDefault();
                     e.stopPropagation();
                     toggleGroup(sessionId);
                   }}
-                  className="flex w-full items-center gap-1.5 py-1 text-left outline-none"
+                  className="flex w-full cursor-pointer items-center gap-1.5 py-1 text-left outline-none"
                 >
                   {isCollapsed ? (
                     <CaretRight size={14} className="shrink-0 text-muted-foreground" />
@@ -307,7 +306,7 @@ export function GlobalSearchDialog({ open, onOpenChange }: GlobalSearchDialogPro
                   <span className="ml-1 rounded-full bg-muted px-1.5 py-0 text-[10px] text-muted-foreground">
                     {group.messages.length}
                   </span>
-                </button>
+                </div>
               }
             >
               {!isCollapsed && group.messages.map((item, idx) => {

--- a/src/components/layout/GlobalSearchDialog.tsx
+++ b/src/components/layout/GlobalSearchDialog.tsx
@@ -292,7 +292,7 @@ export function GlobalSearchDialog({ open, onOpenChange }: GlobalSearchDialogPro
                     e.stopPropagation();
                     toggleGroup(sessionId);
                   }}
-                  className="flex w-full cursor-pointer items-center gap-1.5 py-1 text-left outline-none"
+                  className="flex w-full cursor-pointer items-center gap-1.5 rounded bg-muted/40 px-1 py-1 text-left font-medium text-foreground outline-none"
                 >
                   {isCollapsed ? (
                     <CaretRight size={14} className="shrink-0 text-muted-foreground" />

--- a/src/components/layout/GlobalSearchDialog.tsx
+++ b/src/components/layout/GlobalSearchDialog.tsx
@@ -176,7 +176,8 @@ export function GlobalSearchDialog({ open, onOpenChange }: GlobalSearchDialogPro
       } else if (item.type === 'message') {
         router.push(`/chat/${item.sessionId}?message=${item.messageId}${qParam}`);
       } else if (item.type === 'file') {
-        router.push(`/chat/${item.sessionId}?file=${encodeURIComponent(item.path)}${qParam}`);
+        const seek = Date.now().toString(36);
+        router.push(`/chat/${item.sessionId}?file=${encodeURIComponent(item.path)}&seek=${seek}${qParam}`);
       }
     },
     [router, onOpenChange, query],

--- a/src/components/layout/GlobalSearchDialog.tsx
+++ b/src/components/layout/GlobalSearchDialog.tsx
@@ -52,15 +52,15 @@ interface GlobalSearchDialogProps {
 }
 
 const TYPE_ICONS: Record<string, IconComponent> = {
-  session: ChatCircleText,
-  message: NotePencil,
-  file: Folder,
+  sessions: ChatCircleText,
+  messages: NotePencil,
+  files: Folder,
 };
 
 const TYPE_LABELS: Record<string, string> = {
-  session: 'Sessions',
-  message: 'Messages',
-  file: 'Files',
+  sessions: 'Sessions',
+  messages: 'Messages',
+  files: 'Files',
 };
 
 export function GlobalSearchDialog({ open, onOpenChange }: GlobalSearchDialogProps) {

--- a/src/components/layout/GlobalSearchDialog.tsx
+++ b/src/components/layout/GlobalSearchDialog.tsx
@@ -1,0 +1,226 @@
+'use client';
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { useRouter } from 'next/navigation';
+import { useTranslation } from '@/hooks/useTranslation';
+import {
+  CommandDialog,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+} from '@/components/ui/command';
+import { MagnifyingGlass, ChatCircleText, NotePencil, Folder } from '@/components/ui/icon';
+import type { IconComponent } from '@/types';
+
+interface SearchResultSession {
+  type: 'session';
+  id: string;
+  title: string;
+  projectName: string;
+  updatedAt: string;
+}
+
+interface SearchResultMessage {
+  type: 'message';
+  sessionId: string;
+  sessionTitle: string;
+  messageId: string;
+  role: 'user' | 'assistant';
+  snippet: string;
+  createdAt: string;
+}
+
+interface SearchResultFile {
+  type: 'file';
+  sessionId: string;
+  sessionTitle: string;
+  path: string;
+  name: string;
+}
+
+interface SearchResponse {
+  sessions: SearchResultSession[];
+  messages: SearchResultMessage[];
+  files: SearchResultFile[];
+}
+
+interface GlobalSearchDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+const TYPE_ICONS: Record<string, IconComponent> = {
+  session: ChatCircleText,
+  message: NotePencil,
+  file: Folder,
+};
+
+const TYPE_LABELS: Record<string, string> = {
+  session: 'Sessions',
+  message: 'Messages',
+  file: 'Files',
+};
+
+export function GlobalSearchDialog({ open, onOpenChange }: GlobalSearchDialogProps) {
+  const { t } = useTranslation();
+  const router = useRouter();
+  const [query, setQuery] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [results, setResults] = useState<SearchResponse>({ sessions: [], messages: [], files: [] });
+  const abortRef = useRef<AbortController | null>(null);
+
+  const performSearch = useCallback(async (q: string) => {
+    if (abortRef.current) {
+      abortRef.current.abort();
+    }
+    if (!q.trim()) {
+      setResults({ sessions: [], messages: [], files: [] });
+      setLoading(false);
+      return;
+    }
+
+    const controller = new AbortController();
+    abortRef.current = controller;
+    setLoading(true);
+
+    try {
+      const res = await fetch(`/api/search?q=${encodeURIComponent(q)}`, {
+        signal: controller.signal,
+      });
+      if (!res.ok) throw new Error('Search failed');
+      const data: SearchResponse = await res.json();
+      if (!controller.signal.aborted) {
+        setResults(data);
+      }
+    } catch {
+      if (!controller.signal.aborted) {
+        setResults({ sessions: [], messages: [], files: [] });
+      }
+    } finally {
+      if (!controller.signal.aborted) {
+        setLoading(false);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      performSearch(query);
+    }, 150);
+    return () => clearTimeout(timer);
+  }, [query, performSearch]);
+
+  useEffect(() => {
+    if (!open) {
+      setQuery('');
+      setResults({ sessions: [], messages: [], files: [] });
+    }
+  }, [open]);
+
+  const handleSelect = useCallback(
+    (item: SearchResultSession | SearchResultMessage | SearchResultFile) => {
+      onOpenChange(false);
+      if (item.type === 'session') {
+        router.push(`/chat/${item.id}`);
+      } else if (item.type === 'message') {
+        router.push(`/chat/${item.sessionId}`);
+      } else if (item.type === 'file') {
+        // For files, navigate to the session and let the file tree show it
+        router.push(`/chat/${item.sessionId}`);
+      }
+    },
+    [router, onOpenChange],
+  );
+
+  const hasResults =
+    results.sessions.length > 0 ||
+    results.messages.length > 0 ||
+    results.files.length > 0;
+
+  const renderGroup = (
+    key: keyof SearchResponse,
+    items: (SearchResultSession | SearchResultMessage | SearchResultFile)[],
+  ) => {
+    if (items.length === 0) return null;
+    const Icon = TYPE_ICONS[key];
+    return (
+      <CommandGroup key={key} heading={TYPE_LABELS[key]}>
+        {items.map((item, idx) => (
+          <CommandItem
+            key={`${key}-${idx}`}
+            value={`${key}-${idx}-${item.type === 'session' ? item.id : item.type === 'message' ? item.messageId : item.path}`}
+            onSelect={() => handleSelect(item)}
+            className="flex items-start gap-2 py-2"
+          >
+            <Icon size={16} className="mt-0.5 shrink-0 text-muted-foreground" />
+            <div className="min-w-0 flex-1">
+              {item.type === 'session' && (
+                <>
+                  <p className="truncate text-sm">{item.title}</p>
+                  {item.projectName && (
+                    <p className="truncate text-xs text-muted-foreground">{item.projectName}</p>
+                  )}
+                </>
+              )}
+              {item.type === 'message' && (
+                <>
+                  <p className="truncate text-xs text-muted-foreground">
+                    {item.sessionTitle} · {item.role === 'user' ? 'User' : 'Assistant'}
+                  </p>
+                  <p className="truncate text-sm">{item.snippet}</p>
+                </>
+              )}
+              {item.type === 'file' && (
+                <>
+                  <p className="truncate text-sm">{item.name}</p>
+                  <p className="truncate text-xs text-muted-foreground">{item.sessionTitle}</p>
+                </>
+              )}
+            </div>
+          </CommandItem>
+        ))}
+      </CommandGroup>
+    );
+  };
+
+  return (
+    <CommandDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Global Search"
+      description="Search across sessions, messages, and files"
+      className="sm:max-w-lg"
+      showCloseButton={false}
+    >
+      <CommandInput
+        placeholder="Search... (try sessions:, messages:, files:)"
+        value={query}
+        onValueChange={setQuery}
+        className="h-12"
+      />
+      <CommandList className="max-h-[60vh]">
+        {!query && !loading && (
+          <div className="py-6 text-center text-sm text-muted-foreground">
+            <p>Type to search across sessions and messages</p>
+            <p className="mt-1 text-xs">
+              Prefix with <code className="rounded bg-muted px-1">sessions:</code>{' '}
+              <code className="rounded bg-muted px-1">messages:</code>{' '}
+              <code className="rounded bg-muted px-1">files:</code> to narrow scope
+            </p>
+          </div>
+        )}
+        {query && !loading && !hasResults && (
+          <CommandEmpty>No results found</CommandEmpty>
+        )}
+        {renderGroup('sessions', results.sessions)}
+        {renderGroup('messages', results.messages)}
+        {renderGroup('files', results.files)}
+        {loading && (
+          <div className="py-4 text-center text-sm text-muted-foreground">Searching...</div>
+        )}
+      </CommandList>
+    </CommandDialog>
+  );
+}

--- a/src/components/layout/GlobalSearchDialog.tsx
+++ b/src/components/layout/GlobalSearchDialog.tsx
@@ -54,6 +54,8 @@ interface GlobalSearchDialogProps {
   onOpenChange: (open: boolean) => void;
 }
 
+type SearchScope = 'all' | 'sessions' | 'messages' | 'files';
+
 const TYPE_ICONS: Record<string, IconComponent> = {
   sessions: ChatCircleText,
   messages: NotePencil,
@@ -82,17 +84,30 @@ export function GlobalSearchDialog({ open, onOpenChange }: GlobalSearchDialogPro
   const abortRef = useRef<AbortController | null>(null);
   const composingRef = useRef(false);
   const normalizedQuery = query.trim();
-  const searchTerm = useMemo(() => {
+  const parsedQuery = useMemo<{ scope: SearchScope; term: string; prefix: string | null }>(() => {
     const trimmed = query.trim();
     const lower = trimmed.toLowerCase();
-    if (lower.startsWith('session:')) return trimmed.slice(8).trim();
-    if (lower.startsWith('sessions:')) return trimmed.slice(9).trim();
-    if (lower.startsWith('message:')) return trimmed.slice(8).trim();
-    if (lower.startsWith('messages:')) return trimmed.slice(9).trim();
-    if (lower.startsWith('file:')) return trimmed.slice(5).trim();
-    if (lower.startsWith('files:')) return trimmed.slice(6).trim();
-    return trimmed;
+
+    const parsePrefix = (single: string, plural: string, scope: Exclude<SearchScope, 'all'>) => {
+      if (lower.startsWith(`${single}:`)) {
+        return { scope, term: trimmed.slice(single.length + 1).trim(), prefix: `${single}:` };
+      }
+      if (lower.startsWith(`${plural}:`)) {
+        return { scope, term: trimmed.slice(plural.length + 1).trim(), prefix: `${single}:` };
+      }
+      return null;
+    };
+
+    return (
+      parsePrefix('session', 'sessions', 'sessions') ??
+      parsePrefix('message', 'messages', 'messages') ??
+      parsePrefix('file', 'files', 'files') ??
+      { scope: 'all', term: trimmed, prefix: null }
+    );
   }, [query]);
+  const searchTerm = parsedQuery.term;
+  const activeScope = parsedQuery.scope;
+  const activePrefix = parsedQuery.prefix;
 
   const performSearch = useCallback(async (q: string) => {
     if (composingRef.current) return;
@@ -284,6 +299,17 @@ export function GlobalSearchDialog({ open, onOpenChange }: GlobalSearchDialogPro
           setQuery(value);
         }}
       />
+      {normalizedQuery && activeScope !== 'all' && (
+        <div className="flex items-center justify-between border-b border-primary/20 bg-primary/5 px-3 py-1.5 text-xs">
+          <span className="inline-flex items-center gap-1.5 text-primary">
+            <span className="size-1.5 rounded-full bg-primary" />
+            {t('globalSearch.activeScope', { scope: t(TYPE_LABEL_KEYS[activeScope]) })}
+          </span>
+          <code className="rounded border border-primary/25 bg-primary/10 px-1.5 py-0.5 font-mono text-[11px] text-primary">
+            {activePrefix}
+          </code>
+        </div>
+      )}
       <CommandList className="flex-1 min-h-0 overflow-y-auto max-h-none">
         {!query && !loading && (
           <div className="py-6 text-center text-sm text-muted-foreground">

--- a/src/components/layout/GlobalSearchDialog.tsx
+++ b/src/components/layout/GlobalSearchDialog.tsx
@@ -81,6 +81,18 @@ export function GlobalSearchDialog({ open, onOpenChange }: GlobalSearchDialogPro
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set());
   const abortRef = useRef<AbortController | null>(null);
   const composingRef = useRef(false);
+  const normalizedQuery = query.trim();
+  const searchTerm = useMemo(() => {
+    const trimmed = query.trim();
+    const lower = trimmed.toLowerCase();
+    if (lower.startsWith('session:')) return trimmed.slice(8).trim();
+    if (lower.startsWith('sessions:')) return trimmed.slice(9).trim();
+    if (lower.startsWith('message:')) return trimmed.slice(8).trim();
+    if (lower.startsWith('messages:')) return trimmed.slice(9).trim();
+    if (lower.startsWith('file:')) return trimmed.slice(5).trim();
+    if (lower.startsWith('files:')) return trimmed.slice(6).trim();
+    return trimmed;
+  }, [query]);
 
   const performSearch = useCallback(async (q: string) => {
     if (composingRef.current) return;
@@ -88,6 +100,7 @@ export function GlobalSearchDialog({ open, onOpenChange }: GlobalSearchDialogPro
       abortRef.current.abort();
     }
     if (!q.trim()) {
+      abortRef.current = null;
       setResults({ sessions: [], messages: [], files: [] });
       setLoading(false);
       return;
@@ -112,6 +125,7 @@ export function GlobalSearchDialog({ open, onOpenChange }: GlobalSearchDialogPro
       }
     } finally {
       if (!controller.signal.aborted) {
+        abortRef.current = null;
         setLoading(false);
       }
     }
@@ -126,11 +140,20 @@ export function GlobalSearchDialog({ open, onOpenChange }: GlobalSearchDialogPro
 
   useEffect(() => {
     if (!open) {
+      abortRef.current?.abort();
+      abortRef.current = null;
       setQuery('');
       setResults({ sessions: [], messages: [], files: [] });
       setCollapsedGroups(new Set());
+      setLoading(false);
     }
   }, [open]);
+
+  useEffect(() => {
+    return () => {
+      abortRef.current?.abort();
+    };
+  }, []);
 
   const toggleGroup = useCallback((sessionId: string) => {
     setCollapsedGroups(prev => {
@@ -258,7 +281,6 @@ export function GlobalSearchDialog({ open, onOpenChange }: GlobalSearchDialogPro
           composingRef.current = false;
           const value = (e.target as HTMLInputElement).value;
           setQuery(value);
-          performSearch(value);
         }}
       />
       <CommandList className="flex-1 min-h-0 overflow-y-auto max-h-none">
@@ -274,26 +296,23 @@ export function GlobalSearchDialog({ open, onOpenChange }: GlobalSearchDialogPro
             </p>
           </div>
         )}
-        {query && !loading && !hasResults && (
+        {normalizedQuery && !loading && !hasResults && (
           <CommandEmpty>{t('globalSearch.noResults')}</CommandEmpty>
         )}
-        {renderGroup('sessions', results.sessions)}
+        {normalizedQuery && renderGroup('sessions', results.sessions)}
 
-        {groupedMessages.map((group, groupIdx) => {
+        {normalizedQuery && groupedMessages.map((group, groupIdx) => {
           const isCollapsed = collapsedGroups.has(group.messages[0]?.sessionId || `group-${groupIdx}`);
           const sessionId = group.messages[0]?.sessionId || `group-${groupIdx}`;
           return (
-            <CommandGroup
-              key={`msg-group-${groupIdx}`}
-              heading={
-                <div
-                  onClick={(e) => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    toggleGroup(sessionId);
-                  }}
-                  className="flex w-full cursor-pointer items-center gap-1.5 rounded bg-muted/40 px-1 py-1 text-left font-medium text-foreground outline-none"
-                >
+            <CommandGroup key={`msg-group-${groupIdx}`}>
+              <CommandItem
+                value={`message-group-${sessionId}`}
+                onSelect={() => toggleGroup(sessionId)}
+                className="flex w-full items-center gap-1.5 rounded bg-muted/40 px-1 py-1 text-left font-medium text-foreground"
+                aria-expanded={!isCollapsed}
+              >
+                <div className="flex min-w-0 items-center gap-1.5">
                   {isCollapsed ? (
                     <CaretRight size={14} className="shrink-0 text-muted-foreground" />
                   ) : (
@@ -307,8 +326,7 @@ export function GlobalSearchDialog({ open, onOpenChange }: GlobalSearchDialogPro
                     {group.messages.length}
                   </span>
                 </div>
-              }
-            >
+              </CommandItem>
               {!isCollapsed && group.messages.map((item, idx) => {
                 const Icon = CONTENT_TYPE_ICONS[item.contentType];
                 const labelKey: TranslationKey =
@@ -326,7 +344,7 @@ export function GlobalSearchDialog({ open, onOpenChange }: GlobalSearchDialogPro
                   >
                     <Icon size={16} className="mt-0.5 shrink-0 text-muted-foreground" />
                     <div className="min-w-0 flex-1">
-                      <p className="truncate text-sm">{renderHighlightedSnippet(item.snippet, query)}</p>
+                      <p className="truncate text-sm">{renderHighlightedSnippet(item.snippet, searchTerm)}</p>
                       <p className="truncate text-xs text-muted-foreground">{t(labelKey)}</p>
                     </div>
                   </CommandItem>
@@ -336,7 +354,7 @@ export function GlobalSearchDialog({ open, onOpenChange }: GlobalSearchDialogPro
           );
         })}
 
-        {renderGroup('files', results.files)}
+        {normalizedQuery && renderGroup('files', results.files)}
         {loading && (
           <div className="py-4 text-center text-sm text-muted-foreground">{t('globalSearch.searching')}</div>
         )}

--- a/src/components/layout/panels/FileTreePanel.tsx
+++ b/src/components/layout/panels/FileTreePanel.tsx
@@ -18,6 +18,10 @@ export function FileTreePanel() {
   const { t } = useTranslation();
   const [width, setWidth] = useState(TREE_DEFAULT_WIDTH);
 
+  const highlightPath = typeof window !== 'undefined'
+    ? new URLSearchParams(window.location.search).get('file') || undefined
+    : undefined;
+
   const handleResize = useCallback((delta: number) => {
     setWidth((w) => Math.min(TREE_MAX_WIDTH, Math.max(TREE_MIN_WIDTH, w - delta)));
   }, []);
@@ -84,6 +88,7 @@ export function FileTreePanel() {
               workingDirectory={workingDirectory}
               onFileSelect={handleFileSelect}
               onFileAdd={handleFileAdd}
+              highlightPath={highlightPath}
             />
           </div>
         </div>

--- a/src/components/layout/panels/FileTreePanel.tsx
+++ b/src/components/layout/panels/FileTreePanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useCallback } from "react";
+import { useSearchParams } from "next/navigation";
 import { X } from "@/components/ui/icon";
 import { Button } from "@/components/ui/button";
 import { usePanel } from "@/hooks/usePanel";
@@ -16,11 +17,11 @@ const TREE_DEFAULT_WIDTH = 280;
 export function FileTreePanel() {
   const { workingDirectory, sessionId, previewFile, setPreviewFile, setPreviewOpen, setFileTreeOpen } = usePanel();
   const { t } = useTranslation();
+  const searchParams = useSearchParams();
   const [width, setWidth] = useState(TREE_DEFAULT_WIDTH);
 
-  const highlightPath = typeof window !== 'undefined'
-    ? new URLSearchParams(window.location.search).get('file') || undefined
-    : undefined;
+  const highlightPath = searchParams.get('file') || undefined;
+  const highlightSeek = searchParams.get('seek') || undefined;
 
   const handleResize = useCallback((delta: number) => {
     setWidth((w) => Math.min(TREE_MAX_WIDTH, Math.max(TREE_MIN_WIDTH, w - delta)));
@@ -89,6 +90,7 @@ export function FileTreePanel() {
               onFileSelect={handleFileSelect}
               onFileAdd={handleFileAdd}
               highlightPath={highlightPath}
+              highlightSeek={highlightSeek}
             />
           </div>
         </div>

--- a/src/components/project/FileTree.tsx
+++ b/src/components/project/FileTree.tsx
@@ -135,7 +135,7 @@ export function FileTree({ workingDirectory, onFileSelect, onFileAdd, highlightP
   const [searchQuery, setSearchQuery] = useState("");
   const abortRef = useRef<AbortController | null>(null);
   const { t } = useTranslation();
-  const hasFlashedRef = useRef(false);
+  const seekKeyRef = useRef<string | null>(null);
 
   const fetchTree = useCallback(async () => {
     // Always cancel in-flight request first — even when clearing directory,
@@ -220,21 +220,19 @@ export function FileTree({ workingDirectory, onFileSelect, onFileAdd, highlightP
     }
   }, [highlightPath]);
 
-  // Reset flash tracker when highlightPath changes
+  // Scroll to and flash highlighted file from search results.
+  // Guarded by seekKeyRef so tree auto-refreshes don't re-trigger the scroll.
   useEffect(() => {
-    hasFlashedRef.current = false;
-  }, [highlightPath]);
+    if (!highlightPath || tree.length === 0) return;
+    if (seekKeyRef.current === highlightPath) return;
+    seekKeyRef.current = highlightPath;
 
-  // Scroll to and flash highlighted file from search results
-  useEffect(() => {
-    if (!highlightPath || hasFlashedRef.current || tree.length === 0) return;
     let attempts = 0;
     const maxAttempts = 15;
     const interval = setInterval(() => {
       attempts++;
       const el = document.getElementById('file-tree-highlight');
       if (el) {
-        hasFlashedRef.current = true;
         el.scrollIntoView({ behavior: 'smooth', block: 'center' });
         clearInterval(interval);
       } else if (attempts >= maxAttempts) {
@@ -242,7 +240,7 @@ export function FileTree({ workingDirectory, onFileSelect, onFileAdd, highlightP
       }
     }, 100);
     return () => clearInterval(interval);
-  }, [highlightPath, tree, loading]);
+  }, [highlightPath, tree]);
 
   return (
     <div className="flex flex-col h-full min-h-0">

--- a/src/components/project/FileTree.tsx
+++ b/src/components/project/FileTree.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback, useRef, useMemo } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { ArrowsClockwise, MagnifyingGlass, FileCode, Code, File } from "@/components/ui/icon";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -203,30 +203,46 @@ export function FileTree({ workingDirectory, onFileSelect, onFileAdd, highlightP
     return () => window.removeEventListener('refresh-file-tree', handler);
   }, [fetchTree]);
 
+  // Controlled expansion state for search-driven highlighting
+  const [expandedPaths, setExpandedPaths] = useState<Set<string>>(new Set());
+
+  // Sync expanded paths when highlightPath changes
+  useEffect(() => {
+    if (highlightPath) {
+      const next = new Set<string>();
+      for (const parent of getParentPaths(highlightPath)) {
+        next.add(parent);
+      }
+      next.add(highlightPath);
+      setExpandedPaths(next);
+    } else {
+      setExpandedPaths(new Set());
+    }
+  }, [highlightPath]);
+
+  // Reset flash tracker when highlightPath changes
+  useEffect(() => {
+    hasFlashedRef.current = false;
+  }, [highlightPath]);
+
   // Scroll to and flash highlighted file from search results
   useEffect(() => {
-    if (!highlightPath || hasFlashedRef.current) return;
-    const timer = setTimeout(() => {
+    if (!highlightPath || hasFlashedRef.current || tree.length === 0) return;
+    let attempts = 0;
+    const maxAttempts = 15;
+    const interval = setInterval(() => {
+      attempts++;
       const el = document.getElementById('file-tree-highlight');
       if (el) {
         hasFlashedRef.current = true;
         el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        clearInterval(interval);
+      } else if (attempts >= maxAttempts) {
+        clearInterval(interval);
       }
-    }, 300);
-    return () => clearTimeout(timer);
+    }, 100);
+    return () => clearInterval(interval);
   }, [highlightPath, tree, loading]);
-
-  // Default to all directories collapsed; expand parents and the target itself
-  const defaultExpanded = useMemo(() => {
-    const expanded = new Set<string>();
-    if (highlightPath) {
-      for (const parent of getParentPaths(highlightPath)) {
-        expanded.add(parent);
-      }
-      expanded.add(highlightPath);
-    }
-    return expanded;
-  }, [highlightPath]);
 
   return (
     <div className="flex flex-col h-full min-h-0">
@@ -265,7 +281,8 @@ export function FileTree({ workingDirectory, onFileSelect, onFileAdd, highlightP
           </p>
         ) : (
           <AIFileTree
-            defaultExpanded={defaultExpanded}
+            expanded={expandedPaths}
+            onExpandedChange={setExpandedPaths}
             // eslint-disable-next-line @typescript-eslint/no-explicit-any -- AI Elements FileTree onSelect type conflicts with HTMLAttributes.onSelect
             onSelect={onFileSelect as any}
             onAdd={onFileAdd}

--- a/src/components/project/FileTree.tsx
+++ b/src/components/project/FileTree.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { ArrowsClockwise, MagnifyingGlass, FileCode, Code, File } from "@/components/ui/icon";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -18,6 +18,7 @@ interface FileTreeProps {
   workingDirectory: string;
   onFileSelect: (path: string) => void;
   onFileAdd?: (path: string) => void;
+  highlightPath?: string;
 }
 
 function getFileIcon(extension?: string): ReactNode {
@@ -77,27 +78,37 @@ function filterTree(nodes: FileTreeNode[], query: string): FileTreeNode[] {
     }));
 }
 
-function RenderTreeNodes({ nodes, searchQuery }: { nodes: FileTreeNode[]; searchQuery: string }) {
+function RenderTreeNodes({ nodes, searchQuery, highlightPath }: { nodes: FileTreeNode[]; searchQuery: string; highlightPath?: string }) {
   const filtered = searchQuery ? filterTree(nodes, searchQuery) : nodes;
 
   return (
     <>
       {filtered.map((node) => {
         if (node.type === "directory") {
+          const isHighlighted = node.path === highlightPath;
           return (
-            <FileTreeFolder key={node.path} path={node.path} name={node.name}>
+            <FileTreeFolder
+              key={node.path}
+              path={node.path}
+              name={node.name}
+              className={cn(isHighlighted && "file-tree-flash")}
+              id={isHighlighted ? `file-tree-highlight` : undefined}
+            >
               {node.children && (
-                <RenderTreeNodes nodes={node.children} searchQuery={searchQuery} />
+                <RenderTreeNodes nodes={node.children} searchQuery={searchQuery} highlightPath={highlightPath} />
               )}
             </FileTreeFolder>
           );
         }
+        const isHighlighted = node.path === highlightPath;
         return (
           <FileTreeFile
             key={node.path}
             path={node.path}
             name={node.name}
             icon={getFileIcon(node.extension)}
+            className={cn(isHighlighted && "file-tree-flash")}
+            id={isHighlighted ? `file-tree-highlight` : undefined}
           />
         );
       })}
@@ -105,13 +116,26 @@ function RenderTreeNodes({ nodes, searchQuery }: { nodes: FileTreeNode[]; search
   );
 }
 
-export function FileTree({ workingDirectory, onFileSelect, onFileAdd }: FileTreeProps) {
+function getParentPaths(filePath: string): string[] {
+  const parents: string[] = [];
+  let current = filePath;
+  while (true) {
+    const parent = current.substring(0, current.lastIndexOf('/'));
+    if (!parent || parent === current) break;
+    parents.push(parent);
+    current = parent;
+  }
+  return parents;
+}
+
+export function FileTree({ workingDirectory, onFileSelect, onFileAdd, highlightPath }: FileTreeProps) {
   const [tree, setTree] = useState<FileTreeNode[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
   const abortRef = useRef<AbortController | null>(null);
   const { t } = useTranslation();
+  const hasFlashedRef = useRef(false);
 
   const fetchTree = useCallback(async () => {
     // Always cancel in-flight request first — even when clearing directory,
@@ -179,8 +203,30 @@ export function FileTree({ workingDirectory, onFileSelect, onFileAdd }: FileTree
     return () => window.removeEventListener('refresh-file-tree', handler);
   }, [fetchTree]);
 
-  // Default to all directories collapsed
-  const defaultExpanded = new Set<string>();
+  // Scroll to and flash highlighted file from search results
+  useEffect(() => {
+    if (!highlightPath || hasFlashedRef.current) return;
+    const timer = setTimeout(() => {
+      const el = document.getElementById('file-tree-highlight');
+      if (el) {
+        hasFlashedRef.current = true;
+        el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      }
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [highlightPath, tree, loading]);
+
+  // Default to all directories collapsed; expand parents and the target itself
+  const defaultExpanded = useMemo(() => {
+    const expanded = new Set<string>();
+    if (highlightPath) {
+      for (const parent of getParentPaths(highlightPath)) {
+        expanded.add(parent);
+      }
+      expanded.add(highlightPath);
+    }
+    return expanded;
+  }, [highlightPath]);
 
   return (
     <div className="flex flex-col h-full min-h-0">
@@ -225,7 +271,7 @@ export function FileTree({ workingDirectory, onFileSelect, onFileAdd }: FileTree
             onAdd={onFileAdd}
             className="border-0 rounded-none"
           >
-            <RenderTreeNodes nodes={tree} searchQuery={searchQuery} />
+            <RenderTreeNodes nodes={tree} searchQuery={searchQuery} highlightPath={highlightPath} />
           </AIFileTree>
         )}
       </div>

--- a/src/components/project/FileTree.tsx
+++ b/src/components/project/FileTree.tsx
@@ -19,6 +19,7 @@ interface FileTreeProps {
   onFileSelect: (path: string) => void;
   onFileAdd?: (path: string) => void;
   highlightPath?: string;
+  highlightSeek?: string;
 }
 
 function getFileIcon(extension?: string): ReactNode {
@@ -128,7 +129,7 @@ function getParentPaths(filePath: string): string[] {
   return parents;
 }
 
-export function FileTree({ workingDirectory, onFileSelect, onFileAdd, highlightPath }: FileTreeProps) {
+export function FileTree({ workingDirectory, onFileSelect, onFileAdd, highlightPath, highlightSeek }: FileTreeProps) {
   const [tree, setTree] = useState<FileTreeNode[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -218,14 +219,15 @@ export function FileTree({ workingDirectory, onFileSelect, onFileAdd, highlightP
     } else {
       setExpandedPaths(new Set());
     }
-  }, [highlightPath]);
+  }, [highlightPath, highlightSeek]);
 
   // Scroll to and flash highlighted file from search results.
   // Guarded by seekKeyRef so tree auto-refreshes don't re-trigger the scroll.
   useEffect(() => {
     if (!highlightPath || tree.length === 0) return;
-    if (seekKeyRef.current === highlightPath) return;
-    seekKeyRef.current = highlightPath;
+    const seekTargetKey = `${highlightPath}::${highlightSeek || ''}`;
+    if (seekKeyRef.current === seekTargetKey) return;
+    seekKeyRef.current = seekTargetKey;
 
     let attempts = 0;
     const maxAttempts = 15;
@@ -240,7 +242,7 @@ export function FileTree({ workingDirectory, onFileSelect, onFileAdd, highlightP
       }
     }, 100);
     return () => clearInterval(interval);
-  }, [highlightPath, tree]);
+  }, [highlightPath, highlightSeek, tree]);
 
   return (
     <div className="flex flex-col h-full min-h-0">

--- a/src/components/project/FileTree.tsx
+++ b/src/components/project/FileTree.tsx
@@ -138,6 +138,13 @@ export function FileTree({ workingDirectory, onFileSelect, onFileAdd, highlightP
   const { t } = useTranslation();
   const seekKeyRef = useRef<string | null>(null);
 
+  // Clear stale tree data when switching projects to avoid cross-session seek races.
+  useEffect(() => {
+    setTree([]);
+    setError(null);
+    seekKeyRef.current = null;
+  }, [workingDirectory]);
+
   const fetchTree = useCallback(async () => {
     // Always cancel in-flight request first — even when clearing directory,
     // otherwise a stale response from the old project can arrive and repopulate the tree.
@@ -224,10 +231,9 @@ export function FileTree({ workingDirectory, onFileSelect, onFileAdd, highlightP
   // Scroll to and flash highlighted file from search results.
   // Guarded by seekKeyRef so tree auto-refreshes don't re-trigger the scroll.
   useEffect(() => {
-    if (!highlightPath || tree.length === 0) return;
-    const seekTargetKey = `${highlightPath}::${highlightSeek || ''}`;
+    if (!workingDirectory || !highlightPath || tree.length === 0) return;
+    const seekTargetKey = `${workingDirectory}::${highlightPath}::${highlightSeek || ''}`;
     if (seekKeyRef.current === seekTargetKey) return;
-    seekKeyRef.current = seekTargetKey;
 
     let attempts = 0;
     const maxAttempts = 15;
@@ -236,13 +242,14 @@ export function FileTree({ workingDirectory, onFileSelect, onFileAdd, highlightP
       const el = document.getElementById('file-tree-highlight');
       if (el) {
         el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        seekKeyRef.current = seekTargetKey;
         clearInterval(interval);
       } else if (attempts >= maxAttempts) {
         clearInterval(interval);
       }
     }, 100);
     return () => clearInterval(interval);
-  }, [highlightPath, highlightSeek, tree]);
+  }, [workingDirectory, highlightPath, highlightSeek, tree]);
 
   return (
     <div className="flex flex-col h-full min-h-0">

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -35,12 +35,14 @@ function CommandDialog({
   children,
   className,
   showCloseButton = true,
+  shouldFilter,
   ...props
 }: React.ComponentProps<typeof Dialog> & {
   title?: string
   description?: string
   className?: string
   showCloseButton?: boolean
+  shouldFilter?: boolean
 }) {
   return (
     <Dialog {...props}>
@@ -52,7 +54,10 @@ function CommandDialog({
         className={cn("overflow-hidden p-0", className)}
         showCloseButton={showCloseButton}
       >
-        <Command className="[&_[cmdk-group-heading]]:text-muted-foreground **:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+        <Command
+          shouldFilter={shouldFilter}
+          className="[&_[cmdk-group-heading]]:text-muted-foreground **:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5"
+        >
           {children}
         </Command>
       </DialogContent>

--- a/src/hooks/useGlobalSearchShortcut.ts
+++ b/src/hooks/useGlobalSearchShortcut.ts
@@ -1,0 +1,28 @@
+import { useEffect, useCallback } from 'react';
+
+export function useGlobalSearchShortcut(onOpen: () => void) {
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      const isModifier = e.metaKey || e.ctrlKey;
+      if (isModifier && e.key.toLowerCase() === 'k') {
+        // Avoid intercepting when an input/textarea is focused
+        const active = document.activeElement;
+        const isEditing =
+          active instanceof HTMLInputElement ||
+          active instanceof HTMLTextAreaElement ||
+          active?.getAttribute('contenteditable') === 'true';
+        // Still allow shortcut when focus is on body or non-editable elements
+        if (!isEditing) {
+          e.preventDefault();
+          onOpen();
+        }
+      }
+    },
+    [onOpen],
+  );
+
+  useEffect(() => {
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [handleKeyDown]);
+}

--- a/src/hooks/useGlobalSearchShortcut.ts
+++ b/src/hooks/useGlobalSearchShortcut.ts
@@ -5,17 +5,9 @@ export function useGlobalSearchShortcut(onOpen: () => void) {
     (e: KeyboardEvent) => {
       const isModifier = e.metaKey || e.ctrlKey;
       if (isModifier && e.key.toLowerCase() === 'k') {
-        // Avoid intercepting when an input/textarea is focused
-        const active = document.activeElement;
-        const isEditing =
-          active instanceof HTMLInputElement ||
-          active instanceof HTMLTextAreaElement ||
-          active?.getAttribute('contenteditable') === 'true';
-        // Still allow shortcut when focus is on body or non-editable elements
-        if (!isEditing) {
-          e.preventDefault();
-          onOpen();
-        }
+        // Global search should be reachable from anywhere, including the chat input.
+        e.preventDefault();
+        onOpen();
       }
     },
     [onOpen],

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -39,11 +39,25 @@ const en = {
   'chatList.showMore': 'Show {count} more',
   'chatList.showLess': 'Show less',
 
+  // ── Global search ───────────────────────────────────────────
+  'globalSearch.placeholder': 'Search... (try session:, message:, file:)',
+  'globalSearch.hint': 'Type to search across sessions and messages',
+  'globalSearch.hintPrefix': 'Prefix with',
+  'globalSearch.toNarrowScope': 'to narrow scope',
+  'globalSearch.noResults': 'No results found',
+  'globalSearch.searching': 'Searching...',
+  'globalSearch.sessions': 'Sessions',
+  'globalSearch.messages': 'Messages',
+  'globalSearch.files': 'Files',
+  'globalSearch.toolLabel': 'Tool',
+
   // ── Message list ────────────────────────────────────────────
   'messageList.claudeChat': 'CodePilot Chat',
   'messageList.emptyDescription': 'Start a conversation with CodePilot. Ask questions, get help with code, or explore ideas.',
   'messageList.loadEarlier': 'Load earlier messages',
   'messageList.loading': 'Loading...',
+  'messageList.userLabel': 'User',
+  'messageList.assistantLabel': 'Assistant',
 
   // ── Message input ───────────────────────────────────────────
   'messageInput.attachFiles': 'Attach files',

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -49,6 +49,7 @@ const en = {
   'globalSearch.sessions': 'Sessions',
   'globalSearch.messages': 'Messages',
   'globalSearch.files': 'Files',
+  'globalSearch.activeScope': 'Searching in {scope}',
   'globalSearch.toolLabel': 'Tool',
 
   // ── Message list ────────────────────────────────────────────

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -36,11 +36,25 @@ const zh: Record<TranslationKey, string> = {
   'chatList.showMore': '展开更多（{count} 条）',
   'chatList.showLess': '收起',
 
+  // ── Global search ───────────────────────────────────────────
+  'globalSearch.placeholder': '搜索...（尝试 session: / message: / file:）',
+  'globalSearch.hint': '输入关键词搜索会话和消息',
+  'globalSearch.hintPrefix': '使用前缀',
+  'globalSearch.toNarrowScope': '限定搜索范围',
+  'globalSearch.noResults': '未找到结果',
+  'globalSearch.searching': '搜索中...',
+  'globalSearch.sessions': '会话',
+  'globalSearch.messages': '消息',
+  'globalSearch.files': '文件',
+  'globalSearch.toolLabel': '工具',
+
   // ── Message list ────────────────────────────────────────────
   'messageList.claudeChat': 'CodePilot 对话',
   'messageList.emptyDescription': '开始与 CodePilot 对话。提问、获取代码帮助或探索想法。',
   'messageList.loadEarlier': '加载更早的消息',
   'messageList.loading': '加载中...',
+  'messageList.userLabel': '用户',
+  'messageList.assistantLabel': '助手',
 
   // ── Message input ───────────────────────────────────────────
   'messageInput.attachFiles': '附加文件',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -46,6 +46,7 @@ const zh: Record<TranslationKey, string> = {
   'globalSearch.sessions': '会话',
   'globalSearch.messages': '消息',
   'globalSearch.files': '文件',
+  'globalSearch.activeScope': '当前搜索范围：{scope}',
   'globalSearch.toolLabel': '工具',
 
   // ── Message list ────────────────────────────────────────────

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1203,6 +1203,8 @@ export interface SessionSearchResult {
   createdAt: string;
   /** Snippet extracted from content with query context (up to ~200 chars). */
   snippet: string;
+  /** Derived message type for search UI icons/filtering. */
+  contentType: 'user' | 'assistant' | 'tool';
 }
 
 /**
@@ -1282,10 +1284,26 @@ export function searchMessages(
     role: row.role,
     createdAt: row.createdAt,
     snippet: buildSnippet(row.content, lowerQuery),
+    contentType: deriveContentType(row.role, row.content),
   }));
 }
 
-/** Extract a ~200-char snippet around the first match (case-insensitive). */
+function deriveContentType(role: 'user' | 'assistant', content: string): 'user' | 'assistant' | 'tool' {
+  if (role === 'user') return 'user';
+  try {
+    const parsed = JSON.parse(content);
+    if (Array.isArray(parsed)) {
+      if (parsed.some((b: unknown) => typeof b === 'object' && b !== null && (b as { type?: string }).type === 'tool_use')) {
+        return 'tool';
+      }
+    }
+  } catch {
+    // fallback to plain text assistant
+  }
+  return 'assistant';
+}
+
+/** Extract a ~140-char snippet with the match near the front so it survives single-line truncation in UI lists. */
 function buildSnippet(content: string, lowerQuery: string): string {
   if (!content) return '';
   const lowerContent = content.toLowerCase();
@@ -1295,8 +1313,10 @@ function buildSnippet(content: string, lowerQuery: string): string {
     // and the query matches bytes inside quoted strings.
     return content.length > 200 ? content.slice(0, 200) + '…' : content;
   }
-  const start = Math.max(0, idx - 80);
-  const end = Math.min(content.length, idx + lowerQuery.length + 120);
+  const LEADING = 28;
+  const TAIL = 100;
+  const start = Math.max(0, idx - LEADING);
+  const end = Math.min(content.length, idx + lowerQuery.length + TAIL);
   const prefix = start > 0 ? '…' : '';
   const suffix = end < content.length ? '…' : '';
   return prefix + content.slice(start, end) + suffix;


### PR DESCRIPTION
## Summary

在原有“仅搜索会话名”的基础上，升级为 Obsidian 风格的全局搜索：支持搜索会话、消息内容、文件、目录，并附带上下文预览和直达定位。

> **Scope 说明（更新）：**
> 1. 本 PR 交付的是稳定可用的全局搜索 UI/UX，以及文件/目录定位链路。  
> 2. **session 内 message 精确滚动定位（点击消息后在同一会话内滚动并高亮到某条消息）当前不在本 PR 范围内**。  
> 3. 原因是该能力仍受已知滚动竞争问题影响（与会话区自动滚动/`StickToBottom` 存在 race condition），为避免引入不稳定体验，暂不在本 PR 合入。

---

## 与原搜索的区别

| 维度 | 之前 | 现在 |
|------|------|------|
| 搜索范围 | 只能搜 **会话标题** | 会话标题、**消息内容**、**文件名**、**目录名** |
| 结果展示 | 平铺 10 条混合结果，看不出消息属于哪个会话 | 消息按 **会话折叠分组**；文件、会话各自独立成组 |
| 命中预览 | 无 | 显示消息 snippet，**关键词高亮** |
| 文件定位 | 无 | 点击后自动打开文件树、展开目录、滚动到目标节点并闪烁高亮 |

<img width="800" height="484" alt="global-search-demo" src="https://github.com/user-attachments/assets/693420cd-a6be-40da-a643-d0cbca1de83d" />

---

## 设计思路

### 1. 搜索结果分组展示
之前搜到 10 条消息时，根本不知道它们来自哪几个会话。现在消息按会话折叠分组，文件和会话也各自成组，扫一眼就能定位到想找的上下文。

### 2. 结果 preview 更友好
- 对话框放宽到 `sm:max-w-3xl`，snippet 能显示更多内容
- 固定 `min(80vh, 520px)` 高度，输入框始终置顶，不会因结果加载而上下跳动
- 命中关键词用主题色高亮，一眼知道为什么匹配
- 用图标区分 human / assistant / tool / file / folder

### 3. 文件/目录可搜索、可直达
- 之前只能搜到文件，现在目录也可以被搜索（比如只记得 tests/ 但不记得具体文件名）
- 点击后自动打开右侧文件树、展开父目录、滚动到目标节点并闪烁高亮
- 考虑到文件树会在 AI 流式输出结束后自动刷新，加了 `seekKeyRef` 保护，防止刷新后把用户正在手动浏览的滚动位置又拽回高亮节点

### 4. 搜索前缀更顺手
提示文案改成单数 `session:` / `message:` / `file:`，API 同时兼容复数旧写法。snippet 截取策略把关键词往前靠，避免被单行 truncate 截掉。

---

## Follow-up fixes (post review)

根据 UI/UX 验收反馈，补充了以下稳定性与可用性修复：

1. **默认全局搜索补齐文件/目录维度**
   - `scope=all` 现在也会返回 files（不再需要必须写 `file:` 才能命中）

2. **文件 deep-link 不再被默认面板初始化覆盖**
   - 从搜索结果进入 `?file=` 时，优先保持文件树打开，避免“点了结果但文件树被关掉”

3. **关闭搜索弹窗时中止 in-flight 请求**
   - close/unmount 都会 abort 当前请求，避免弹窗重开后出现残留旧结果

4. **关键词高亮对前缀查询生效**
   - `session:xxx / message:xxx / file:xxx` 会用解析后的实际关键词 `xxx` 进行高亮

5. **消息分组折叠头支持键盘操作**
   - 用可聚焦的 `CommandItem` 承载折叠逻辑，支持 command 列表内键盘导航与回车切换

6. **IME 结束时避免重复请求**
   - 去掉 `onCompositionEnd` 里的即时搜索，统一走去抖查询

7. **文件树重复定位与跨会话定位稳定性修复**
   - 引入 `seek` 标识并将定位键扩展为 `path + seek (+ workingDirectory)`，避免第二次同路径跳转被误判为“已定位”
   - 在工作目录切换时清理陈旧 seek 状态，仅在真实命中节点后才标记完成定位

8. **更新检查接口降级处理**
   - 当上游 release 拉取失败时，`/api/app/updates` 返回可降级响应，避免前端出现 502 噪音

---

## v0.50.3 验收更新

已将本 PR 分支对齐到 `v0.50.3` 基线后重新验收：

- [x] `npm run test` 通过（1047/1047）
- [x] `npm run build` 通过
- [x] `playwright`：`global-search-file-seek.spec.ts` 通过
- [x] `playwright`：`global-search-modes.spec.ts` 通过

结论：在 `v0.50.3` 上，当前 PR 覆盖范围内的搜索功能与 UI/UX 未发现新增回归。

---

## Test plan

- [x] 搜索关键词 → 消息按会话分组、图标正常
- [x] 默认搜索（不加前缀）可返回文件/目录结果
- [x] `file:xxx` → 仅显示文件/目录结果
- [x] 点击文件/目录 → 文件树自动展开并定位到目标
- [x] 同一 session 重复点击同一路径结果可重复定位
- [x] 跨 session 点击文件结果可正确定位
- [x] 树自动刷新后，手动滚动不再被抢回
- [x] 缩放窗口 → 对话框高度平滑变化，无跳动
- [x] 前缀查询下关键词高亮正确
- [x] 键盘可切换消息分组折叠

Relates to #482


---

## Latest incremental update

- 新增：当输入命中有效前缀（`session:` / `message:` / `file:`）时，在搜索框下方显示主题色范围提示条（含当前 scope 文案与前缀标识），降低“当前正在搜哪一类内容”的认知负担。
