### PR TITLE
fix(ui): bump sidebar list gap from 2px to 6px

### DIFF
--- a/docs/exec-plans/active/sidebar-list-spacing.md
+++ b/docs/exec-plans/active/sidebar-list-spacing.md
@@ -1,0 +1,64 @@
+# Sidebar list spacing — 2px → 6px
+
+> 状态：已完成 · 提交：`3285fa3 fix(ui): bump sidebar list gap from 2px to 6px` + `bc0c857 docs(ui-governance): add spacing convention`
+> 范围：`src/components/layout/ChatListPanel.tsx` (2 行) + `docs/ui-governance.md` (新增 1 节)
+
+## 1. 问题
+
+`ChatListPanel` 中两处 sidebar 列表用 `flex flex-col gap-0.5`（2px）。2px 是 cell **内部** stack 的标准（icon+label、title+subtitle），但用于 **列表项之间** 偏紧：浅色主题下 hover 背景 `bg-sidebar-accent` (≈ 6% 黑叠加) 边缘与 2px 间隔融合，扫鼠标时两条 hover 背景读作"一段色带"，看不出"这是两条独立条目"。
+
+## 2. 改动
+
+| 文件 | 行 | 改动 |
+|---|---|---|
+| `src/components/layout/ChatListPanel.tsx` | L470 | `gap-0.5` → `gap-1.5`（feature nav items） |
+| `src/components/layout/ChatListPanel.tsx` | L598 | `gap-0.5` → `gap-1.5`（项目组内 session 列表） |
+| `docs/ui-governance.md` | — | 新增"间距规范"一节，把规则写入 design system contract |
+
+总代码改动 = 2 行 Tailwind className。
+
+## 3. 选型
+
+| 候选 | 视觉 | 长列表代价 | 决定 |
+|---|---|---|---|
+| 2px (`gap-0.5`) | 与 hover bg 融合 | 0 | ❌ 问题没解决 |
+| **6px (`gap-1.5`)** | **清晰分隔** | **20 行 = 120px** | ✅ |
+| 8px (`gap-2`) | 略松 | 20 行 = 160px，挤掉"新建会话"入口 | ❌ |
+
+6px 与行内 `px-3` / `h-8` 构成"外 6 / 内 32 / 内 12"三档节奏。
+
+## 4. 不改的地方
+
+- **`SessionListItem.tsx:218` 仍是 `gap-0.5`**：这是 cell 内部 stack（图标+标题+副标题），按"外 6 / 内 2"分层设计。
+- **`ModelsSection` / 角色映射 dialog footer**：原 bug 报告里的 dialog 在新架构已被 refactor 掉（`ModelsSection.tsx` 整个文件已删除，role mapping 拆为 `ProviderForm` JSON 文本域 + `PresetConnectDialog` 多字段）。该 bug 在 main 上不再存在，本 PR 不涉及。
+- **`PresetConnectDialog` 的 footer**：已是 2xl 滚动结构但 footer 没 border + pt，肉眼判断是否过紧需要 dev 模式实看，**不在本 PR 范围**。下一轮视觉 pass 一起处理。
+
+## 5. 验证
+
+| Gate | 结果 |
+|---|---|
+| `npm run typecheck` | ✅ 0 错（`rm -rf .next` 后清理 33 个 stale validator 错误，与本 PR 无关） |
+| `npm run test:unit` | ✅ baseline pass |
+| dev 视觉 | ⏸ reviewer 本地 `npm run electron:dev` 复跑 |
+
+### Reviewer 视觉 smoke（< 1 分钟）
+
+1. 打开 sidebar → 鼠标在两个 feature nav 之间扫 → 期望两条 hover 背景清晰分隔
+2. 展开任一项目组 → 鼠标在两个 session row 之间扫 → 期望同上
+3. 折叠项目组 → 期望折叠态无空白 gap
+4. 单看一个 session row 内部（icon + 标题）→ 期望 **未变**，仍是紧贴的 2px
+
+## 6. 决策日志
+
+| 时间 | 决策 | 备选 | 取舍 |
+|---|---|---|---|
+| v1 (旧 base `48df4d6`) | 修 3 处 `flex flex-col` 加 `gap-0.5` (2px) | — | 在 bug 报告的分支上 |
+| v1.5 (review 反馈) | bump 到 `gap-1.5` (6px) | 4px / 8px | 用户视觉判断 2px 不够 |
+| v2 (新 base `9678e01`) | 只动 2 处（feature nav + session list）；项目分组结构已重写 | 全文件扫描 | 边界明确：动 list 容器，不动 cell 内部 |
+| 文档位置 | `ui-governance.md` 顶部一节 | `design.md` (旧) | 新架构用 ui-governance.md 替代 design.md 作 contract |
+| 不动 Primitive | `DialogFooter` 不下沉 border | primitive 改 | 短弹窗会污染 |
+
+## 7. 链接
+
+- 设计规范（contract）：`docs/ui-governance.md` §「间距规范」
+- 产品反向链接（context）：`docs/insights/sidebar-list-2px-vs-6px.md`

