### PR TITLE
perf(git): pause git status polling when page is hidden

### DIFF
--- a/src/hooks/useGitStatus.ts
+++ b/src/hooks/useGitStatus.ts
@@ -10,13 +10,15 @@ export function useGitStatus(cwd: string) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const cwdRef = useRef(cwd);
+  cwdRef.current = cwd;
 
   const fetchStatus = useCallback(async () => {
-    if (!cwd) return;
+    if (!cwdRef.current) return;
     setLoading(true);
     setError(null);
     try {
-      const res = await fetch(`/api/git/status?cwd=${encodeURIComponent(cwd)}`);
+      const res = await fetch(`/api/git/status?cwd=${encodeURIComponent(cwdRef.current)}`);
       if (!res.ok) {
         const data = await res.json();
         throw new Error(data.error || 'Failed to fetch status');
@@ -28,24 +30,47 @@ export function useGitStatus(cwd: string) {
     } finally {
       setLoading(false);
     }
-  }, [cwd]);
+  }, []);
 
-  // Initial fetch + polling
+  // Polling with visibility-aware pause/resume
   useEffect(() => {
     if (!cwd) {
       setStatus(null);
       return;
     }
 
+    // Initial fetch
     fetchStatus();
 
-    intervalRef.current = setInterval(fetchStatus, POLL_INTERVAL);
+    // Start polling only when page is visible
+    function startPolling() {
+      if (intervalRef.current) return;
+      intervalRef.current = setInterval(fetchStatus, POLL_INTERVAL);
+    }
 
-    const handleVisibility = () => {
-      if (document.visibilityState === 'visible') {
-        fetchStatus();
+    function stopPolling() {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
       }
-    };
+    }
+
+    function handleVisibility() {
+      if (document.visibilityState === 'visible') {
+        // Page became visible — fetch immediately and restart polling
+        fetchStatus();
+        startPolling();
+      } else {
+        // Page hidden — stop polling to save CPU/network
+        stopPolling();
+      }
+    }
+
+    // Start polling if page is currently visible
+    if (document.visibilityState === 'visible') {
+      startPolling();
+    }
+
     document.addEventListener('visibilitychange', handleVisibility);
 
     // Listen for manual refresh events (e.g. after commit from topbar)
@@ -53,7 +78,7 @@ export function useGitStatus(cwd: string) {
     window.addEventListener('git-refresh', handleRefreshEvent);
 
     return () => {
-      if (intervalRef.current) clearInterval(intervalRef.current);
+      stopPolling();
       document.removeEventListener('visibilitychange', handleVisibility);
       window.removeEventListener('git-refresh', handleRefreshEvent);
     };


### PR DESCRIPTION
## Problem

`useGitStatus` polls `GET /api/git/status` every 10 seconds via `setInterval`, unconditionally. Each poll spawns a `git status` subprocess on the server side — in large repos this takes 200–500ms. The polling continues even when:

- The page is hidden (user switched to another tab)
- The window is minimized
- The user is on the settings page where git status isn't displayed

Combined with the notification poll (5s interval), the app makes at least 1 HTTP request every 5 seconds even when completely idle.

## Fix

Implement visibility-aware pause/resume:

- **Page hidden** → stop the `setInterval` entirely. No polls, no HTTP requests, no subprocess spawns.
- **Page visible** → fetch immediately (to catch any changes that happened while hidden) and restart the interval.
- **Manual refresh** → the `git-refresh` custom event listener remains active regardless of visibility state.

This eliminates all background git polling when the app isn't being actively viewed, reducing both CPU (no subprocess spawns) and network overhead.
