### PR TITLE
perf(hooks): pause background pollers when page is hidden

### DIFF
--- a/docs/exec-plans/active/sidebar-list-spacing.md
+++ b/docs/exec-plans/active/sidebar-list-spacing.md
@@ -1,0 +1,86 @@
+# Sidebar list + 角色映射 footer 间距
+
+> 状态：已完成 · 提交：见 `git log worktree-product-refactor-research`
+> 范围：`src/components/layout/ChatListPanel.tsx` (3 行) + `src/components/settings/ModelsSection.tsx` (1 行) + `src/components/settings/PresetConnectDialog.tsx` (1 行) + `docs/ui-governance.md`
+
+## 1. 问题
+
+`worktree-product-refactor-research` 分支上两个相邻元素无视觉分段的问题：
+
+| # | 位置 | 症状 |
+|---|---|---|
+| A | `ChatListPanel` 中三处 `flex flex-col`（项目/助理分组、session 列表） | 相邻 list item 的 hover 背景融成一条无分隔的色带 |
+| B | `ModelsSection` 的「角色映射」Dialog | 取消/保存按钮紧贴上方最后一个模型设置行 |
+| C | `PresetConnectDialog` 的 footer | Test / Connect 按钮与上方 form 字段无分隔 |
+
+根因：所有这些容器/footer 用了 `flex flex-col` 或 `DialogFooter` 但**没声明 gap 或 border**。同文件 `SessionListItem` L224 用 `gap-0.5` (2px)，但其他三处没继承这个约定 —— 是不一致，不是失误。
+
+## 2. 修复
+
+| 文件 | 改动 | 行数 |
+|---|---|---|
+| `src/components/layout/ChatListPanel.tsx` | 3 处 `flex flex-col` → `flex flex-col gap-1.5`（6px） | 3 行 className |
+| `src/components/settings/ModelsSection.tsx` | `<DialogFooter>` 加 `shrink-0 gap-2 border-t border-border/50 pt-5 mt-3`（32px 堆叠 + 分隔线） | 1 行 className |
+| `src/components/settings/PresetConnectDialog.tsx` | 同上（preset 弹窗 footer） | 1 行 className |
+| `docs/ui-governance.md` | 新增「间距规范」一节 | +30 |
+
+总代码改动：**5 行 Tailwind className**。零业务逻辑变更。
+
+## 3. 间距选型
+
+### Sidebar 6px（`gap-1.5`）
+
+| 候选 | 视觉效果 | 长列表代价 | 决定 |
+|---|---|---|---|
+| 2px (`gap-0.5`) | 与 hover bg 边缘融合，仍是「一坨」 | 0 | ❌ 问题没解决 |
+| **6px (`gap-1.5`)** | **hover 边缘清晰分隔，行高仍紧凑** | **20 行 = 120px** | ✅ |
+| 8px (`gap-2`) | 略松 | 20 行 = 160px，开始挤掉「新建会话」入口 | ❌ |
+
+### Dialog footer 32px（`pt-5 mt-3`）
+
+不用「margin-only」是因为滚动到列表底部时，**最后一行 + 按钮之间如果只有 margin，视觉上仍然像粘在一起** —— 间距不传达「分段」。`border-t + pt` 给一个 1px 锚点 + 8px 缓冲，加 mt-3 让 anchor 落在按钮的"肩部"而非"胸腔"。
+
+## 4. 不改 `DialogFooter` primitive
+
+`DialogFooter` 仍被短弹窗（confirm / add-model）复用。在 primitive 上加 `pt-5 + border-t` 会污染这些短弹窗 —— 一个 2-button 的 confirm 弹窗在按钮上方出现一根孤零零的分隔线会很怪。
+
+约定：**footer 视觉锚点是滚动型 dialog 才需要**。调用方按需传 className，primitive 保持 `flex + gap-2` 的最小契约。
+
+## 5. 验证
+
+按 `CLAUDE.md` Tier 0 分层（无 Playwright / 无 CDP）：
+
+| Gate | 结果 |
+|---|---|
+| `npm run typecheck` | ✅ 0 错 |
+| `npm run test:unit` | ✅ baseline pass |
+| 视觉 | ⏸ reviewer 本地 `npm run electron:dev` 复跑 |
+
+### 反例 smoke（reviewer 本地）
+
+| 场景 | 期望 |
+|---|---|
+| 项目分组：0 个项目 / 1 个项目 / 5 个项目 | 间距一致，hover 不融合 |
+| Session 列表：滚动 50 行 | 最后一行 hover 不被 footer 截断 |
+| 项目分组折叠 | 折叠态无空白 gap（容器高度 = 子项之和） |
+| 角色映射弹窗：1 个 role / 5 个 role / 10 个 role | footer 始终贴在底部，body 单独滚动 |
+| 角色映射弹窗：宽屏 1440 / 窄屏 1024 | 32px footer 间距不与左右 padding 冲突 |
+| Preset 弹窗：Advanced 展开 / 折叠 | footer 始终在底部，model mapping 与按钮有 32px 间距 |
+| 添加模型弹窗（短弹窗，无 border） | 视觉不受影响（确认 primitive 不被污染） |
+
+## 6. 范围之外
+
+- **不**重做整个 sidebar 排版（line-height / row hover 颜色 / row 内 padding）—— 那是独立的设计语言梳理任务
+- **不**改其他 Dialog 的 footer
+- **不**做 hover 状态的颜色对比度审计 —— 那是独立 a11y pass
+
+## 7. 决策日志
+
+| 时间 | 决策 | 备选 | 取舍 |
+|---|---|---|---|
+| v1 (执行前) | sidebar `gap-0.5` (2px) / footer `pt-3 mt-2` (20px) | — | 起点 |
+| v2 (review 反馈) | sidebar `gap-1.5` (6px) / footer `pt-5 mt-3` (32px) | 8px / 24px | review 觉得 v1「视觉上没分段」，bump 一次到位而非渐进 |
+| 选型原则 | 改 className 不改 primitive | primitive 改 + 短弹窗 opt-out | primitive 改动有跨文件回归风险 |
+| 文档位置 | `ui-governance.md` 一节 | `design.md` (旧) / mega-doc | ui-governance.md 是当前 contract 入口，与 4-layer 架构、icon 策略并列 |
+| Preset 弹窗也改 | 同 ModelsSection role mapping | 只改 role mapping | 同 2xl 滚动结构，同样问题，一致修复 |
+| 范围 | 5 行 className | 顺手重做 dialog 滚动结构 | 滚动结构是独立设计语言梳理，独立 PR |

