### PR TITLE
fix(network): 修复重连状态展示与代理未生效问题

### DIFF
--- a/src/__tests__/e2e/network-acceptance.spec.ts
+++ b/src/__tests__/e2e/network-acceptance.spec.ts
@@ -1,0 +1,461 @@
+import { expect, test, type Page } from '@playwright/test';
+import { goToChat, goToSettings } from '../helpers';
+
+type AppSettingsStore = Record<string, string>;
+
+function sseBody(events: Array<{ type: string; data: string }>): string {
+  return events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join('');
+}
+
+function composerInput(page: Page) {
+  return page.locator(
+    'textarea[placeholder*="Message"], textarea[placeholder*="消息"], textarea[placeholder*="Claude"], textarea[placeholder*="Send"]'
+  ).first();
+}
+
+async function installSessionDetailMocks(page: Page, assistantContent: string) {
+  await page.route('**/api/chat/sessions/sess-e2e-network', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        session: {
+          id: 'sess-e2e-network',
+          title: 'E2E Network Session',
+          working_directory: '/tmp/codepilot-e2e',
+          model: 'gpt-5.3-codex-spark',
+          provider_id: 'openai-oauth',
+          permission_profile: 'default',
+          mode: 'code',
+          context_summary: '',
+        },
+      }),
+    });
+  });
+
+  await page.route('**/api/chat/sessions/sess-e2e-network/messages*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        messages: [
+          {
+            id: 'msg-user-e2e',
+            session_id: 'sess-e2e-network',
+            role: 'user',
+            content: 'network acceptance message',
+            created_at: new Date().toISOString(),
+            token_usage: null,
+          },
+          {
+            id: 'msg-assistant-e2e',
+            session_id: 'sess-e2e-network',
+            role: 'assistant',
+            content: assistantContent,
+            created_at: new Date().toISOString(),
+            token_usage: null,
+          },
+        ],
+        hasMore: false,
+      }),
+    });
+  });
+}
+
+async function dismissBlockingDialogOverlay(page: Page) {
+  const overlay = page.locator('[data-slot="dialog-overlay"][data-state="open"]');
+  if (await overlay.count()) {
+    await page.keyboard.press('Escape');
+    await overlay.first().waitFor({ state: 'hidden', timeout: 2000 }).catch(() => {});
+  }
+}
+
+async function installCommonChatMocks(page: Page) {
+  await page.route('**/api/setup/recent-projects*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ projects: [] }),
+    });
+  });
+
+  await page.route('**/api/setup*', async (route) => {
+    const method = route.request().method();
+    if (method !== 'GET') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true }),
+      });
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        completed: true,
+        claude: 'completed',
+        provider: 'completed',
+        project: 'completed',
+        defaultProject: '/tmp/codepilot-e2e',
+      }),
+    });
+  });
+
+  await page.route('**/api/files/browse?*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ files: [], directories: [] }),
+    });
+  });
+
+  await page.route('**/api/settings/workspace', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ path: '', valid: false, state: {} }),
+    });
+  });
+
+  await page.route('**/api/providers/models', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        groups: [
+          {
+            provider_id: 'openai-oauth',
+            provider_name: 'OpenAI OAuth',
+            models: [{ value: 'gpt-5.3-codex-spark', label: 'GPT-5.3-Codex-Spark' }],
+          },
+        ],
+      }),
+    });
+  });
+
+  await page.route('**/api/providers/options?providerId=__global__', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        options: {
+          default_model: 'gpt-5.3-codex-spark',
+          default_model_provider: 'openai-oauth',
+        },
+      }),
+    });
+  });
+
+  await page.route('**/api/chat/sessions', async (route) => {
+    const method = route.request().method();
+    if (method === 'GET') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ sessions: [] }),
+      });
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        session: { id: 'sess-e2e-network', title: 'E2E Network Session' },
+      }),
+    });
+  });
+}
+
+async function installSettingsAndProviderMocks(page: Page) {
+  const appSettings: AppSettingsStore = {
+    network_proxy_enabled: '',
+    network_proxy_url: '',
+    network_no_proxy: '',
+    network_proxy_ca_path: '',
+  };
+  const settingsWrites: Array<Record<string, unknown>> = [];
+
+  await page.route('**/api/setup/recent-projects*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ projects: [] }),
+    });
+  });
+
+  await page.route('**/api/setup*', async (route) => {
+    const method = route.request().method();
+    if (method !== 'GET') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true }),
+      });
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        completed: true,
+        claude: 'completed',
+        provider: 'completed',
+        project: 'completed',
+        defaultProject: '/tmp/codepilot-e2e',
+      }),
+    });
+  });
+
+  await page.route('**/api/files/browse?*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ files: [], directories: [] }),
+    });
+  });
+
+  await page.route('**/api/settings/workspace', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ path: '', valid: false, state: {} }),
+    });
+  });
+
+  await page.route('**/api/settings/app', async (route) => {
+    const method = route.request().method();
+    if (method === 'GET') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ settings: appSettings }),
+      });
+      return;
+    }
+
+    let body: Record<string, unknown> = {};
+    try {
+      body = route.request().postDataJSON() as Record<string, unknown>;
+    } catch {
+      body = {};
+    }
+
+    settingsWrites.push(body);
+    const settings = (body.settings as Record<string, unknown>) || {};
+    for (const [key, value] of Object.entries(settings)) {
+      appSettings[key] = String(value ?? '');
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ success: true }),
+    });
+  });
+
+  await page.route('**/api/providers', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ providers: [], env_detected: {} }),
+    });
+  });
+
+  await page.route('**/api/openai-oauth/status', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ authenticated: true, email: 'network-e2e@example.com', plan: 'Plus' }),
+    });
+  });
+
+  await page.route('**/api/providers/models', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        groups: [
+          {
+            provider_id: 'openai-oauth',
+            provider_name: 'OpenAI OAuth',
+            models: [{ value: 'gpt-5.3-codex-spark', label: 'GPT-5.3-Codex-Spark' }],
+          },
+        ],
+      }),
+    });
+  });
+
+  await page.route('**/api/providers/options?providerId=__global__', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ options: {} }),
+    });
+  });
+
+  await page.route('**/api/providers/test', async (route) => {
+    if (appSettings.network_proxy_enabled === 'true') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true }),
+      });
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        success: false,
+        error: {
+          code: 'NETWORK_UNREACHABLE',
+          message: 'AI_RetryError: Failed after 3 attempts. Last error: Cannot connect to API: Connect Timeout Error (attempted address: chatgpt.com:443, timeout: 10000ms)',
+          suggestion: 'Enable proxy and retry.',
+        },
+      }),
+    });
+  });
+
+  return { appSettings, settingsWrites };
+}
+
+async function openThirdPartyProviderDialog(page: Page) {
+  await goToSettings(page);
+  await dismissBlockingDialogOverlay(page);
+
+  const providersTab = page.locator('nav button').filter({ hasText: /Providers|提供商|服务商/ }).first();
+  await expect(providersTab).toBeVisible();
+  await providersTab.click({ force: true });
+  await expect(page.locator('text=/Add Provider|添加提供商/')).toBeVisible();
+
+  const presetName = page.getByText(/^Anthropic Third-party API$/).first();
+  await expect(presetName).toBeVisible();
+
+  const row = presetName.locator('xpath=ancestor::div[contains(@class,"flex") and .//button][1]');
+  await expect(row).toBeVisible();
+  await row.getByRole('button', { name: /\+\s*(Connect|连接)/ }).click();
+
+  const dialog = page.getByRole('dialog');
+  await expect(dialog).toBeVisible();
+
+  await dialog.locator('input[placeholder="https://api.example.com"]').fill('https://chatgpt.com');
+  await dialog.locator('input[type="password"]').fill('sk-e2e-network');
+
+  return dialog;
+}
+
+async function setNetworkProxy(page: Page, enabled: boolean) {
+  await goToSettings(page);
+  await dismissBlockingDialogOverlay(page);
+
+  const proxyUrlInput = page.locator('input[placeholder*="127.0.0.1:7890"]').first();
+  await expect(proxyUrlInput).toBeVisible();
+
+  if (enabled) {
+    await proxyUrlInput.fill('http://127.0.0.1:7890');
+  } else {
+    await proxyUrlInput.fill('');
+  }
+
+  const proxyBlock = proxyUrlInput.locator('xpath=ancestor::div[contains(@class,"max-w-md")][1]');
+  const switchButton = proxyBlock.locator('[role="switch"]').first();
+  await expect(switchButton).toBeVisible();
+
+  const state = await switchButton.getAttribute('data-state');
+  const isChecked = state === 'checked';
+  if (isChecked !== enabled) {
+    await switchButton.click();
+  }
+
+  await dismissBlockingDialogOverlay(page);
+}
+
+test.describe('Network Acceptance', () => {
+  test('chat surfaces AI_RetryError timeout details', async ({ page }) => {
+    await installCommonChatMocks(page);
+    await installSessionDetailMocks(
+      page,
+      '**Error:** AI_RetryError: Failed after 3 attempts. Last error: Cannot connect to API: Connect Timeout Error (attempted address: chatgpt.com:443, timeout: 10000ms)'
+    );
+    await page.route('**/api/chat', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'text/event-stream',
+        body: sseBody([
+          {
+            type: 'error',
+            data: JSON.stringify({
+              category: 'NETWORK_UNREACHABLE',
+              userMessage: 'AI_RetryError: Failed after 3 attempts. Last error: Cannot connect to API: Connect Timeout Error (attempted address: chatgpt.com:443, timeout: 10000ms)',
+              actionHint: 'Check proxy settings and endpoint availability.',
+            }),
+          },
+          { type: 'done', data: '' },
+        ]),
+      });
+    });
+
+    await goToChat(page);
+    await expect(composerInput(page)).toBeVisible();
+    await expect(composerInput(page)).toBeEnabled({ timeout: 10_000 });
+    await composerInput(page).fill('network timeout acceptance check');
+    await composerInput(page).press('Enter');
+
+    await page.waitForURL('**/chat/*', { timeout: 15_000 });
+    await expect(page.locator('text=AI_RetryError: Failed after 3 attempts')).toBeVisible();
+    await expect(page.locator('text=Connect Timeout Error')).toBeVisible();
+  });
+
+  test('chat surfaces no-output stream error', async ({ page }) => {
+    await installCommonChatMocks(page);
+    await installSessionDetailMocks(page, '**Error:** No output generated. Check the stream for errors.');
+    await page.route('**/api/chat', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'text/event-stream',
+        body: sseBody([
+          { type: 'error', data: 'No output generated. Check the stream for errors.' },
+          { type: 'done', data: '' },
+        ]),
+      });
+    });
+
+    await goToChat(page);
+    await expect(composerInput(page)).toBeVisible();
+    await expect(composerInput(page)).toBeEnabled({ timeout: 10_000 });
+    await composerInput(page).fill('no output acceptance check');
+    await composerInput(page).press('Enter');
+
+    await page.waitForURL('**/chat/*', { timeout: 15_000 });
+    await expect(page.locator('text=No output generated. Check the stream for errors.')).toBeVisible();
+  });
+
+  test('provider connectivity reflects proxy off/on states (Codex-style endpoint)', async ({ page }) => {
+    const { settingsWrites } = await installSettingsAndProviderMocks(page);
+
+    await setNetworkProxy(page, false);
+    const dialogWhenOff = await openThirdPartyProviderDialog(page);
+    await dialogWhenOff.locator('button').filter({ hasText: /Test|测试连接/ }).click();
+    await expect(dialogWhenOff.locator('text=AI_RetryError: Failed after 3 attempts')).toBeVisible();
+    await expect(dialogWhenOff.locator('text=Connect Timeout Error')).toBeVisible();
+    await dialogWhenOff.locator('button').filter({ hasText: /Cancel|取消/ }).click();
+
+    await setNetworkProxy(page, true);
+    const dialogWhenOn = await openThirdPartyProviderDialog(page);
+    await dialogWhenOn.locator('button').filter({ hasText: /Test|测试连接/ }).click();
+    await expect(dialogWhenOn.locator('text=/Connection successful|连接成功/')).toBeVisible();
+
+    const wroteProxyOn = settingsWrites.some((body) => {
+      const settings = (body.settings as Record<string, unknown>) || {};
+      return settings.network_proxy_enabled === 'true';
+    });
+
+    expect(settingsWrites.length).toBeGreaterThan(0);
+    expect(wroteProxyOn).toBe(true);
+  });
+});