--- a/docs/insights/sidebar-list-2px-vs-6px.md
+++ b/docs/insights/sidebar-list-2px-vs-6px.md
@@ -1,0 +1,50 @@
+# Sidebar list 间距：2px vs 6px
+
+> 与 `docs/exec-plans/active/sidebar-list-spacing.md` 互为反向链接。
+> 本文是 **why**，exec plan 是 **what**。
+
+## 共同的设计失败模式
+
+"`flex flex-col` 没声明 gap 时是 0px 间距" 这件事在 CSS 里是默认行为，但人写代码时容易把 "flex" 当成"自动有节奏" 的隐含约定。`SessionListItem` 内部用 `gap-0.5`、外层容器也用 `gap-0.5` 时，看着"反正都是 gap-0.5 一致"——但**它们是不同语境下的 0.5**：
+
+- **cell 内部**（icon + label、title + subtitle）：同一个交互单元里的元素，必须**紧贴**，2px 才对
+- **list 容器**（nav 项、session row）：不同交互单元之间，必须**清晰分隔**，2px 不够
+
+把它们 collapse 成同一个值，混用 = 节奏混乱。
+
+## 为什么 hover 重叠是 sidebar 特有的
+
+`bg-sidebar-accent` 在 light 主题下大概 6% 黑色叠加。**两段 6% 黑叠加 + 0~2px 间距 = 一段 12% 黑色色带**。人眼看到的不是"两个 hover 状态"，而是"一段色带"。
+
+这是 sidebar 的特殊语境：
+- 长列表（10–50 行）
+- 高频 hover（鼠标扫描导航很常见）
+- 行高紧凑（`h-8` ≈ 32px）—— 给 0~2px 误差的容错空间小
+
+## 为什么 6px 是 sidebar 列表的"最小可读分隔"
+
+- **2px** 与 6% 黑叠加的 hover bg 边缘融合，色带无法被拆成两条
+- **4px** 浅色下勉强可读，但深色主题下 token 透明度变化，4px 又掉到边缘融合区间，**不可靠**
+- **6px** 是 6% + 12% 黑叠加之间能形成"两段色带"感知的最小物理距离；与 `px-3` (12px) / `h-8` (32px) 构成"外 6 / 内 32 / 内 12"三档节奏，视觉上不冲突
+- **8px** 在单行看略松，**但在 20 行列表上累计 160px**，把"新建会话"挤到 768p 折叠线以下 —— 高频用户最常用的入口被推下去，是反 UX 的
+
+## 为什么不在 `DialogFooter` primitive 上加 border
+
+`DialogFooter` 被两类 dialog 共用：
+- **2xl 滚动 dialog**（provider detail、role mapping 长列表、preset 多步表单）：footer 是"决策出口"，需要 32px 缓冲 + 1px 锚点
+- **短弹窗**（confirm、add-model 单字段）：footer 是"看一眼就关"，再加 border + 32px 是噪音
+
+Primitive 一改，两边都被污染。**调用方按需传 className，primitive 保持 `flex + gap-2` 的最小契约**。这是 "primitive 干净，policy 在调用方" 的标准做法。
+
+## 不在这次范围
+
+- `PresetConnectDialog` 的 footer 是否需要 border + pt：肉眼判断需要 dev 模式实看，**下一轮视觉 pass 一起做**
+- `ProviderForm`（短表单）footer：保持无 border 是对的
+- hover 颜色对比度审计：独立 a11y pass
+- sidebar 排版语言整体梳理：独立设计 sprint
+
+## 这次 PR 没做的"另一个 bug"
+
+用户最初报告的"角色映射 dialog footer 紧贴"在 main 上**已经不存在**：原 `ModelsSection.tsx` 整个文件被 refactor 掉，role mapping 拆成了 `ProviderForm` 里的 JSON 文本域（短表单）和 `PresetConnectDialog` 里的多字段（中等长度）。bug 报告时所在的 `worktree-product-refactor-research` 分支还停在 309 个 commit 前的快照上，那个 dialog 早就不在了。
+
+教训：**报告 bug 前先确认 base**。这次的 fix commit 只动了 sidebar list，dialog 部分留给 reviewer 在新架构下重新评估。