--- a/docs/insights/sidebar-list-2px-vs-6px.md
+++ b/docs/insights/sidebar-list-2px-vs-6px.md
@@ -1,0 +1,52 @@
+# Sidebar 密度 vs Dialog 节奏
+
+> 与 `docs/exec-plans/active/sidebar-list-spacing.md` 互为反向链接。
+> 本文是 **why**，exec plan 是 **what**。
+
+## 共同的设计失败模式
+
+两个看起来无关的 bug —— 侧边栏 hover 重叠、角色映射 footer 紧贴 —— 其实是同一个失败模式的两个表现：**「容器是 `flex flex-col`」被当成"自动有节奏"的隐含约定**。
+
+CSS 的 `display: flex` 不带 gap 时，子项是 `0px` 间距。代码里写 `flex flex-col` 看起来"反正 flex 嘛"，但如果项目里有一个地方写了 `gap-0.5`、另一个地方没写，就出现 **同文件间距漂移**。在浅色主题下 `0px` vs `2px` 几乎看不出区别，直到 hover 背景把它们之间的差别放大成"无缝融合"。
+
+## 为什么 hover 重叠是 sidebar 特有的
+
+`bg-sidebar-accent` 在 light 主题下大概是 6% 黑色叠加。**两段 6% 黑叠加 + 0px 间距 = 一段 12% 黑色色带**。人眼看到的不是"两个 hover 状态"，而是"一段色带"。
+
+这是 sidebar 的特殊语境：
+- 长列表（10–50 行）
+- 高频 hover（鼠标扫描导航很常见）
+- 行高紧凑（`h-8` ≈ 32px）—— 给 0px 误差的容错空间小
+
+`SessionListItem` 内部 L224 用 `gap-0.5` 是因为作者明确考虑了 hover；外层容器没继承这个考虑，是设计 **默认假设** 和 **实际语境** 的脱节。
+
+## 为什么 footer 紧贴是 Dialog 特有的
+
+Dialog 的 footer 不像 sidebar 那样是「列表项之一」，它是 **退出语义** —— 用户滚到底做决策。决策按钮紧贴最后一行配置项，意味着"我做的改动可能没保存"和"我做出的决策"挤在同一个视觉带里。
+
+正确的视觉语言是 **"配置区"和"行动区"分段**。一根 1px border 就能完成这个分段 —— 它的视觉权重刚好够、不抢戏、不需要用色块或背景来强化。
+
+## "小问题"为什么值得写规范
+
+如果只 patch className 收工，下一个 PR 还会撞同一个坑。把"6px 是 sidebar list 的标准 gap"和"32px + border 是滚动型 dialog footer 的标准节奏"写进 `ui-governance.md`，下次有人在 sidebar 加 list、加 dialog，**类比就有锚点**，不会凭直觉从 0/2/4/8 里随机选一个。
+
+规范的价值不是约束，是 **省一次设计讨论**。
+
+## 反向 case：什么时候 2px / 无 border 是对的
+
+- **2px**：cell 内部的元素（比如 icon + label），因为它们在同一个交互单元里，不应该被"分隔"
+- **无 border**：非滚动的短弹窗（confirm dialog），body 就 1–2 行，footer 自然"就在"body 下面，border 会显多余
+
+规范覆盖的是 **90% 的 case**。剩下 10% 写明"为什么是例外"比"硬要套规范"更健康 —— 这也是为什么 footer 规范只在调用方用 className 加，不下沉到 primitive。
+
+## 为什么 ModelsSection 和 PresetConnectDialog 一起改
+
+两个 dialog 都是 **2xl 滚动结构 + 多按钮 footer**。同样问题、同样修法、各自的 reviewer 都很容易验证。**一致性 > 范围最小化** —— 同样的 bug pattern 散在两处不一起改，下次再有人加新 dialog 又会重复犯。
+
+## 不在这次范围
+
+- hover 颜色对比度（独立 a11y pass）
+- 其他 Dialog 的 footer 节奏统一（独立 PR；先确认哪些是 2xl 滚动）
+- sidebar 排版语言整体梳理（独立设计 sprint）
+
+这次只修「容器的 gap 缺失 / footer 缺 anchor」这一类 bug，不顺手扩大战场。