--- a/src/__tests__/unit/app-updates-route.test.ts
+++ b/src/__tests__/unit/app-updates-route.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { GET } from '../../app/api/app/updates/route';
+
+const originalFetch = globalThis.fetch;
+const originalVersion = process.env.NEXT_PUBLIC_APP_VERSION;
+
+beforeEach(() => {
+  process.env.NEXT_PUBLIC_APP_VERSION = '0.1.0';
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  if (typeof originalVersion === 'string') {
+    process.env.NEXT_PUBLIC_APP_VERSION = originalVersion;
+  } else {
+    delete process.env.NEXT_PUBLIC_APP_VERSION;
+  }
+});
+
+describe('GET /api/app/updates', () => {
+  it('returns compatible success payload when upstream release is fetched', async () => {
+    globalThis.fetch = (async () => (
+      new Response(
+        JSON.stringify({
+          tag_name: 'v0.2.0',
+          name: 'v0.2.0',
+          body: 'release notes',
+          published_at: '2026-04-18T00:00:00.000Z',
+          html_url: 'https://github.com/op7418/CodePilot/releases/tag/v0.2.0',
+          assets: [],
+        }),
+        { status: 200 },
+      )
+    )) as typeof fetch;
+
+    const response = await GET();
+    assert.equal(response.status, 200);
+    const payload = await response.json() as Record<string, unknown>;
+
+    assert.equal(payload.latestVersion, '0.2.0');
+    assert.equal(payload.currentVersion, '0.1.0');
+    assert.equal(payload.updateAvailable, true);
+    assert.equal(typeof payload.releaseName, 'string');
+    assert.equal(typeof payload.releaseNotes, 'string');
+    assert.equal(typeof payload.releaseUrl, 'string');
+    assert.equal(typeof payload.downloadUrl, 'string');
+    assert.equal(typeof payload.detectedPlatform, 'string');
+  });
+
+  it('maps upstream 5xx into a readable 502 payload', async () => {
+    globalThis.fetch = (async () => (
+      new Response('bad gateway', { status: 503, statusText: 'Service Unavailable' })
+    )) as typeof fetch;
+
+    const response = await GET();
+    assert.equal(response.status, 502);
+    const payload = await response.json() as Record<string, unknown>;
+
+    assert.equal(payload.error, 'Failed to fetch release info');
+    assert.equal(typeof payload.detail, 'string');
+    assert.equal(typeof payload.requestId, 'string');
+  });
+
+  it('returns 500 when response JSON is invalid', async () => {
+    globalThis.fetch = (async () => (
+      new Response('not-json', { status: 200 })
+    )) as typeof fetch;
+
+    const response = await GET();
+    assert.equal(response.status, 500);
+    const payload = await response.json() as Record<string, unknown>;
+
+    assert.equal(payload.error, 'Failed to check for updates');
+    assert.equal(typeof payload.detail, 'string');
+    assert.equal(typeof payload.requestId, 'string');
+  });
+});

--- a/src/__tests__/unit/app-updates-route.test.ts
+++ b/src/__tests__/unit/app-updates-route.test.ts
@@ -49,31 +49,35 @@ describe('GET /api/app/updates', () => {
     assert.equal(typeof payload.detectedPlatform, 'string');
   });
 
-  it('maps upstream 5xx into a readable 502 payload', async () => {
+  it('falls back to a no-update payload when upstream is unavailable', async () => {
     globalThis.fetch = (async () => (
       new Response('bad gateway', { status: 503, statusText: 'Service Unavailable' })
     )) as typeof fetch;
 
     const response = await GET();
-    assert.equal(response.status, 502);
+    assert.equal(response.status, 200);
     const payload = await response.json() as Record<string, unknown>;
 
-    assert.equal(payload.error, 'Failed to fetch release info');
-    assert.equal(typeof payload.detail, 'string');
-    assert.equal(typeof payload.requestId, 'string');
+    assert.equal(payload.latestVersion, '0.1.0');
+    assert.equal(payload.currentVersion, '0.1.0');
+    assert.equal(payload.updateAvailable, false);
+    assert.equal(payload.releaseName, '');
+    assert.equal(payload.downloadUrl, '');
   });
 
-  it('returns 500 when response JSON is invalid', async () => {
+  it('falls back to a no-update payload when response JSON is invalid', async () => {
     globalThis.fetch = (async () => (
       new Response('not-json', { status: 200 })
     )) as typeof fetch;
 
     const response = await GET();
-    assert.equal(response.status, 500);
+    assert.equal(response.status, 200);
     const payload = await response.json() as Record<string, unknown>;
 
-    assert.equal(payload.error, 'Failed to check for updates');
-    assert.equal(typeof payload.detail, 'string');
-    assert.equal(typeof payload.requestId, 'string');
+    assert.equal(payload.latestVersion, '0.1.0');
+    assert.equal(payload.currentVersion, '0.1.0');
+    assert.equal(payload.updateAvailable, false);
+    assert.equal(payload.releaseName, '');
+    assert.equal(payload.downloadUrl, '');
   });
 });

--- a/src/__tests__/unit/http-client.test.ts
+++ b/src/__tests__/unit/http-client.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { getJson } from '../../lib/http/client';
+import { HttpClientError } from '../../lib/http/errors';
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe('http client', () => {
+  it('retries network errors with exponential backoff and keeps requestId', async () => {
+    let attempts = 0;
+    const requestIds: string[] = [];
+
+    globalThis.fetch = (async (_url: RequestInfo | URL, init?: RequestInit) => {
+      attempts += 1;
+      requestIds.push(new Headers(init?.headers).get('x-request-id') || '');
+      if (attempts === 1) throw new TypeError('fetch failed');
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    }) as typeof fetch;
+
+    const result = await getJson<{ ok: boolean }>('https://example.test/retry', {
+      retries: 2,
+      retryDelayMs: 1,
+      retryJitterMs: 0,
+    });
+
+    assert.equal(result.data.ok, true);
+    assert.equal(attempts, 2);
+    assert.equal(Boolean(requestIds[0]), true);
+    assert.equal(requestIds[0], requestIds[1]);
+  });
+
+  it('retries on 429 and succeeds', async () => {
+    let attempts = 0;
+
+    globalThis.fetch = (async () => {
+      attempts += 1;
+      if (attempts === 1) {
+        return new Response('rate limited', {
+          status: 429,
+          statusText: 'Too Many Requests',
+          headers: { 'retry-after': '0' },
+        });
+      }
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    }) as typeof fetch;
+
+    const result = await getJson<{ ok: boolean }>('https://example.test/rate-limit', {
+      retries: 2,
+      retryDelayMs: 1,
+      retryJitterMs: 0,
+    });
+
+    assert.equal(result.data.ok, true);
+    assert.equal(attempts, 2);
+  });
+
+  it('does not retry non-retryable 4xx errors', async () => {
+    let attempts = 0;
+
+    globalThis.fetch = (async () => {
+      attempts += 1;
+      return new Response('not found', { status: 404, statusText: 'Not Found' });
+    }) as typeof fetch;
+
+    await assert.rejects(
+      () => getJson('https://example.test/not-found', { retries: 3, retryDelayMs: 1, retryJitterMs: 0 }),
+      (error: unknown) => {
+        assert.equal(error instanceof HttpClientError, true);
+        const httpError = error as HttpClientError;
+        assert.equal(httpError.code, 'http_status');
+        assert.equal(httpError.status, 404);
+        assert.equal(httpError.retryable, false);
+        return true;
+      },
+    );
+    assert.equal(attempts, 1);
+  });
+
+  it('times out and returns normalized timeout error', async () => {
+    globalThis.fetch = ((_url: RequestInfo | URL, init?: RequestInit) => (
+      new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => {
+          reject(new DOMException('The operation was aborted.', 'AbortError'));
+        }, { once: true });
+      })
+    )) as typeof fetch;
+
+    await assert.rejects(
+      () => getJson('https://example.test/timeout', { timeoutMs: 20, retries: 0 }),
+      (error: unknown) => {
+        assert.equal(error instanceof HttpClientError, true);
+        const httpError = error as HttpClientError;
+        assert.equal(httpError.code, 'timeout');
+        assert.match(httpError.requestId, /.+/);
+        return true;
+      },
+    );
+  });
+});