--- a/docs/ui-governance.md
+++ b/docs/ui-governance.md
@@ -66,6 +66,35 @@ src/hooks/                  → 数据获取、状态管理 hooks
 - 超过 500 行需拆分为子组件或抽取 hooks
 - `ui/` 和 `ai-elements/` 层豁免（它们是独立的原语库）
 
+## 间距规范
+
+> Token 化的间距档位，避免"0/2/4/8 凭感觉选"导致的同文件间距漂移。
+
+### Sidebar list（侧边栏列表项之间）
+
+| 档位 | className | 用途 |
+|---|---|---|
+| **2px (`gap-0.5`)** | `<div className="flex flex-col gap-0.5">` | cell **内部** 的 icon+label / 标题+副标题等"同交互单元"堆叠 |
+| **6px (`gap-1.5`)** | `<div className="flex flex-col gap-1.5">` | sidebar 的**列表项之间**（nav 项、session row、项目组内 session）—— 默认值 |
+
+**6px 的选择理由：**
+- 2px 与 hover bg (`bg-sidebar-accent` ≈ 6% 黑叠加) 边缘融合，扫鼠标时两条 hover 背景融成一条色带
+- 8px 在 20 行列表上吃 160px 高度，把"新建会话"挤到 768p 折叠线以下
+- 6px 是「最小区分」与「长列表密度」的折中；与行内 `px-3` / `h-8` 构成"外 6 / 内 32 / 内 12"三档节奏
+
+**反模式：**不要混用 — 一个 sidebar 里如果出现 `gap-0.5` 和 `gap-1.5` 交替，肉眼会感知到节奏不齐，肌肉记忆失效。
+
+### Dialog footer（2xl 滚动 dialog 的底部按钮区）
+
+| 模式 | className | 适用场景 |
+|---|---|---|
+| **有 border + pt** | `<DialogFooter className="shrink-0 gap-2 border-t border-border/50 pt-5 mt-3">` | 2xl 滚动 dialog（provider detail、role mapping 长列表、preset 多步表单） |
+| **无 border** | `<DialogFooter className="shrink-0 gap-2">` | 短弹窗（confirm、add-model 单字段） |
+
+**为什么 footer 用 border + pt 而不是单 margin：**单纯 margin 即使 32px 在视觉上仍像"最后一行 + 按钮粘在一起"，间距不传达"分段"。1px anchor + 8px 缓冲让按钮"站在"分隔线肩部，"决策出口"语义成立。
+
+**为什么不在 primitive (`DialogFooter`) 上加 border：**短弹窗（confirm / add-model）不想要 32px 缓冲 + 1px 锚点，primitive 改动会污染它们。**调用方按需传 className，primitive 保持 `flex + gap-2` 的最小契约。**
+
 ## 新 Primitive 审批流程
 
 1. 先检查 `ui/` 中是否已有可复用的组件