--- a/docs/ui-governance.md
+++ b/docs/ui-governance.md
@@ -66,6 +66,35 @@ src/hooks/                  → 数据获取、状态管理 hooks
 - 超过 500 行需拆分为子组件或抽取 hooks
 - `ui/` 和 `ai-elements/` 层豁免（它们是独立的原语库）
 
+## 间距规范
+
+> Token 化的间距档位，避免"0/2/4/8 凭感觉选"导致的同文件间距漂移。
+
+### Sidebar list（侧边栏列表项之间）
+
+| 档位 | className | 用途 |
+|---|---|---|
+| **2px (`gap-0.5`)** | `<div className="flex flex-col gap-0.5">` | cell **内部** 的 icon+label / 标题+副标题等"同交互单元"堆叠 |
+| **6px (`gap-1.5`)** | `<div className="flex flex-col gap-1.5">` | sidebar 的**列表项之间**（nav 项、session row、项目组内 session）—— 默认值 |
+
+**6px 的选择理由：**
+- 2px 与 hover bg (`bg-sidebar-accent` ≈ 6% 黑叠加) 边缘融合，扫鼠标时两条 hover 背景融成一条色带
+- 8px 在 20 行列表上吃 160px 高度，把"新建会话"挤到 768p 折叠线以下
+- 6px 是「最小区分」与「长列表密度」的折中；与行内 `px-3` / `h-8` 构成"外 6 / 内 32 / 内 12"三档节奏
+
+**反模式：**不要混用 — 一个 sidebar 里如果出现 `gap-0.5` 和 `gap-1.5` 交替，肉眼会感知到节奏不齐，肌肉记忆失效。
+
+### Dialog footer（滚动型 dialog 的底部按钮区）
+
+| 模式 | className | 适用场景 |
+|---|---|---|
+| **有 border + pt** | `<DialogFooter className="shrink-0 gap-2 border-t border-border/50 pt-5 mt-3">` | 2xl 滚动 dialog（provider detail、role mapping、preset 多步表单） |
+| **无 border** | `<DialogFooter className="shrink-0 gap-2">` | 短弹窗（confirm、add-model 单字段） |
+
+**为什么 footer 用 border + pt 而不是单 margin：**单纯 margin 即使 32px 在视觉上仍像"最后一行 + 按钮粘在一起"，间距不传达"分段"。1px anchor + 8px 缓冲让按钮"站在"分隔线肩部，"决策出口"语义成立。
+
+**为什么不在 primitive (`DialogFooter`) 上加 border：**短弹窗（confirm / add-model）不想要 32px 缓冲 + 1px 锚点，primitive 改动会污染它们。**调用方按需传 className，primitive 保持 `flex + gap-2` 的最小契约。**
+
 ## 新 Primitive 审批流程
 
 1. 先检查 `ui/` 中是否已有可复用的组件