--- a/src/__tests__/unit/network-proxy.test.ts
+++ b/src/__tests__/unit/network-proxy.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { getGlobalDispatcher, setGlobalDispatcher } from 'undici';
+import type { Dispatcher } from 'undici';
 import { applyNetworkProxyFromAppSettings, readNetworkProxySettings } from '@/lib/network-proxy';
 
 const ENV_KEYS = [
@@ -13,12 +15,14 @@ const ENV_KEYS = [
 ] as const;
 
 let snapshot: Partial<Record<(typeof ENV_KEYS)[number], string | undefined>> = {};
+let dispatcherSnapshot: Dispatcher | null = null;
 
 function saveEnvSnapshot() {
   snapshot = {};
   for (const key of ENV_KEYS) {
     snapshot[key] = process.env[key];
   }
+  dispatcherSnapshot = getGlobalDispatcher();
 }
 
 function restoreEnvSnapshot() {
@@ -27,6 +31,10 @@ function restoreEnvSnapshot() {
     if (value === undefined) delete process.env[key];
     else process.env[key] = value;
   }
+  if (dispatcherSnapshot) {
+    setGlobalDispatcher(dispatcherSnapshot);
+  }
+  dispatcherSnapshot = null;
 }
 
 describe('applyNetworkProxyFromAppSettings', () => {
@@ -90,6 +98,26 @@ describe('applyNetworkProxyFromAppSettings', () => {
     assert.equal(process.env.NO_PROXY, undefined);
     assert.equal(process.env.no_proxy, undefined);
     assert.equal(process.env.NODE_EXTRA_CA_CERTS, undefined);
+  });
+
+  it('switches undici global dispatcher when proxy toggles', () => {
+    saveEnvSnapshot();
+
+    applyNetworkProxyFromAppSettings({
+      network_proxy_enabled: 'true',
+      network_proxy_url: 'http://127.0.0.1:7890',
+      network_no_proxy: '',
+      network_proxy_ca_path: '',
+    });
+    assert.equal(getGlobalDispatcher().constructor.name, 'EnvHttpProxyAgent');
+
+    applyNetworkProxyFromAppSettings({
+      network_proxy_enabled: '',
+      network_proxy_url: '',
+      network_no_proxy: '',
+      network_proxy_ca_path: '',
+    });
+    assert.equal(getGlobalDispatcher().constructor.name, 'Agent');
   });
 
   it('reads network proxy settings from settings getter safely', () => {

--- a/src/__tests__/unit/network-proxy.test.ts
+++ b/src/__tests__/unit/network-proxy.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { applyNetworkProxyFromAppSettings, readNetworkProxySettings } from '@/lib/network-proxy';
+
+const ENV_KEYS = [
+  'HTTP_PROXY',
+  'HTTPS_PROXY',
+  'http_proxy',
+  'https_proxy',
+  'NO_PROXY',
+  'no_proxy',
+  'NODE_EXTRA_CA_CERTS',
+] as const;
+
+let snapshot: Partial<Record<(typeof ENV_KEYS)[number], string | undefined>> = {};
+
+function saveEnvSnapshot() {
+  snapshot = {};
+  for (const key of ENV_KEYS) {
+    snapshot[key] = process.env[key];
+  }
+}
+
+function restoreEnvSnapshot() {
+  for (const key of ENV_KEYS) {
+    const value = snapshot[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+}
+
+describe('applyNetworkProxyFromAppSettings', () => {
+  afterEach(() => restoreEnvSnapshot());
+
+  it('enables proxy env vars and optional NO_PROXY/CA path', () => {
+    saveEnvSnapshot();
+
+    applyNetworkProxyFromAppSettings({
+      network_proxy_enabled: 'true',
+      network_proxy_url: 'http://127.0.0.1:7890',
+      network_no_proxy: 'localhost,127.0.0.1',
+      network_proxy_ca_path: '/tmp/custom-ca.pem',
+    });
+
+    assert.equal(process.env.HTTP_PROXY, 'http://127.0.0.1:7890');
+    assert.equal(process.env.HTTPS_PROXY, 'http://127.0.0.1:7890');
+    assert.equal(process.env.http_proxy, 'http://127.0.0.1:7890');
+    assert.equal(process.env.https_proxy, 'http://127.0.0.1:7890');
+    assert.equal(process.env.NO_PROXY, 'localhost,127.0.0.1,::1');
+    assert.equal(process.env.no_proxy, 'localhost,127.0.0.1,::1');
+    assert.equal(process.env.NODE_EXTRA_CA_CERTS, '/tmp/custom-ca.pem');
+  });
+
+  it('adds localhost bypass defaults into NO_PROXY when enabled', () => {
+    saveEnvSnapshot();
+
+    applyNetworkProxyFromAppSettings({
+      network_proxy_enabled: 'true',
+      network_proxy_url: 'http://127.0.0.1:7890',
+      network_no_proxy: 'example.com,localhost',
+      network_proxy_ca_path: '',
+    });
+
+    assert.equal(process.env.NO_PROXY, 'example.com,localhost,127.0.0.1,::1');
+    assert.equal(process.env.no_proxy, 'example.com,localhost,127.0.0.1,::1');
+  });
+
+  it('clears proxy env vars when disabled', () => {
+    saveEnvSnapshot();
+
+    process.env.HTTP_PROXY = 'http://127.0.0.1:7890';
+    process.env.HTTPS_PROXY = 'http://127.0.0.1:7890';
+    process.env.http_proxy = 'http://127.0.0.1:7890';
+    process.env.https_proxy = 'http://127.0.0.1:7890';
+    process.env.NO_PROXY = 'localhost';
+    process.env.no_proxy = 'localhost';
+    process.env.NODE_EXTRA_CA_CERTS = '/tmp/custom-ca.pem';
+
+    applyNetworkProxyFromAppSettings({
+      network_proxy_enabled: '',
+      network_proxy_url: 'http://127.0.0.1:7890',
+      network_no_proxy: '',
+      network_proxy_ca_path: '',
+    });
+
+    assert.equal(process.env.HTTP_PROXY, undefined);
+    assert.equal(process.env.HTTPS_PROXY, undefined);
+    assert.equal(process.env.http_proxy, undefined);
+    assert.equal(process.env.https_proxy, undefined);
+    assert.equal(process.env.NO_PROXY, undefined);
+    assert.equal(process.env.no_proxy, undefined);
+    assert.equal(process.env.NODE_EXTRA_CA_CERTS, undefined);
+  });
+
+  it('reads network proxy settings from settings getter safely', () => {
+    const values: Record<string, string> = {
+      network_proxy_enabled: 'true',
+      network_proxy_url: 'http://127.0.0.1:7890',
+      network_no_proxy: 'localhost',
+      network_proxy_ca_path: '/tmp/custom-ca.pem',
+    };
+    const settings = readNetworkProxySettings((key) => values[key]);
+    assert.deepEqual(settings, values);
+
+    const empty = readNetworkProxySettings(() => undefined);
+    assert.deepEqual(empty, {
+      network_proxy_enabled: '',
+      network_proxy_url: '',
+      network_no_proxy: '',
+      network_proxy_ca_path: '',
+    });
+  });
+});

--- a/src/__tests__/unit/provider-doctor-network.test.ts
+++ b/src/__tests__/unit/provider-doctor-network.test.ts
@@ -1,0 +1,153 @@
+import { after, before, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const originalDataDir = process.env.CLAUDE_GUI_DATA_DIR;
+const originalHome = process.env.HOME;
+const originalUserProfile = process.env.USERPROFILE;
+const originalHttpsProxy = process.env.HTTPS_PROXY;
+const originalHttpProxy = process.env.HTTP_PROXY;
+const originalNoProxy = process.env.NO_PROXY;
+const originalNodeExtraCaCerts = process.env.NODE_EXTRA_CA_CERTS;
+const originalFetch = global.fetch;
+
+let tempDataDir = '';
+let tempHome = '';
+
+async function resetDoctorState(): Promise<void> {
+  const { getDb } = await import('../../lib/db');
+  const db = getDb();
+  db.prepare('DELETE FROM api_providers').run();
+  db.prepare("DELETE FROM settings WHERE key IN ('default_provider_id', 'global_default_model_provider', 'global_default_model')").run();
+}
+
+function getCodeFinding(
+  findings: Array<{ code: string; severity: string; message: string; detail?: string }>,
+  code: string,
+) {
+  return findings.find(f => f.code === code);
+}
+
+before(async () => {
+  tempDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codepilot-doctor-network-db-'));
+  tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'codepilot-doctor-network-home-'));
+  process.env.CLAUDE_GUI_DATA_DIR = tempDataDir;
+  process.env.HOME = tempHome;
+  process.env.USERPROFILE = tempHome;
+  await resetDoctorState();
+});
+
+beforeEach(async () => {
+  await resetDoctorState();
+  delete process.env.HTTPS_PROXY;
+  delete process.env.HTTP_PROXY;
+  delete process.env.NO_PROXY;
+  delete process.env.NODE_EXTRA_CA_CERTS;
+  global.fetch = (async () => new Response('', { status: 204 })) as typeof fetch;
+});
+
+after(() => {
+  if (originalDataDir !== undefined) process.env.CLAUDE_GUI_DATA_DIR = originalDataDir;
+  else delete process.env.CLAUDE_GUI_DATA_DIR;
+  if (originalHome !== undefined) process.env.HOME = originalHome;
+  else delete process.env.HOME;
+  if (originalUserProfile !== undefined) process.env.USERPROFILE = originalUserProfile;
+  else delete process.env.USERPROFILE;
+  if (originalHttpsProxy !== undefined) process.env.HTTPS_PROXY = originalHttpsProxy;
+  else delete process.env.HTTPS_PROXY;
+  if (originalHttpProxy !== undefined) process.env.HTTP_PROXY = originalHttpProxy;
+  else delete process.env.HTTP_PROXY;
+  if (originalNoProxy !== undefined) process.env.NO_PROXY = originalNoProxy;
+  else delete process.env.NO_PROXY;
+  if (originalNodeExtraCaCerts !== undefined) process.env.NODE_EXTRA_CA_CERTS = originalNodeExtraCaCerts;
+  else delete process.env.NODE_EXTRA_CA_CERTS;
+  global.fetch = originalFetch;
+  try { fs.rmSync(tempDataDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  try { fs.rmSync(tempHome, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+describe('provider doctor network diagnostics', () => {
+  it('adds proxy loopback bypass and gateway reachability findings', async () => {
+    process.env.HTTPS_PROXY = 'http://proxy.corp.internal:8080';
+    process.env.NO_PROXY = 'corp.internal,.example.com';
+
+    const { createProvider, setDefaultProviderId } = await import('../../lib/db');
+    const provider = createProvider({
+      name: 'Corp Gateway',
+      provider_type: 'anthropic',
+      protocol: 'anthropic',
+      base_url: 'https://gw.corp.example.com/v1',
+      api_key: 'sk-test-gw',
+    });
+    setDefaultProviderId(provider.id);
+
+    const { runDiagnosis } = await import('../../lib/provider-doctor');
+    const diagnosis = await runDiagnosis();
+    const network = diagnosis.probes.find(p => p.probe === 'network');
+    assert.ok(network, 'expected network probe');
+
+    const proxyConfigured = getCodeFinding(network.findings, 'network.proxy.configured');
+    assert.ok(proxyConfigured, 'expected network.proxy.configured finding');
+
+    const loopbackBypass = getCodeFinding(network.findings, 'network.proxy.loopback-not-bypassed');
+    assert.ok(loopbackBypass, 'expected network.proxy.loopback-not-bypassed finding');
+    assert.equal(loopbackBypass.severity, 'warn');
+
+    const gatewayValid = getCodeFinding(network.findings, 'gateway.base-url-valid');
+    assert.ok(gatewayValid, 'expected gateway.base-url-valid finding');
+
+    const gatewayReachability =
+      getCodeFinding(network.findings, 'gateway.reachable') ||
+      getCodeFinding(network.findings, 'gateway.unreachable') ||
+      getCodeFinding(network.findings, 'gateway.timeout');
+    assert.ok(
+      gatewayReachability,
+      `expected gateway reachability finding; got codes: ${network.findings.map(f => f.code).join(', ')}`,
+    );
+  });
+
+  it('reports NODE_EXTRA_CA_CERTS readable/missing states', async () => {
+    const certFile = path.join(tempHome, 'corp-ca.pem');
+    fs.writeFileSync(certFile, '-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----\n');
+    process.env.NODE_EXTRA_CA_CERTS = certFile;
+
+    const { runDiagnosis } = await import('../../lib/provider-doctor');
+    const readableDiagnosis = await runDiagnosis();
+    const readableNetwork = readableDiagnosis.probes.find(p => p.probe === 'network');
+    assert.ok(readableNetwork, 'expected network probe');
+    assert.ok(getCodeFinding(readableNetwork.findings, 'network.ca.readable'), 'expected network.ca.readable finding');
+
+    process.env.NODE_EXTRA_CA_CERTS = path.join(tempHome, 'missing-ca.pem');
+    const missingDiagnosis = await runDiagnosis();
+    const missingNetwork = missingDiagnosis.probes.find(p => p.probe === 'network');
+    assert.ok(missingNetwork, 'expected network probe');
+    const missingCa = getCodeFinding(missingNetwork.findings, 'network.ca.missing');
+    assert.ok(missingCa, 'expected network.ca.missing finding');
+    assert.equal(missingCa.severity, 'warn');
+  });
+
+  it('adds gateway invalid-base-url finding for malformed provider URL', async () => {
+    const { createProvider, setDefaultProviderId } = await import('../../lib/db');
+    const provider = createProvider({
+      name: 'Broken Gateway',
+      provider_type: 'anthropic',
+      protocol: 'anthropic',
+      base_url: 'ht!tp:// bad-url',
+      api_key: 'sk-bad',
+    });
+    setDefaultProviderId(provider.id);
+
+    const { runDiagnosis } = await import('../../lib/provider-doctor');
+    const diagnosis = await runDiagnosis();
+    const network = diagnosis.probes.find(p => p.probe === 'network');
+    assert.ok(network, 'expected network probe');
+
+    const invalidGateway = getCodeFinding(network.findings, 'gateway.invalid-base-url');
+    assert.ok(invalidGateway, 'expected gateway.invalid-base-url finding');
+
+    const invalidNetworkUrl = getCodeFinding(network.findings, 'network.invalid-url');
+    assert.ok(invalidNetworkUrl, 'expected network.invalid-url finding');
+  });
+});

--- a/src/__tests__/unit/settings-verify-route-http-client.test.ts
+++ b/src/__tests__/unit/settings-verify-route-http-client.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import type { NextRequest } from 'next/server';
+
+import { POST as verifyDiscord } from '../../app/api/settings/discord/verify/route';
+import { POST as verifyFeishu } from '../../app/api/settings/feishu/verify/route';
+import { POST as verifyQq } from '../../app/api/settings/qq/verify/route';
+
+const originalFetch = globalThis.fetch;
+
+function makeRequest(body: Record<string, unknown>): NextRequest {
+  return new Request('http://localhost/api/test', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  }) as unknown as NextRequest;
+}
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe('settings verify routes with shared HTTP client', () => {
+  it('keeps Discord success shape', async () => {
+    globalThis.fetch = (async () => (
+      new Response(JSON.stringify({
+        id: '123',
+        username: 'test-bot',
+        discriminator: '0001',
+      }), { status: 200 })
+    )) as typeof fetch;
+
+    const response = await verifyDiscord(makeRequest({ bot_token: 'discord_token' }));
+    assert.equal(response.status, 200);
+
+    const payload = await response.json() as Record<string, unknown>;
+    assert.equal(payload.verified, true);
+    assert.equal(payload.botName, 'test-bot#0001');
+  });
+
+  it('adds detail/requestId on Discord upstream http error', async () => {
+    globalThis.fetch = (async () => (
+      new Response('unauthorized', { status: 401, statusText: 'Unauthorized' })
+    )) as typeof fetch;
+
+    const response = await verifyDiscord(makeRequest({ bot_token: 'bad_token' }));
+    assert.equal(response.status, 200);
+
+    const payload = await response.json() as Record<string, unknown>;
+    assert.equal(payload.verified, false);
+    assert.equal(payload.error, 'HTTP 401: Token verification failed');
+    assert.equal(typeof payload.detail, 'string');
+    assert.equal(typeof payload.requestId, 'string');
+  });
+
+  it('keeps QQ success shape', async () => {
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url.includes('/getAppAccessToken')) {
+        return new Response(JSON.stringify({ access_token: 'qq_token' }), { status: 200 });
+      }
+      if (url.includes('/gateway')) {
+        return new Response(JSON.stringify({ url: 'wss://gateway.qq.test/ws' }), { status: 200 });
+      }
+      throw new Error(`Unexpected URL: ${url}`);
+    }) as typeof fetch;
+
+    const response = await verifyQq(makeRequest({ app_id: 'appid', app_secret: 'appsecret' }));
+    assert.equal(response.status, 200);
+
+    const payload = await response.json() as Record<string, unknown>;
+    assert.equal(payload.verified, true);
+    assert.equal(payload.gatewayUrl, 'wss://gateway.qq.test/ws');
+  });
+
+  it('adds detail/requestId on QQ upstream http error', async () => {
+    let attempts = 0;
+    globalThis.fetch = (async () => {
+      attempts += 1;
+      return new Response('service unavailable', { status: 503, statusText: 'Service Unavailable' });
+    }) as typeof fetch;
+
+    const response = await verifyQq(makeRequest({ app_id: 'appid', app_secret: 'appsecret' }));
+    assert.equal(response.status, 200);
+
+    const payload = await response.json() as Record<string, unknown>;
+    assert.equal(payload.verified, false);
+    assert.equal(payload.error, 'HTTP 503: Verification failed');
+    assert.equal(typeof payload.detail, 'string');
+    assert.equal(typeof payload.requestId, 'string');
+    assert.equal(attempts, 2);
+  });
+
+  it('keeps Feishu success shape', async () => {
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url.includes('/tenant_access_token/internal')) {
+        return new Response(JSON.stringify({ tenant_access_token: 'token_123' }), { status: 200 });
+      }
+      if (url.includes('/bot/v3/info/')) {
+        return new Response(JSON.stringify({ bot: { open_id: 'ou_xxx', app_name: 'FeishuBot' } }), { status: 200 });
+      }
+      throw new Error(`Unexpected URL: ${url}`);
+    }) as typeof fetch;
+
+    const response = await verifyFeishu(makeRequest({
+      app_id: 'appid',
+      app_secret: 'secret',
+      domain: 'feishu',
+    }));
+    assert.equal(response.status, 200);
+
+    const payload = await response.json() as Record<string, unknown>;
+    assert.equal(payload.verified, true);
+    assert.equal(payload.botName, 'FeishuBot');
+  });
+
+  it('adds detail/requestId on Feishu upstream http error', async () => {
+    let attempts = 0;
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url.includes('/tenant_access_token/internal')) {
+        attempts += 1;
+        return new Response('forbidden', { status: 403, statusText: 'Forbidden' });
+      }
+      throw new Error(`Unexpected URL: ${url}`);
+    }) as typeof fetch;
+
+    const response = await verifyFeishu(makeRequest({
+      app_id: 'appid',
+      app_secret: 'secret',
+      domain: 'feishu',
+    }));
+    assert.equal(response.status, 200);
+
+    const payload = await response.json() as Record<string, unknown>;
+    assert.equal(payload.verified, false);
+    assert.equal(payload.error, 'HTTP 403: Verification failed');
+    assert.equal(typeof payload.detail, 'string');
+    assert.equal(typeof payload.requestId, 'string');
+    assert.equal(attempts, 1);
+  });
+});

--- a/src/__tests__/unit/streaming-status.test.ts
+++ b/src/__tests__/unit/streaming-status.test.ts
@@ -1,0 +1,44 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { shouldShowThinkingPhaseIndicator } from '@/lib/streaming-status';
+
+describe('shouldShowThinkingPhaseIndicator', () => {
+  it('shows thinking indicator when stream has no content and no status', () => {
+    assert.equal(
+      shouldShowThinkingPhaseIndicator({
+        isStreaming: true,
+        content: '',
+        toolUsesCount: 0,
+        thinkingContent: '',
+        statusText: undefined,
+      }),
+      true,
+    );
+  });
+
+  it('hides thinking indicator when reconnect status is present', () => {
+    assert.equal(
+      shouldShowThinkingPhaseIndicator({
+        isStreaming: true,
+        content: '',
+        toolUsesCount: 0,
+        thinkingContent: '',
+        statusText: 'Reconnecting to previous conversation...',
+      }),
+      false,
+    );
+  });
+
+  it('hides thinking indicator after stream has content', () => {
+    assert.equal(
+      shouldShowThinkingPhaseIndicator({
+        isStreaming: true,
+        content: 'partial answer',
+        toolUsesCount: 0,
+        thinkingContent: '',
+        statusText: undefined,
+      }),
+      false,
+    );
+  });
+});

--- a/src/app/api/app/updates/route.ts
+++ b/src/app/api/app/updates/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { getRuntimeArchitectureInfo } from "@/lib/platform";
 import { selectRecommendedReleaseAsset, type ReleaseAsset } from "@/lib/update-release";
+import { getJson } from "@/lib/http/client";
 
 const GITHUB_REPO = "op7418/CodePilot";
 
@@ -37,19 +38,24 @@ export async function GET() {
     const currentVersion = process.env.NEXT_PUBLIC_APP_VERSION || "0.0.0";
     const runtimeInfo = getRuntimeArchitectureInfo();
 
-    const res = await fetch(
+    const { data: release } = await getJson<{
+      tag_name?: string;
+      name?: string;
+      body?: string;
+      published_at?: string;
+      html_url?: string;
+      assets?: ReleaseAsset[];
+    }>(
       `https://api.github.com/repos/${GITHUB_REPO}/releases/latest`,
       {
         headers: { Accept: "application/vnd.github.v3+json" },
+        timeoutMs: 8000,
+        retries: 2,
+        retryDelayMs: 250,
+        retryJitterMs: 50,
         next: { revalidate: 300 },
       }
     );
-
-    if (!res.ok) {
-      return NextResponse.json(noUpdatePayload(currentVersion, runtimeInfo));
-    }
-
-    const release = await res.json();
     const latestVersion = (release.tag_name || "").replace(/^v/, "");
     const updateAvailable = compareSemver(latestVersion, currentVersion) > 0;
     const recommendedAsset = selectRecommendedReleaseAsset(

--- a/src/app/api/claude-status/route.ts
+++ b/src/app/api/claude-status/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { findClaudeBinary, getClaudeVersion, findAllClaudeBinaries, classifyClaudePath, isWindows, findGitBash, isWingetInstall } from '@/lib/platform';
 import type { ClaudeInstallInfo, ClaudeInstallType } from '@/lib/platform';
+import { getJson } from '@/lib/http/client';
 
 /** Latest version cache */
 let cachedLatestVersion: string | null = null;
@@ -16,15 +17,13 @@ async function fetchLatestVersion(): Promise<string | null> {
     return cachedLatestVersion;
   }
   try {
-    const res = await fetch('https://registry.npmjs.org/@anthropic-ai/claude-code/latest', {
-      signal: AbortSignal.timeout(5000),
+    const { data } = await getJson<{ version?: string }>('https://registry.npmjs.org/@anthropic-ai/claude-code/latest', {
+      timeoutMs: 5000,
+      retries: 1,
+      retryDelayMs: 250,
+      retryJitterMs: 50,
+      next: { revalidate: 3600 },
     });
-    if (!res.ok) {
-      lastFetchFailed = true;
-      cachedLatestVersionTimestamp = now;
-      return cachedLatestVersion;
-    }
-    const data = await res.json();
     const version = data.version as string | undefined;
     if (version) {
       cachedLatestVersion = version;

--- a/src/app/api/settings/app/route.ts
+++ b/src/app/api/settings/app/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getSetting, setSetting } from '@/lib/db';
+import { applyNetworkProxyFromAppSettings, readNetworkProxySettings } from '@/lib/network-proxy';
 
 /**
  * CodePilot app-level settings (stored in SQLite, separate from ~/.claude/settings.json).
@@ -18,6 +19,10 @@ const ALLOWED_KEYS = [
   'default_panel',
   'agent_runtime',
   'cli_enabled',
+  'network_proxy_enabled',
+  'network_proxy_url',
+  'network_no_proxy',
+  'network_proxy_ca_path',
   // Feature announcement dismiss flags (persist across Electron restarts)
   'codepilot:announcement:v0.48-agent-engine',
 ];
@@ -66,6 +71,8 @@ export async function PUT(request: NextRequest) {
         setSetting(key, '');
       }
     }
+
+    applyNetworkProxyFromAppSettings(readNetworkProxySettings(getSetting));
 
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/src/app/api/settings/discord/verify/route.ts
+++ b/src/app/api/settings/discord/verify/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getSetting } from '@/lib/db';
+import { getJson, HttpClientError } from '@/lib/http/client';
 
 /**
  * POST /api/settings/discord/verify
@@ -24,24 +25,20 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Call Discord API to verify the token
-    const res = await fetch('https://discord.com/api/v10/users/@me', {
+    const { data } = await getJson<{
+      id?: string;
+      username?: string;
+      discriminator?: string;
+    }>('https://discord.com/api/v10/users/@me', {
       method: 'GET',
       headers: {
         Authorization: `Bot ${bot_token}`,
       },
-      signal: AbortSignal.timeout(10_000),
+      timeoutMs: 10_000,
+      retries: 1,
+      retryDelayMs: 250,
+      retryJitterMs: 50,
     });
-
-    if (!res.ok) {
-      const errorData = await res.json().catch(() => ({}));
-      return NextResponse.json({
-        verified: false,
-        error: errorData.message || `HTTP ${res.status}: Token verification failed`,
-      });
-    }
-
-    const data = await res.json();
 
     if (data.id) {
       return NextResponse.json({
@@ -55,6 +52,24 @@ export async function POST(request: NextRequest) {
       error: 'Could not retrieve bot info',
     });
   } catch (error) {
+    if (error instanceof HttpClientError) {
+      if (error.code === 'http_status') {
+        return NextResponse.json({
+          verified: false,
+          error: `HTTP ${error.status ?? 500}: Token verification failed`,
+          detail: error.message,
+          requestId: error.requestId,
+        });
+      }
+
+      return NextResponse.json({
+        verified: false,
+        error: 'Verification request failed',
+        detail: error.message,
+        requestId: error.requestId,
+      }, { status: 500 });
+    }
+
     const message = error instanceof Error ? error.message : 'Verification failed';
     return NextResponse.json({ verified: false, error: message }, { status: 500 });
   }

--- a/src/app/api/settings/feishu/verify/route.ts
+++ b/src/app/api/settings/feishu/verify/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getSetting } from '@/lib/db';
+import { getJson, requestJson, HttpClientError } from '@/lib/http/client';
 
 /**
  * POST /api/settings/feishu/verify
@@ -33,13 +34,15 @@ export async function POST(request: NextRequest) {
       : 'https://open.feishu.cn';
 
     // Get tenant access token
-    const tokenRes = await fetch(`${baseUrl}/open-apis/auth/v3/tenant_access_token/internal`, {
+    const { data: tokenData } = await requestJson<{ tenant_access_token?: string; msg?: string }>(`${baseUrl}/open-apis/auth/v3/tenant_access_token/internal`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ app_id, app_secret }),
-      signal: AbortSignal.timeout(10_000),
+      timeoutMs: 10_000,
+      retries: 1,
+      retryDelayMs: 250,
+      retryJitterMs: 50,
     });
-    const tokenData = await tokenRes.json();
 
     if (!tokenData.tenant_access_token) {
       return NextResponse.json({
@@ -49,12 +52,14 @@ export async function POST(request: NextRequest) {
     }
 
     // Get bot info
-    const botRes = await fetch(`${baseUrl}/open-apis/bot/v3/info/`, {
+    const { data: botData } = await getJson<{ bot?: { open_id?: string; app_name?: string }; msg?: string }>(`${baseUrl}/open-apis/bot/v3/info/`, {
       method: 'GET',
       headers: { Authorization: `Bearer ${tokenData.tenant_access_token}` },
-      signal: AbortSignal.timeout(10_000),
+      timeoutMs: 10_000,
+      retries: 1,
+      retryDelayMs: 250,
+      retryJitterMs: 50,
     });
-    const botData = await botRes.json();
 
     if (botData?.bot?.open_id) {
       return NextResponse.json({
@@ -68,6 +73,22 @@ export async function POST(request: NextRequest) {
       error: botData?.msg || 'Could not retrieve bot info',
     });
   } catch (error) {
+    if (error instanceof HttpClientError) {
+      if (error.code === 'http_status') {
+        return NextResponse.json({
+          verified: false,
+          error: `HTTP ${error.status ?? 500}: Verification failed`,
+          detail: error.message,
+          requestId: error.requestId,
+        });
+      }
+      return NextResponse.json({
+        verified: false,
+        error: 'Verification request failed',
+        detail: error.message,
+        requestId: error.requestId,
+      }, { status: 500 });
+    }
     const message = error instanceof Error ? error.message : 'Verification failed';
     return NextResponse.json({ verified: false, error: message }, { status: 500 });
   }

--- a/src/app/api/settings/qq/verify/route.ts
+++ b/src/app/api/settings/qq/verify/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getSetting } from '@/lib/db';
+import { getJson, requestJson, HttpClientError } from '@/lib/http/client';
 
 /**
  * POST /api/settings/qq/verify
@@ -31,14 +32,19 @@ export async function POST(request: NextRequest) {
     }
 
     // Step 1: Get access token
-    const tokenRes = await fetch('https://bots.qq.com/app/getAppAccessToken', {
+    const { data: tokenData } = await requestJson<{
+      access_token?: string;
+      message?: string;
+    }>('https://bots.qq.com/app/getAppAccessToken', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ appId: app_id, clientSecret: app_secret }),
-      signal: AbortSignal.timeout(10_000),
+      timeoutMs: 10_000,
+      retries: 1,
+      retryDelayMs: 250,
+      retryJitterMs: 50,
     });
 
-    const tokenData = await tokenRes.json();
     if (!tokenData.access_token) {
       return NextResponse.json({
         verified: false,
@@ -47,13 +53,16 @@ export async function POST(request: NextRequest) {
     }
 
     // Step 2: Verify gateway is reachable
-    const gatewayRes = await fetch('https://api.sgroup.qq.com/gateway', {
+    const { data: gatewayData } = await getJson<{
+      url?: string;
+    }>('https://api.sgroup.qq.com/gateway', {
       method: 'GET',
       headers: { Authorization: `QQBot ${tokenData.access_token}` },
-      signal: AbortSignal.timeout(10_000),
+      timeoutMs: 10_000,
+      retries: 1,
+      retryDelayMs: 250,
+      retryJitterMs: 50,
     });
-
-    const gatewayData = await gatewayRes.json();
     if (!gatewayData.url) {
       return NextResponse.json({
         verified: false,
@@ -66,6 +75,24 @@ export async function POST(request: NextRequest) {
       gatewayUrl: gatewayData.url,
     });
   } catch (error) {
+    if (error instanceof HttpClientError) {
+      if (error.code === 'http_status') {
+        return NextResponse.json({
+          verified: false,
+          error: `HTTP ${error.status ?? 500}: Verification failed`,
+          detail: error.message,
+          requestId: error.requestId,
+        });
+      }
+
+      return NextResponse.json({
+        verified: false,
+        error: 'Verification request failed',
+        detail: error.message,
+        requestId: error.requestId,
+      }, { status: 500 });
+    }
+
     const message = error instanceof Error ? error.message : 'Verification failed';
     return NextResponse.json({ verified: false, error: message }, { status: 500 });
   }

--- a/src/components/chat/StreamingMessage.tsx
+++ b/src/components/chat/StreamingMessage.tsx
@@ -16,6 +16,7 @@ import { BatchPlanInlinePreview } from './batch-image-gen/BatchPlanInlinePreview
 import { WidgetRenderer } from './WidgetRenderer';
 import { parseAllShowWidgets, computePartialWidgetKey } from './MessageItem';
 import { PENDING_KEY, buildReferenceImages } from '@/lib/image-ref-store';
+import { shouldShowThinkingPhaseIndicator } from '@/lib/streaming-status';
 import type { PlannerOutput, MediaBlock } from '@/types';
 
 interface ImageGenRequest {
@@ -524,7 +525,13 @@ export function StreamingMessage({
         })()}
 
         {/* Loading indicator when no content yet and no thinking content — evolves over time */}
-        {isStreaming && !content && toolUses.length === 0 && !thinkingContent && (
+        {shouldShowThinkingPhaseIndicator({
+          isStreaming,
+          content,
+          toolUsesCount: toolUses.length,
+          thinkingContent,
+          statusText,
+        }) && (
           <div className="py-2">
             <ThinkingPhaseLabel />
           </div>

--- a/src/components/settings/GeneralSection.tsx
+++ b/src/components/settings/GeneralSection.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useCallback, useEffect, useSyncExternalStore } from "react";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
 import {
   AlertDialog,
@@ -129,6 +130,11 @@ export function GeneralSection() {
   const [generativeUI, setGenerativeUI] = useState(true);
   const [generativeUISaving, setGenerativeUISaving] = useState(false);
   const [defaultPanel, setDefaultPanel] = useState('file_tree');
+  const [networkProxyEnabled, setNetworkProxyEnabled] = useState(false);
+  const [networkProxyUrl, setNetworkProxyUrl] = useState('');
+  const [networkNoProxy, setNetworkNoProxy] = useState('');
+  const [networkProxyCaPath, setNetworkProxyCaPath] = useState('');
+  const [networkProxySaving, setNetworkProxySaving] = useState(false);
   const { accountInfo } = useAccountInfo();
   const { t, locale, setLocale } = useTranslation();
 
@@ -143,6 +149,10 @@ export function GeneralSection() {
         setGenerativeUI(appSettings.generative_ui_enabled !== "false");
         // default_panel defaults to 'file_tree' when not set
         setDefaultPanel(appSettings.default_panel || 'file_tree');
+        setNetworkProxyEnabled(appSettings.network_proxy_enabled === "true");
+        setNetworkProxyUrl(appSettings.network_proxy_url || '');
+        setNetworkNoProxy(appSettings.network_no_proxy || '');
+        setNetworkProxyCaPath(appSettings.network_proxy_ca_path || '');
       }
     } catch {
       // ignore
@@ -213,6 +223,49 @@ export function GeneralSection() {
     } finally {
       setGenerativeUISaving(false);
     }
+  };
+
+  const saveNetworkProxySettings = async (overrides?: {
+    enabled?: boolean;
+    proxyUrl?: string;
+    noProxy?: string;
+    caPath?: string;
+  }) => {
+    const enabled = overrides?.enabled ?? networkProxyEnabled;
+    const proxyUrl = (overrides?.proxyUrl ?? networkProxyUrl).trim();
+    const noProxy = (overrides?.noProxy ?? networkNoProxy).trim();
+    const caPath = (overrides?.caPath ?? networkProxyCaPath).trim();
+
+    setNetworkProxySaving(true);
+    try {
+      const res = await fetch("/api/settings/app", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          settings: {
+            network_proxy_enabled: enabled ? "true" : "",
+            network_proxy_url: proxyUrl,
+            network_no_proxy: noProxy,
+            network_proxy_ca_path: caPath,
+          },
+        }),
+      });
+      if (res.ok) {
+        setNetworkProxyEnabled(enabled);
+        setNetworkProxyUrl(proxyUrl);
+        setNetworkNoProxy(noProxy);
+        setNetworkProxyCaPath(caPath);
+      }
+    } catch {
+      // ignore
+    } finally {
+      setNetworkProxySaving(false);
+    }
+  };
+
+  const handleNetworkProxyToggle = (checked: boolean) => {
+    setNetworkProxyEnabled(checked);
+    saveNetworkProxySettings({ enabled: checked });
   };
 
   return (
@@ -287,6 +340,55 @@ export function GeneralSection() {
               ))}
             </SelectContent>
           </Select>
+        </FieldRow>
+
+        {/* Network proxy */}
+        <FieldRow
+          label={t('settings.networkProxyTitle' as TranslationKey)}
+          description={t('settings.networkProxyDesc' as TranslationKey)}
+          separator
+        >
+          <div className="w-full max-w-md space-y-2">
+            <div className="flex items-center justify-between">
+              <span className="text-xs text-muted-foreground">{t('settings.networkProxyEnabled' as TranslationKey)}</span>
+              <Switch
+                checked={networkProxyEnabled}
+                onCheckedChange={handleNetworkProxyToggle}
+                disabled={networkProxySaving}
+              />
+            </div>
+            <p className="text-xs text-muted-foreground">{t('settings.networkProxyUrlLabel' as TranslationKey)}</p>
+            <Input
+              value={networkProxyUrl}
+              onChange={(e) => setNetworkProxyUrl(e.target.value)}
+              placeholder={t('settings.networkProxyUrlPlaceholder' as TranslationKey)}
+              disabled={networkProxySaving}
+            />
+            <p className="text-xs text-muted-foreground">{t('settings.networkNoProxyLabel' as TranslationKey)}</p>
+            <Input
+              value={networkNoProxy}
+              onChange={(e) => setNetworkNoProxy(e.target.value)}
+              placeholder={t('settings.networkNoProxyPlaceholder' as TranslationKey)}
+              disabled={networkProxySaving}
+            />
+            <p className="text-xs text-muted-foreground">{t('settings.networkProxyCaPathLabel' as TranslationKey)}</p>
+            <Input
+              value={networkProxyCaPath}
+              onChange={(e) => setNetworkProxyCaPath(e.target.value)}
+              placeholder={t('settings.networkProxyCaPathPlaceholder' as TranslationKey)}
+              disabled={networkProxySaving}
+            />
+            <div className="flex justify-end">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => saveNetworkProxySettings()}
+                disabled={networkProxySaving}
+              >
+                {t('cli.save')}
+              </Button>
+            </div>
+          </div>
         </FieldRow>
 
         {/* Setup Center */}

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -132,6 +132,15 @@ const en = {
   'settings.defaultPanelGit': 'Git',
   'settings.language': 'Language',
   'settings.languageDesc': 'Choose the display language for the interface',
+  'settings.networkProxyTitle': 'Network Proxy',
+  'settings.networkProxyDesc': 'Configure HTTP/HTTPS proxy for app network requests. Changes apply immediately.',
+  'settings.networkProxyEnabled': 'Enable proxy',
+  'settings.networkProxyUrlLabel': 'Proxy URL',
+  'settings.networkProxyUrlPlaceholder': 'Proxy URL (e.g. http://127.0.0.1:7890)',
+  'settings.networkNoProxyLabel': 'NO_PROXY',
+  'settings.networkNoProxyPlaceholder': 'NO_PROXY (comma-separated hosts, optional)',
+  'settings.networkProxyCaPathLabel': 'CA Path',
+  'settings.networkProxyCaPathPlaceholder': 'Custom CA path (NODE_EXTRA_CA_CERTS, optional)',
   'settings.usage': 'Usage',
 
   // ── Settings: Appearance ──────────────────────────────────────

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -129,6 +129,15 @@ const zh: Record<TranslationKey, string> = {
   'settings.defaultPanelGit': 'Git',
   'settings.language': '语言',
   'settings.languageDesc': '选择界面显示语言',
+  'settings.networkProxyTitle': '网络代理',
+  'settings.networkProxyDesc': '为应用网络请求配置 HTTP/HTTPS 代理。保存后立即生效。',
+  'settings.networkProxyEnabled': '启用代理',
+  'settings.networkProxyUrlLabel': '代理地址',
+  'settings.networkProxyUrlPlaceholder': '代理地址（例如 http://127.0.0.1:7890）',
+  'settings.networkNoProxyLabel': 'NO_PROXY',
+  'settings.networkNoProxyPlaceholder': 'NO_PROXY（可选，逗号分隔）',
+  'settings.networkProxyCaPathLabel': 'CA 路径',
+  'settings.networkProxyCaPathPlaceholder': '自定义 CA 路径（NODE_EXTRA_CA_CERTS，可选）',
   'settings.usage': '用量统计',
 
   // ── Settings: Appearance ──────────────────────────────────────

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -4,6 +4,13 @@
  */
 export async function register() {
   if (process.env.NEXT_RUNTIME === 'nodejs') {
+    const { getSetting } = await import('@/lib/db');
+    const { applyNetworkProxyFromAppSettings, readNetworkProxySettings } = await import('@/lib/network-proxy');
+
+    // Re-apply persisted network proxy settings on boot.
+    // Without this, proxy envs only take effect after settings are saved once in current process.
+    applyNetworkProxyFromAppSettings(readNetworkProxySettings(getSetting));
+
     // Initialize Sentry for server-side error capture (respects opt-out marker file)
     const dsn = process.env.NEXT_PUBLIC_SENTRY_DSN;
     if (dsn) {

--- a/src/lib/http/client.ts
+++ b/src/lib/http/client.ts
@@ -1,0 +1,237 @@
+import { HttpClientError, isLikelyNetworkError, isRetryableHttpStatus } from '@/lib/http/errors';
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+const DEFAULT_RETRIES = 2;
+const DEFAULT_RETRY_DELAY_MS = 250;
+const DEFAULT_RETRY_JITTER_MS = 75;
+
+type NextFetchOptions = {
+  revalidate?: number | false;
+  tags?: string[];
+};
+
+export interface HttpClientRequestOptions extends Omit<RequestInit, 'signal'> {
+  timeoutMs?: number;
+  retries?: number;
+  retryDelayMs?: number;
+  retryJitterMs?: number;
+  requestId?: string;
+  signal?: AbortSignal;
+  next?: NextFetchOptions;
+}
+
+export interface HttpJsonResponse<T> {
+  data: T;
+  status: number;
+  headers: Headers;
+  requestId: string;
+}
+
+function generateRequestId(): string {
+  const maybeCrypto = globalThis.crypto as Crypto | undefined;
+  if (maybeCrypto?.randomUUID) return maybeCrypto.randomUUID();
+  return `req_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function computeBackoffDelay(
+  attempt: number,
+  baseDelayMs: number,
+  jitterMs: number,
+  retryAfterSeconds?: number,
+): number {
+  if (typeof retryAfterSeconds === 'number' && Number.isFinite(retryAfterSeconds) && retryAfterSeconds > 0) {
+    return Math.max(baseDelayMs, Math.ceil(retryAfterSeconds * 1000));
+  }
+  const exponential = baseDelayMs * Math.pow(2, Math.max(0, attempt - 1));
+  const jitter = jitterMs > 0 ? Math.floor(Math.random() * jitterMs) : 0;
+  return exponential + jitter;
+}
+
+function delay(ms: number, signal?: AbortSignal): Promise<void> {
+  if (ms <= 0) return Promise.resolve();
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(new DOMException('Aborted', 'AbortError'));
+    };
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+function createTimeoutSignal(timeoutMs: number): { signal: AbortSignal; cleanup: () => void } {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  return {
+    signal: controller.signal,
+    cleanup: () => clearTimeout(timer),
+  };
+}
+
+function combineSignals(primary: AbortSignal, secondary?: AbortSignal): AbortSignal {
+  if (!secondary) return primary;
+  if (typeof AbortSignal.any === 'function') {
+    return AbortSignal.any([primary, secondary]);
+  }
+  const controller = new AbortController();
+  const abort = () => controller.abort();
+  if (primary.aborted || secondary.aborted) {
+    controller.abort();
+    return controller.signal;
+  }
+  primary.addEventListener('abort', abort, { once: true });
+  secondary.addEventListener('abort', abort, { once: true });
+  return controller.signal;
+}
+
+function normalizeMethod(method?: string): string {
+  return (method || 'GET').toUpperCase();
+}
+
+function buildRequestInit(
+  url: string,
+  requestId: string,
+  options: HttpClientRequestOptions,
+  signal: AbortSignal,
+): RequestInit & { next?: NextFetchOptions } {
+  const init = { ...options } as HttpClientRequestOptions & { [key: string]: unknown };
+  delete init.timeoutMs;
+  delete init.retries;
+  delete init.retryDelayMs;
+  delete init.retryJitterMs;
+  delete init.requestId;
+
+  const headers = new Headers(options.headers);
+  if (!headers.has('x-request-id')) {
+    headers.set('x-request-id', requestId);
+  }
+
+  return {
+    ...init,
+    method: normalizeMethod(options.method),
+    headers,
+    signal,
+    next: options.next,
+  };
+}
+
+function extractRetryAfterSeconds(headers: Headers): number | undefined {
+  const value = headers.get('retry-after');
+  if (!value) return undefined;
+  const parsed = Number(value);
+  if (Number.isFinite(parsed)) return parsed;
+  const dateMs = Date.parse(value);
+  if (Number.isNaN(dateMs)) return undefined;
+  return Math.max(0, (dateMs - Date.now()) / 1000);
+}
+
+export async function requestJson<T>(url: string, options: HttpClientRequestOptions = {}): Promise<HttpJsonResponse<T>> {
+  const requestId = options.requestId || generateRequestId();
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const retries = Math.max(0, options.retries ?? DEFAULT_RETRIES);
+  const retryDelayMs = Math.max(0, options.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS);
+  const retryJitterMs = Math.max(0, options.retryJitterMs ?? DEFAULT_RETRY_JITTER_MS);
+  const method = normalizeMethod(options.method);
+
+  for (let attempt = 1; attempt <= retries + 1; attempt++) {
+    const timeout = createTimeoutSignal(timeoutMs);
+    const signal = combineSignals(timeout.signal, options.signal);
+    const init = buildRequestInit(url, requestId, options, signal);
+    try {
+      const response = await fetch(url, init);
+      if (!response.ok) {
+        const retryable = isRetryableHttpStatus(response.status);
+        const statusText = response.statusText || 'Unknown Error';
+        const error = new HttpClientError({
+          code: 'http_status',
+          requestId,
+          status: response.status,
+          url,
+          method,
+          retryable,
+          attempt,
+          message: `Upstream HTTP ${response.status} ${statusText}`,
+        });
+        if (retryable && attempt <= retries) {
+          const delayMs = computeBackoffDelay(
+            attempt,
+            retryDelayMs,
+            retryJitterMs,
+            extractRetryAfterSeconds(response.headers),
+          );
+          await delay(delayMs, options.signal);
+          continue;
+        }
+        throw error;
+      }
+
+      let data: unknown;
+      try {
+        data = await response.json();
+      } catch (cause) {
+        throw new HttpClientError({
+          code: 'invalid_json',
+          requestId,
+          url,
+          method,
+          retryable: false,
+          attempt,
+          message: 'Failed to parse JSON response',
+          cause,
+        });
+      }
+
+      return {
+        data: data as T,
+        status: response.status,
+        headers: response.headers,
+        requestId,
+      };
+    } catch (error) {
+      if (error instanceof HttpClientError) {
+        throw error;
+      }
+
+      const isTimeout = timeout.signal.aborted && !options.signal?.aborted;
+      const code = isTimeout ? 'timeout' : (isLikelyNetworkError(error) ? 'network' : 'unknown');
+      const retryable = code === 'timeout' || code === 'network';
+      const normalized = new HttpClientError({
+        code,
+        requestId,
+        url,
+        method,
+        retryable,
+        attempt,
+        message: isTimeout ? `Request timeout after ${timeoutMs}ms` : `Request failed: ${String((error as Error)?.message || error)}`,
+        cause: error,
+      });
+      if (retryable && attempt <= retries) {
+        const delayMs = computeBackoffDelay(attempt, retryDelayMs, retryJitterMs);
+        await delay(delayMs, options.signal);
+        continue;
+      }
+      throw normalized;
+    } finally {
+      timeout.cleanup();
+    }
+  }
+
+  throw new HttpClientError({
+    code: 'unknown',
+    requestId,
+    url,
+    method,
+    retryable: false,
+    attempt: retries + 1,
+    message: 'Request failed after retries',
+  });
+}
+
+export async function getJson<T>(url: string, options: HttpClientRequestOptions = {}): Promise<HttpJsonResponse<T>> {
+  return requestJson<T>(url, { ...options, method: 'GET' });
+}
+
+export { HttpClientError } from '@/lib/http/errors';

--- a/src/lib/http/errors.ts
+++ b/src/lib/http/errors.ts
@@ -1,0 +1,71 @@
+export type HttpClientErrorCode = 'timeout' | 'network' | 'http_status' | 'invalid_json' | 'unknown';
+
+export interface HttpClientErrorOptions {
+  code: HttpClientErrorCode;
+  requestId: string;
+  message: string;
+  url: string;
+  method: string;
+  status?: number;
+  retryable: boolean;
+  attempt: number;
+  cause?: unknown;
+}
+
+export class HttpClientError extends Error {
+  readonly code: HttpClientErrorCode;
+  readonly requestId: string;
+  readonly status?: number;
+  readonly url: string;
+  readonly method: string;
+  readonly retryable: boolean;
+  readonly attempt: number;
+
+  constructor(options: HttpClientErrorOptions) {
+    super(options.message);
+    this.name = 'HttpClientError';
+    this.code = options.code;
+    this.requestId = options.requestId;
+    this.status = options.status;
+    this.url = options.url;
+    this.method = options.method;
+    this.retryable = options.retryable;
+    this.attempt = options.attempt;
+    if (options.cause !== undefined) {
+      (this as Error & { cause?: unknown }).cause = options.cause;
+    }
+  }
+}
+
+export function isRetryableHttpStatus(status: number): boolean {
+  return status === 429 || status >= 500;
+}
+
+export function isLikelyNetworkError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+  if ((error as { name?: string }).name === 'AbortError') return false;
+
+  const withCode = error as { code?: string };
+  if (typeof withCode.code === 'string') {
+    const code = withCode.code.toUpperCase();
+    if (
+      code === 'ECONNRESET' ||
+      code === 'ECONNREFUSED' ||
+      code === 'ETIMEDOUT' ||
+      code === 'ENOTFOUND' ||
+      code === 'EAI_AGAIN'
+    ) {
+      return true;
+    }
+  }
+
+  const message = String((error as { message?: string }).message || '').toLowerCase();
+  return (
+    message.includes('fetch failed') ||
+    message.includes('network') ||
+    message.includes('socket') ||
+    message.includes('econn') ||
+    message.includes('timeout') ||
+    message.includes('enotfound')
+  );
+}

--- a/src/lib/network-proxy.ts
+++ b/src/lib/network-proxy.ts
@@ -1,0 +1,80 @@
+type NetworkProxySettings = {
+  network_proxy_enabled?: string;
+  network_proxy_url?: string;
+  network_no_proxy?: string;
+  network_proxy_ca_path?: string;
+};
+
+const DEFAULT_NO_PROXY_ENTRIES = ['localhost', '127.0.0.1', '::1'];
+
+function setOrDeleteEnv(key: string, value: string): void {
+  if (value) {
+    process.env[key] = value;
+    return;
+  }
+  delete process.env[key];
+}
+
+function normalizeNoProxy(raw: string): string {
+  const seen = new Set<string>();
+  const merged: string[] = [];
+
+  for (const token of raw.split(',').map(v => v.trim()).filter(Boolean)) {
+    if (seen.has(token)) continue;
+    seen.add(token);
+    merged.push(token);
+  }
+  for (const token of DEFAULT_NO_PROXY_ENTRIES) {
+    if (seen.has(token)) continue;
+    seen.add(token);
+    merged.push(token);
+  }
+  return merged.join(',');
+}
+
+export function applyNetworkProxyFromAppSettings(settings: NetworkProxySettings): void {
+  const enabled = settings.network_proxy_enabled === 'true';
+  const proxyUrl = (settings.network_proxy_url || '').trim();
+  const noProxy = normalizeNoProxy((settings.network_no_proxy || '').trim());
+  const caPath = (settings.network_proxy_ca_path || '').trim();
+
+  if (!enabled) {
+    delete process.env.HTTP_PROXY;
+    delete process.env.HTTPS_PROXY;
+    delete process.env.http_proxy;
+    delete process.env.https_proxy;
+    delete process.env.NO_PROXY;
+    delete process.env.no_proxy;
+    delete process.env.NODE_EXTRA_CA_CERTS;
+    return;
+  }
+
+  if (!proxyUrl) {
+    delete process.env.HTTP_PROXY;
+    delete process.env.HTTPS_PROXY;
+    delete process.env.http_proxy;
+    delete process.env.https_proxy;
+  } else {
+    process.env.HTTP_PROXY = proxyUrl;
+    process.env.HTTPS_PROXY = proxyUrl;
+    process.env.http_proxy = proxyUrl;
+    process.env.https_proxy = proxyUrl;
+  }
+
+  setOrDeleteEnv('NO_PROXY', noProxy);
+  setOrDeleteEnv('no_proxy', noProxy);
+  setOrDeleteEnv('NODE_EXTRA_CA_CERTS', caPath);
+}
+
+export function readNetworkProxySettings(
+  getSetting: (key: string) => string | undefined,
+): NetworkProxySettings {
+  return {
+    network_proxy_enabled: getSetting('network_proxy_enabled') ?? '',
+    network_proxy_url: getSetting('network_proxy_url') ?? '',
+    network_no_proxy: getSetting('network_no_proxy') ?? '',
+    network_proxy_ca_path: getSetting('network_proxy_ca_path') ?? '',
+  };
+}
+
+export type { NetworkProxySettings };

--- a/src/lib/network-proxy.ts
+++ b/src/lib/network-proxy.ts
@@ -1,3 +1,6 @@
+import { Agent, EnvHttpProxyAgent, getGlobalDispatcher, setGlobalDispatcher } from 'undici';
+import type { Dispatcher } from 'undici';
+
 type NetworkProxySettings = {
   network_proxy_enabled?: string;
   network_proxy_url?: string;
@@ -6,6 +9,12 @@ type NetworkProxySettings = {
 };
 
 const DEFAULT_NO_PROXY_ENTRIES = ['localhost', '127.0.0.1', '::1'];
+const DISPATCHER_STATE_KEY = '__codepilotNetworkDispatcherState__' as const;
+
+type ManagedDispatcherState = {
+  dispatcher: Dispatcher | null;
+  signature: string;
+};
 
 function setOrDeleteEnv(key: string, value: string): void {
   if (value) {
@@ -32,6 +41,42 @@ function normalizeNoProxy(raw: string): string {
   return merged.join(',');
 }
 
+function getDispatcherState(): ManagedDispatcherState {
+  const globalRef = globalThis as Record<string, unknown>;
+  const existing = globalRef[DISPATCHER_STATE_KEY] as ManagedDispatcherState | undefined;
+  if (existing) return existing;
+  const initial: ManagedDispatcherState = { dispatcher: null, signature: '' };
+  globalRef[DISPATCHER_STATE_KEY] = initial;
+  return initial;
+}
+
+function closeDispatcher(dispatcher: Dispatcher | null): void {
+  if (!dispatcher) return;
+  const maybeClose = (dispatcher as { close?: () => Promise<void> }).close;
+  if (typeof maybeClose !== 'function') return;
+  void maybeClose.call(dispatcher).catch(() => {
+    // best effort cleanup
+  });
+}
+
+function ensureGlobalDispatcher(signature: string, createDispatcher: () => Dispatcher): void {
+  const state = getDispatcherState();
+  // If another part of the app replaced the dispatcher, don't assume ours is active.
+  if (
+    state.signature === signature
+    && state.dispatcher
+    && getGlobalDispatcher() === state.dispatcher
+  ) {
+    return;
+  }
+
+  const next = createDispatcher();
+  setGlobalDispatcher(next);
+  closeDispatcher(state.dispatcher);
+  state.dispatcher = next;
+  state.signature = signature;
+}
+
 export function applyNetworkProxyFromAppSettings(settings: NetworkProxySettings): void {
   const enabled = settings.network_proxy_enabled === 'true';
   const proxyUrl = (settings.network_proxy_url || '').trim();
@@ -46,6 +91,7 @@ export function applyNetworkProxyFromAppSettings(settings: NetworkProxySettings)
     delete process.env.NO_PROXY;
     delete process.env.no_proxy;
     delete process.env.NODE_EXTRA_CA_CERTS;
+    ensureGlobalDispatcher('direct', () => new Agent());
     return;
   }
 
@@ -64,6 +110,16 @@ export function applyNetworkProxyFromAppSettings(settings: NetworkProxySettings)
   setOrDeleteEnv('NO_PROXY', noProxy);
   setOrDeleteEnv('no_proxy', noProxy);
   setOrDeleteEnv('NODE_EXTRA_CA_CERTS', caPath);
+
+  if (!proxyUrl) {
+    ensureGlobalDispatcher('direct', () => new Agent());
+    return;
+  }
+
+  // Use EnvHttpProxyAgent so NO_PROXY/no_proxy rules are honored.
+  // Recreate the dispatcher whenever proxy/no_proxy/CA signature changes.
+  const signature = `proxy:${proxyUrl}|no_proxy:${noProxy}|ca:${caPath}`;
+  ensureGlobalDispatcher(signature, () => new EnvHttpProxyAgent());
 }
 
 export function readNetworkProxySettings(

--- a/src/lib/provider-doctor.ts
+++ b/src/lib/provider-doctor.ts
@@ -97,6 +97,47 @@ function probeSeverity(findings: Finding[]): Severity {
   return sev;
 }
 
+function readFirstEnv(keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = process.env[key];
+    if (typeof value === 'string' && value.trim().length > 0) {
+      return value.trim();
+    }
+  }
+  return undefined;
+}
+
+function describeProxy(value: string): string {
+  try {
+    const u = new URL(value);
+    return `${u.protocol}//${u.hostname}${u.port ? `:${u.port}` : ''}`;
+  } catch {
+    return '<invalid-proxy-url>';
+  }
+}
+
+function parseNoProxy(value: string | undefined): string[] {
+  if (!value) return [];
+  return value
+    .split(',')
+    .map(item => item.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+function noProxyBypassesLoopback(entries: string[]): boolean {
+  if (entries.includes('*')) return true;
+  for (const raw of entries) {
+    const entry = raw.replace(/^\./, '');
+    if (entry === 'localhost' || entry === '127.0.0.1' || entry === '::1' || entry === '[::1]') {
+      return true;
+    }
+    if (entry.endsWith('.localhost')) {
+      return true;
+    }
+  }
+  return false;
+}
+
 // ── CLI Probe ───────────────────────────────────────────────────
 
 async function runCliProbe(): Promise<ProbeResult> {
@@ -615,8 +656,85 @@ async function runNetworkProbe(): Promise<ProbeResult> {
   const findings: Finding[] = [];
   const start = Date.now();
 
-  // Collect unique base URLs to check
-  const urlsToCheck = new Map<string, string>(); // url -> label
+  // Proxy diagnostics
+  const httpsProxy = readFirstEnv(['HTTPS_PROXY', 'https_proxy']);
+  const httpProxy = readFirstEnv(['HTTP_PROXY', 'http_proxy']);
+  const noProxyRaw = readFirstEnv(['NO_PROXY', 'no_proxy']);
+  const noProxyEntries = parseNoProxy(noProxyRaw);
+  const hasProxy = !!httpsProxy || !!httpProxy;
+  if (hasProxy) {
+    const proxyParts: string[] = [];
+    if (httpsProxy) proxyParts.push(`HTTPS_PROXY=${describeProxy(httpsProxy)}`);
+    if (httpProxy) proxyParts.push(`HTTP_PROXY=${describeProxy(httpProxy)}`);
+    findings.push({
+      severity: 'ok',
+      code: 'network.proxy.configured',
+      message: 'Proxy environment variables detected',
+      detail: proxyParts.join(', '),
+    });
+
+    const bypassesLoopback = noProxyBypassesLoopback(noProxyEntries);
+    findings.push({
+      severity: bypassesLoopback ? 'ok' : 'warn',
+      code: bypassesLoopback ? 'network.proxy.loopback-bypassed' : 'network.proxy.loopback-not-bypassed',
+      message: bypassesLoopback
+        ? 'NO_PROXY bypasses localhost/loopback'
+        : 'NO_PROXY does not clearly bypass localhost/loopback',
+      detail: noProxyRaw
+        ? `NO_PROXY=${noProxyRaw}`
+        : 'NO_PROXY is not set while proxy is enabled',
+    });
+  } else {
+    findings.push({
+      severity: 'ok',
+      code: 'network.proxy.not-configured',
+      message: 'No HTTP(S) proxy environment variables detected',
+    });
+  }
+
+  // Enterprise CA diagnostics
+  const extraCaCerts = readFirstEnv(['NODE_EXTRA_CA_CERTS']);
+  if (!extraCaCerts) {
+    findings.push({
+      severity: 'ok',
+      code: 'network.ca.not-configured',
+      message: 'NODE_EXTRA_CA_CERTS is not configured',
+    });
+  } else if (!fs.existsSync(extraCaCerts)) {
+    findings.push({
+      severity: 'warn',
+      code: 'network.ca.missing',
+      message: 'NODE_EXTRA_CA_CERTS points to a missing file',
+      detail: extraCaCerts,
+    });
+  } else {
+    try {
+      fs.accessSync(extraCaCerts, fs.constants.R_OK);
+      findings.push({
+        severity: 'ok',
+        code: 'network.ca.readable',
+        message: 'NODE_EXTRA_CA_CERTS file exists and is readable',
+        detail: extraCaCerts,
+      });
+    } catch (err) {
+      findings.push({
+        severity: 'warn',
+        code: 'network.ca.unreadable',
+        message: 'NODE_EXTRA_CA_CERTS file exists but is not readable',
+        detail: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  // Collect base URLs to check
+  type NetworkTarget = {
+    url: string;
+    label: string;
+    source: 'anthropic' | 'provider';
+    providerName?: string;
+    providerId?: string;
+  };
+  const targets: NetworkTarget[] = [];
 
   // Only check Anthropic API if the current resolution actually uses it
   // (env mode with no providers, or provider with anthropic base_url).
@@ -624,7 +742,11 @@ async function runNetworkProbe(): Promise<ProbeResult> {
   const resolved = resolveProvider();
   const isEnvMode = !resolved.provider;
   if (isEnvMode) {
-    urlsToCheck.set('https://api.anthropic.com', 'Anthropic API');
+    targets.push({
+      url: 'https://api.anthropic.com',
+      label: 'Anthropic API',
+      source: 'anthropic',
+    });
   }
 
   // Provider-specific URLs
@@ -633,7 +755,19 @@ async function runNetworkProbe(): Promise<ProbeResult> {
     if (p.base_url) {
       try {
         const u = new URL(p.base_url);
-        urlsToCheck.set(u.origin, `Provider "${p.name}"`);
+        findings.push({
+          severity: 'ok',
+          code: 'gateway.base-url-valid',
+          message: `Gateway base_url for provider "${p.name}" is valid`,
+          detail: `Provider ID: ${p.id}. Origin: ${u.origin}`,
+        });
+        targets.push({
+          url: u.origin,
+          label: `Provider "${p.name}"`,
+          source: 'provider',
+          providerName: p.name,
+          providerId: p.id,
+        });
       } catch {
         findings.push({
           severity: 'warn',
@@ -641,17 +775,23 @@ async function runNetworkProbe(): Promise<ProbeResult> {
           message: `Provider "${p.name}" has invalid base_url`,
           detail: p.base_url,
         });
+        findings.push({
+          severity: 'warn',
+          code: 'gateway.invalid-base-url',
+          message: `Gateway base_url for provider "${p.name}" is invalid`,
+          detail: `Provider ID: ${p.id}. base_url=${p.base_url}`,
+        });
       }
     }
   }
 
   // HEAD request each URL (no API key sent)
   const TIMEOUT = 5000;
-  const checks = Array.from(urlsToCheck.entries()).map(async ([url, label]) => {
+  const checks = targets.map(async (target) => {
     try {
       const controller = new AbortController();
       const timer = setTimeout(() => controller.abort(), TIMEOUT);
-      const resp = await fetch(url, {
+      const resp = await fetch(target.url, {
         method: 'HEAD',
         signal: controller.signal,
         headers: { 'User-Agent': 'CodePilot-ProviderDoctor/1.0' },
@@ -661,18 +801,34 @@ async function runNetworkProbe(): Promise<ProbeResult> {
       findings.push({
         severity: 'ok',
         code: 'network.reachable',
-        message: `${label} (${url}) is reachable`,
+        message: `${target.label} (${target.url}) is reachable`,
         detail: `Status: ${resp.status}`,
       });
+      if (target.source === 'provider' && target.providerName) {
+        findings.push({
+          severity: 'ok',
+          code: 'gateway.reachable',
+          message: `Gateway for provider "${target.providerName}" is reachable`,
+          detail: `Provider ID: ${target.providerId}. URL: ${target.url}. Status: ${resp.status}`,
+        });
+      }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       const isTimeout = message.includes('abort');
       findings.push({
         severity: 'warn',
         code: isTimeout ? 'network.timeout' : 'network.unreachable',
-        message: `${label} (${url}) ${isTimeout ? 'timed out' : 'is unreachable'}`,
+        message: `${target.label} (${target.url}) ${isTimeout ? 'timed out' : 'is unreachable'}`,
         detail: message,
       });
+      if (target.source === 'provider' && target.providerName) {
+        findings.push({
+          severity: 'warn',
+          code: isTimeout ? 'gateway.timeout' : 'gateway.unreachable',
+          message: `Gateway for provider "${target.providerName}" ${isTimeout ? 'timed out' : 'is unreachable'}`,
+          detail: `Provider ID: ${target.providerId}. URL: ${target.url}. ${message}`,
+        });
+      }
     }
   });
 

--- a/src/lib/streaming-status.ts
+++ b/src/lib/streaming-status.ts
@@ -1,0 +1,17 @@
+export interface ThinkingIndicatorParams {
+  isStreaming: boolean;
+  content: string;
+  toolUsesCount: number;
+  thinkingContent?: string;
+  statusText?: string;
+}
+
+export function shouldShowThinkingPhaseIndicator(params: ThinkingIndicatorParams): boolean {
+  return (
+    params.isStreaming
+    && params.content.length === 0
+    && params.toolUsesCount === 0
+    && !params.thinkingContent
+    && !params.statusText?.trim()
+  );
+}


### PR DESCRIPTION
## Summary

这个 PR 是一组网络改造 + 体验修复，内容以远端 `main` 为对比基准。

主要包含三块：

1. 统一 outbound HTTP（作为 Cloud/第三方网关请求层）
2. 轻量代理能力（设置页 + 服务端生效）
3. Streaming 状态与代理实效修复（本次追加）

## 主要改动

### 1) 统一 outbound HTTP / 网关请求层

- 新增统一 HTTP 客户端与错误模型：
  - `src/lib/http/client.ts`
  - `src/lib/http/errors.ts`
- 将关键网络路径接入统一请求层与可读错误：
  - `src/lib/provider-doctor.ts`
  - `src/app/api/app/updates/route.ts`
- 对应单测：
  - `src/__tests__/unit/http-client.test.ts`
  - `src/__tests__/unit/provider-doctor-network.test.ts`
  - `src/__tests__/unit/app-updates-route.test.ts`

### 2) 代理配置与接入

- 设置页新增轻量代理项（开关 / URL / NO_PROXY / CA）：
  - `src/components/settings/GeneralSection.tsx`
  - `src/i18n/en.ts`
  - `src/i18n/zh.ts`
- 服务端启动与设置保存时应用代理：
  - `src/instrumentation.ts`
  - `src/app/api/settings/app/route.ts`
  - `src/lib/network-proxy.ts`
- 网络验证路由对齐统一请求行为：
  - `src/app/api/settings/discord/verify/route.ts`
  - `src/app/api/settings/feishu/verify/route.ts`
  - `src/app/api/settings/qq/verify/route.ts`
  - `src/app/api/claude-status/route.ts`
- 对应单测：
  - `src/__tests__/unit/network-proxy.test.ts`
  - `src/__tests__/unit/settings-verify-route-http-client.test.ts`

### 3) 本次追加修复

- Streaming 状态优先级：重连中不再显示“深度思考”
  - `src/components/chat/StreamingMessage.tsx`
  - `src/lib/streaming-status.ts`
  - `src/__tests__/unit/streaming-status.test.ts`
- 代理实效修复：在环境变量之外，切换 undici 全局 dispatcher
  - 代理开启：`EnvHttpProxyAgent`（尊重 `NO_PROXY`）
  - 代理关闭：`Agent`
  - 文件：`src/lib/network-proxy.ts`
- E2E 网络验收补充（含 `gpt-5.3-codex-spark` 语境）
  - `src/__tests__/e2e/network-acceptance.spec.ts`

## 验收

本地已执行：

- `npm run -s typecheck`
- `npm run -s test:unit`
- `npx playwright test src/__tests__/e2e/network-acceptance.spec.ts`

并做了真实请求对照（OpenAI OAuth + `gpt-5.3-codex-spark`）：

- 代理关闭：可复现 `AI_RetryError / Connect Timeout / ECONNRESET`
- 代理开启（`http://127.0.0.1:7890`）：同会话可正常流式返回

## Notes

- 本地仅用于开发启动的临时改动（`package.json` 中 `electron:dev` 端口/host）未纳入提交。