--- a/src/components/layout/ChatListPanel.tsx
+++ b/src/components/layout/ChatListPanel.tsx
@@ -467,7 +467,7 @@ export function ChatListPanel({ open, width, hasUpdate, readyToInstall }: ChatLi
 
       {/* Feature nav items */}
       <div className="px-3 pb-2">
-        <div className="flex flex-col gap-0.5">
+        <div className="flex flex-col gap-1.5">
           {navItems.map((item) => {
             const isActive = pathname.startsWith(item.href);
             return (
@@ -595,7 +595,7 @@ export function ChatListPanel({ open, width, hasUpdate, readyToInstall }: ChatLi
                         transition={{ duration: 0.2, ease: 'easeOut' }}
                         style={{ overflow: 'hidden' }}
                       >
-                        <div className="mt-0.5 flex flex-col gap-0.5">
+                        <div className="mt-0.5 flex flex-col gap-1.5">
                           {visibleSessions.map((session) => {
                             const isActive = pathname === `/chat/${session.id}`;
                             const canSplit = !isActive && !isInSplit(session.id);

--- a/src/components/settings/PresetConnectDialog.tsx
+++ b/src/components/settings/PresetConnectDialog.tsx
@@ -807,7 +807,7 @@ export function PresetConnectDialog({
             );
           })()}
 
-          <DialogFooter className="flex items-center justify-between sm:justify-between">
+          <DialogFooter className="flex items-center justify-between sm:justify-between shrink-0 gap-2 border-t border-border/50 pt-5 mt-3">
             <Button
               type="button"
               variant="outline"


### PR DESCRIPTION
## Sidebar list 间距 2px → 6px + 角色映射弹窗 footer 视觉分段

两个看似无关的 bug 来自同一个根因（容器用 `flex flex-col` 没声明 gap / 视觉锚点），都收进同一个 PR。

### 改动一览

```
docs/exec-plans/active/sidebar-list-spacing.md       | new  (64 lines)
docs/insights/sidebar-list-2px-vs-6px.md              | new  (50 lines)
docs/ui-governance.md                                 | +29
src/components/layout/ChatListPanel.tsx               |  2 +/-
src/components/settings/PresetConnectDialog.tsx      |  1 +/-
```

**代码改动 = 3 行 Tailwind className**，全部 stock utilities，零业务逻辑。

```diff
- <div className="flex flex-col gap-0.5">          {/* ChatListPanel L470 feature nav */}
+ <div className="flex flex-col gap-1.5">
- <div className="mt-0.5 flex flex-col gap-0.5">   {/* ChatListPanel L598 session list */}
+ <div className="mt-0.5 flex flex-col gap-1.5">
- <DialogFooter className="flex items-center justify-between sm:justify-between">
+ <DialogFooter className="flex items-center justify-between sm:justify-between shrink-0 gap-2 border-t border-border/50 pt-5 mt-3">
```

### 1. Sidebar list 2px → 6px

| 候选 | 视觉 | 长列表代价 | 决定 |
|---|---|---|---|
| 2px | 与 hover bg 融合 | 0 | ❌ |
| **6px** | **清晰分隔** | **20 行 = 120px** | ✅ |
| 8px | 略松 | 20 行 = 160px | ❌ |

`SessionListItem.tsx:218` 内部 stack **保持 2px**（外 6 / 内 2 是不同语境，混用 = 节奏混乱）。

### 2. 角色映射弹窗 footer 视觉锚点

在最新 main 上，"角色映射" 不是独立 dialog —— 原 `ModelsSection.tsx` 整个文件被 refactor 掉。功能现在拆成：

- `ProviderForm.tsx`：role mapping 收成一个 **JSON 文本域**（短表单，不滚，不需要 anchor）
- **`PresetConnectDialog.tsx`**：preset 模式下把 role 拆成 **Sonnet / Opus / Haiku 网格**（这是 2xl 滚动结构，需要 anchor）

本次改的是后者：

```diff
- <DialogFooter className="flex items-center justify-between sm:justify-between">
+ <DialogFooter className="flex items-center justify-between sm:justify-between shrink-0 gap-2 border-t border-border/50 pt-5 mt-3">
```

- `shrink-0`：primitive 上有 `overflow-y-auto`，footer 在内容过长时不被压缩
- `border-t + pt-5 + mt-3`：32px 堆叠 + 1px 分隔锚点

完整 rationale 见 `docs/ui-governance.md` §「间距规范 → Dialog footer」。

### 关于为什么不在 `DialogFooter` primitive 加 border

短弹窗（confirm / add-model）不想要 32px 缓冲 + 1px 锚点，primitive 改动会跨文件回归。**调用方按需传 className，primitive 保持 `flex + gap-2` 的最小契约。** 当前 `PresetConnectDialog` 是仓库内唯一需要这个 anchor 的调用点。

### 验证

| Gate | 结果 |
|---|---|
| `npm run typecheck` | ✅ 0 错（`rm -rf .next` 后清理 33 个 stale validator 错误，与本 PR 无关） |
| `npm run test:unit` | ✅ baseline pass |
| 视觉 | ⏸ reviewer 本地 `npm run electron:dev` 复跑 |

### Reviewer 视觉 smoke（< 2 分钟）

**Sidebar (issue 1):**
1. 打开 sidebar → 鼠标在两个 feature nav 之间扫 → 期望两条 hover 背景清晰分隔
2. 展开任一项目组 → 鼠标在两个 session row 之间扫 → 期望同上
3. 折叠项目组 → 期望折叠态无空白 gap
4. 单看一个 session row 内部（icon + 标题）→ 期望 **未变**

**Role mapping dialog (issue 2):**
5. Settings → Providers → 任一 preset 卡片 → Connect
6. 展开 Advanced options（Advanced 按钮在底部）
7. 滚到底部（model mapping grid + extraEnv / headers / envOverrides textareas 都在 advanced 里）
8. 期望：「Cancel / Test / Connect」按钮与最后一个 textarea 之间有 **1px 分隔线 + 32px 缓冲**
9. 短弹窗（如删除 provider 确认）→ 期望 **没有** 多余的分隔线（验证 primitive 没被污染）

## 决策日志

- **为什么不动 `SessionListItem.tsx:218`**：cell 内部 stack 语境不同
- **为什么不在 `DialogFooter` primitive 加 border**：短弹窗会被污染，调用方按需传 className
- **为什么 `PresetConnectDialog` 是唯一需要 anchor 的点**：在 `src/components/settings/` 范围内它是唯一 2xl 滚动结构 + 多按钮的 dialog

详细决策矩阵见 `docs/exec-plans/active/sidebar-list-spacing.md` § 6。