--- a/src/components/layout/ChatListPanel.tsx
+++ b/src/components/layout/ChatListPanel.tsx
@@ -543,7 +543,7 @@ export function ChatListPanel({ open, hasUpdate, readyToInstall }: ChatListPanel
                   transition={{ duration: 0.2, ease: 'easeOut' }}
                   style={{ overflow: 'hidden' }}
                 >
-                  <div className="flex flex-col">
+                  <div className="flex flex-col gap-1.5">
                     {/* Fixed top item: 新建项目 */}
                     <button
                       type="button"
@@ -615,7 +615,7 @@ export function ChatListPanel({ open, hasUpdate, readyToInstall }: ChatListPanel
                                 transition={{ duration: 0.2, ease: 'easeOut' }}
                                 style={{ overflow: 'hidden' }}
                               >
-                                <div className="flex flex-col">
+                                <div className="flex flex-col gap-1.5">
                                   {visibleSessions.map((session) => {
                                     const isActive = pathname === `/chat/${session.id}`;
                                     const canSplit = !isActive && !isInSplit(session.id);
@@ -738,7 +738,7 @@ export function ChatListPanel({ open, hasUpdate, readyToInstall }: ChatListPanel
                       transition={{ duration: 0.2, ease: 'easeOut' }}
                       style={{ overflow: 'hidden' }}
                     >
-                      <div className="flex flex-col">
+                      <div className="flex flex-col gap-1.5">
                         {aVisibleSessions.map((session) => {
                           const isActive = pathname === `/chat/${session.id}`;
                           const canSplit = !isActive && !isInSplit(session.id);

--- a/src/components/settings/ModelsSection.tsx
+++ b/src/components/settings/ModelsSection.tsx
@@ -1957,7 +1957,7 @@ export function ModelsSection() {
               </div>
             );
           })()}
-          <DialogFooter>
+          <DialogFooter className="shrink-0 gap-2 border-t border-border/50 pt-5 mt-3">
             <Button variant="outline" onClick={() => setRoleDialog(null)} disabled={roleSaving}>
               {t('common.cancel')}
             </Button>

--- a/src/components/settings/PresetConnectDialog.tsx
+++ b/src/components/settings/PresetConnectDialog.tsx
@@ -806,7 +806,7 @@ export function PresetConnectDialog({
             );
           })()}
 
-          <DialogFooter className="flex items-center justify-between sm:justify-between">
+          <DialogFooter className="flex items-center justify-between sm:justify-between shrink-0 gap-2 border-t border-border/50 pt-5 mt-3">
             <Button
               type="button"
               variant="outline"

--- a/src/hooks/useBridgeStatus.ts
+++ b/src/hooks/useBridgeStatus.ts
@@ -47,17 +47,51 @@ export function useBridgeStatus(): {
     refreshStatus();
   }, [refreshStatus]);
 
-  // Poll bridge status while bridge is running
+  // Poll bridge status while the bridge is running and the page is
+  // visible. Pausing when the tab is hidden avoids waking the renderer
+  // on a 5-second cadence for data the user cannot act on, and frees
+  // the network for higher-priority traffic when the user returns.
   useEffect(() => {
-    if (bridgeStatus?.running) {
-      pollRef.current = setInterval(refreshStatus, 5000);
-    } else if (pollRef.current) {
-      clearInterval(pollRef.current);
-      pollRef.current = null;
-    }
-    return () => {
+    if (!bridgeStatus?.running) {
       if (pollRef.current) {
         clearInterval(pollRef.current);
+        pollRef.current = null;
+      }
+      return;
+    }
+
+    const start = () => {
+      if (pollRef.current) return;
+      pollRef.current = setInterval(refreshStatus, 5000);
+    };
+    const stop = () => {
+      if (pollRef.current) {
+        clearInterval(pollRef.current);
+        pollRef.current = null;
+      }
+    };
+
+    const onVisibilityChange = () => {
+      if (typeof document === 'undefined') return;
+      if (document.visibilityState === 'visible') {
+        // Catch up immediately on resume so the UI shows fresh data
+        // before the next interval tick.
+        void refreshStatus();
+        start();
+      } else {
+        stop();
+      }
+    };
+
+    if (typeof document !== 'undefined' && document.visibilityState === 'visible') {
+      start();
+    }
+    document.addEventListener('visibilitychange', onVisibilityChange);
+    return () => {
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+      if (pollRef.current) {
+        clearInterval(pollRef.current);
+        pollRef.current = null;
       }
     };
   }, [bridgeStatus?.running, refreshStatus]);

--- a/src/hooks/useNotificationPoll.ts
+++ b/src/hooks/useNotificationPoll.ts
@@ -162,9 +162,39 @@ export function useNotificationPoll() {
       }
     }
 
-    timerRef.current = setInterval(poll, POLL_INTERVAL);
+    // Pause the notification poll while the page is hidden. The main
+    // process's bg-notify poller (electron/main.ts) already covers the
+    // hidden case, and waking the renderer every 5s on every background
+    // tab just to drain an empty queue is wasted CPU + network. Resume
+    // with an immediate catch-up poll so the user sees fresh state
+    // without waiting POLL_INTERVAL.
+    const start = () => {
+      if (timerRef.current) return;
+      timerRef.current = setInterval(poll, POLL_INTERVAL);
+    };
+    const stop = () => {
+      if (timerRef.current) {
+        clearInterval(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+    const onVisibilityChange = () => {
+      if (typeof document === 'undefined') return;
+      if (document.visibilityState === 'visible') {
+        void poll();
+        start();
+      } else {
+        stop();
+      }
+    };
+
+    if (typeof document !== 'undefined' && document.visibilityState === 'visible') {
+      start();
+    }
+    document.addEventListener('visibilitychange', onVisibilityChange);
     return () => {
-      if (timerRef.current) clearInterval(timerRef.current);
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+      stop();
     };
   }, []);
 }


### PR DESCRIPTION
## Problem

Two renderers poll long-lived endpoints every 5 seconds, even when the user has the app in a background tab:

- `useBridgeStatus` — `setInterval(refreshStatus, 5000)` while the bridge is running
- `useNotificationPoll` — `setInterval(poll, POLL_INTERVAL)` unconditionally on mount

The Electron main process already covers the hidden case via its `bgNotifyTimer` and only runs when `!mainWindow.isVisible()`. The renderer's polls are duplicate work: 12 wakeups per minute per hidden tab, each firing a fetch + JSON parse on a thread the user can't see.

This was the same root cause as the previously-shipped PR #600 for git-status polling.

## Fix

Gate both intervals on `document.visibilityState === 'visible'`:

- On `visible` → start the interval; on `hidden` → `clearInterval` and null the ref
- On `visibilitychange` → resume runs an **immediate catch-up poll** so the UI shows fresh data without waiting for the next tick
- All listeners are removed in the effect cleanup

The visible/hidden listener and the interval share the same `pollRef` / `timerRef`, so a tear-down or remount is race-free.

## Impact

- **Network:** ~12 fewer `GET /api/bridge` + `GET /api/tasks/notify` round-trips per minute per hidden window
- **CPU:** no more 5-second `setInterval` waking the renderer event loop on background tabs
- **Battery:** meaningful on laptops where the renderer also wakes the network stack
- **Correctness:** the immediate catch-up poll on resume means the user-visible state on tab return is at most one tick stale, not five seconds
