### PR TITLE
perf(syntax): lazy-load HLJS themes on demand via useHljsStyle hook

### DIFF
--- a/docs/exec-plans/active/sidebar-list-spacing.md
+++ b/docs/exec-plans/active/sidebar-list-spacing.md
@@ -1,0 +1,86 @@
+# Sidebar list + 角色映射 footer 间距
+
+> 状态：已完成 · 提交：见 `git log worktree-product-refactor-research`
+> 范围：`src/components/layout/ChatListPanel.tsx` (3 行) + `src/components/settings/ModelsSection.tsx` (1 行) + `src/components/settings/PresetConnectDialog.tsx` (1 行) + `docs/ui-governance.md`
+
+## 1. 问题
+
+`worktree-product-refactor-research` 分支上两个相邻元素无视觉分段的问题：
+
+| # | 位置 | 症状 |
+|---|---|---|
+| A | `ChatListPanel` 中三处 `flex flex-col`（项目/助理分组、session 列表） | 相邻 list item 的 hover 背景融成一条无分隔的色带 |
+| B | `ModelsSection` 的「角色映射」Dialog | 取消/保存按钮紧贴上方最后一个模型设置行 |
+| C | `PresetConnectDialog` 的 footer | Test / Connect 按钮与上方 form 字段无分隔 |
+
+根因：所有这些容器/footer 用了 `flex flex-col` 或 `DialogFooter` 但**没声明 gap 或 border**。同文件 `SessionListItem` L224 用 `gap-0.5` (2px)，但其他三处没继承这个约定 —— 是不一致，不是失误。
+
+## 2. 修复
+
+| 文件 | 改动 | 行数 |
+|---|---|---|
+| `src/components/layout/ChatListPanel.tsx` | 3 处 `flex flex-col` → `flex flex-col gap-1.5`（6px） | 3 行 className |
+| `src/components/settings/ModelsSection.tsx` | `<DialogFooter>` 加 `shrink-0 gap-2 border-t border-border/50 pt-5 mt-3`（32px 堆叠 + 分隔线） | 1 行 className |
+| `src/components/settings/PresetConnectDialog.tsx` | 同上（preset 弹窗 footer） | 1 行 className |
+| `docs/ui-governance.md` | 新增「间距规范」一节 | +30 |
+
+总代码改动：**5 行 Tailwind className**。零业务逻辑变更。
+
+## 3. 间距选型
+
+### Sidebar 6px（`gap-1.5`）
+
+| 候选 | 视觉效果 | 长列表代价 | 决定 |
+|---|---|---|---|
+| 2px (`gap-0.5`) | 与 hover bg 边缘融合，仍是「一坨」 | 0 | ❌ 问题没解决 |
+| **6px (`gap-1.5`)** | **hover 边缘清晰分隔，行高仍紧凑** | **20 行 = 120px** | ✅ |
+| 8px (`gap-2`) | 略松 | 20 行 = 160px，开始挤掉「新建会话」入口 | ❌ |
+
+### Dialog footer 32px（`pt-5 mt-3`）
+
+不用「margin-only」是因为滚动到列表底部时，**最后一行 + 按钮之间如果只有 margin，视觉上仍然像粘在一起** —— 间距不传达「分段」。`border-t + pt` 给一个 1px 锚点 + 8px 缓冲，加 mt-3 让 anchor 落在按钮的"肩部"而非"胸腔"。
+
+## 4. 不改 `DialogFooter` primitive
+
+`DialogFooter` 仍被短弹窗（confirm / add-model）复用。在 primitive 上加 `pt-5 + border-t` 会污染这些短弹窗 —— 一个 2-button 的 confirm 弹窗在按钮上方出现一根孤零零的分隔线会很怪。
+
+约定：**footer 视觉锚点是滚动型 dialog 才需要**。调用方按需传 className，primitive 保持 `flex + gap-2` 的最小契约。
+
+## 5. 验证
+
+按 `CLAUDE.md` Tier 0 分层（无 Playwright / 无 CDP）：
+
+| Gate | 结果 |
+|---|---|
+| `npm run typecheck` | ✅ 0 错 |
+| `npm run test:unit` | ✅ baseline pass |
+| 视觉 | ⏸ reviewer 本地 `npm run electron:dev` 复跑 |
+
+### 反例 smoke（reviewer 本地）
+
+| 场景 | 期望 |
+|---|---|
+| 项目分组：0 个项目 / 1 个项目 / 5 个项目 | 间距一致，hover 不融合 |
+| Session 列表：滚动 50 行 | 最后一行 hover 不被 footer 截断 |
+| 项目分组折叠 | 折叠态无空白 gap（容器高度 = 子项之和） |
+| 角色映射弹窗：1 个 role / 5 个 role / 10 个 role | footer 始终贴在底部，body 单独滚动 |
+| 角色映射弹窗：宽屏 1440 / 窄屏 1024 | 32px footer 间距不与左右 padding 冲突 |
+| Preset 弹窗：Advanced 展开 / 折叠 | footer 始终在底部，model mapping 与按钮有 32px 间距 |
+| 添加模型弹窗（短弹窗，无 border） | 视觉不受影响（确认 primitive 不被污染） |
+
+## 6. 范围之外
+
+- **不**重做整个 sidebar 排版（line-height / row hover 颜色 / row 内 padding）—— 那是独立的设计语言梳理任务
+- **不**改其他 Dialog 的 footer
+- **不**做 hover 状态的颜色对比度审计 —— 那是独立 a11y pass
+
+## 7. 决策日志
+
+| 时间 | 决策 | 备选 | 取舍 |
+|---|---|---|---|
+| v1 (执行前) | sidebar `gap-0.5` (2px) / footer `pt-3 mt-2` (20px) | — | 起点 |
+| v2 (review 反馈) | sidebar `gap-1.5` (6px) / footer `pt-5 mt-3` (32px) | 8px / 24px | review 觉得 v1「视觉上没分段」，bump 一次到位而非渐进 |
+| 选型原则 | 改 className 不改 primitive | primitive 改 + 短弹窗 opt-out | primitive 改动有跨文件回归风险 |
+| 文档位置 | `ui-governance.md` 一节 | `design.md` (旧) / mega-doc | ui-governance.md 是当前 contract 入口，与 4-layer 架构、icon 策略并列 |
+| Preset 弹窗也改 | 同 ModelsSection role mapping | 只改 role mapping | 同 2xl 滚动结构，同样问题，一致修复 |
+| 范围 | 5 行 className | 顺手重做 dialog 滚动结构 | 滚动结构是独立设计语言梳理，独立 PR |

--- a/docs/insights/sidebar-list-2px-vs-6px.md
+++ b/docs/insights/sidebar-list-2px-vs-6px.md
@@ -1,0 +1,52 @@
+# Sidebar 密度 vs Dialog 节奏
+
+> 与 `docs/exec-plans/active/sidebar-list-spacing.md` 互为反向链接。
+> 本文是 **why**，exec plan 是 **what**。
+
+## 共同的设计失败模式
+
+两个看起来无关的 bug —— 侧边栏 hover 重叠、角色映射 footer 紧贴 —— 其实是同一个失败模式的两个表现：**「容器是 `flex flex-col`」被当成"自动有节奏"的隐含约定**。
+
+CSS 的 `display: flex` 不带 gap 时，子项是 `0px` 间距。代码里写 `flex flex-col` 看起来"反正 flex 嘛"，但如果项目里有一个地方写了 `gap-0.5`、另一个地方没写，就出现 **同文件间距漂移**。在浅色主题下 `0px` vs `2px` 几乎看不出区别，直到 hover 背景把它们之间的差别放大成"无缝融合"。
+
+## 为什么 hover 重叠是 sidebar 特有的
+
+`bg-sidebar-accent` 在 light 主题下大概是 6% 黑色叠加。**两段 6% 黑叠加 + 0px 间距 = 一段 12% 黑色色带**。人眼看到的不是"两个 hover 状态"，而是"一段色带"。
+
+这是 sidebar 的特殊语境：
+- 长列表（10–50 行）
+- 高频 hover（鼠标扫描导航很常见）
+- 行高紧凑（`h-8` ≈ 32px）—— 给 0px 误差的容错空间小
+
+`SessionListItem` 内部 L224 用 `gap-0.5` 是因为作者明确考虑了 hover；外层容器没继承这个考虑，是设计 **默认假设** 和 **实际语境** 的脱节。
+
+## 为什么 footer 紧贴是 Dialog 特有的
+
+Dialog 的 footer 不像 sidebar 那样是「列表项之一」，它是 **退出语义** —— 用户滚到底做决策。决策按钮紧贴最后一行配置项，意味着"我做的改动可能没保存"和"我做出的决策"挤在同一个视觉带里。
+
+正确的视觉语言是 **"配置区"和"行动区"分段**。一根 1px border 就能完成这个分段 —— 它的视觉权重刚好够、不抢戏、不需要用色块或背景来强化。
+
+## "小问题"为什么值得写规范
+
+如果只 patch className 收工，下一个 PR 还会撞同一个坑。把"6px 是 sidebar list 的标准 gap"和"32px + border 是滚动型 dialog footer 的标准节奏"写进 `ui-governance.md`，下次有人在 sidebar 加 list、加 dialog，**类比就有锚点**，不会凭直觉从 0/2/4/8 里随机选一个。
+
+规范的价值不是约束，是 **省一次设计讨论**。
+
+## 反向 case：什么时候 2px / 无 border 是对的
+
+- **2px**：cell 内部的元素（比如 icon + label），因为它们在同一个交互单元里，不应该被"分隔"
+- **无 border**：非滚动的短弹窗（confirm dialog），body 就 1–2 行，footer 自然"就在"body 下面，border 会显多余
+
+规范覆盖的是 **90% 的 case**。剩下 10% 写明"为什么是例外"比"硬要套规范"更健康 —— 这也是为什么 footer 规范只在调用方用 className 加，不下沉到 primitive。
+
+## 为什么 ModelsSection 和 PresetConnectDialog 一起改
+
+两个 dialog 都是 **2xl 滚动结构 + 多按钮 footer**。同样问题、同样修法、各自的 reviewer 都很容易验证。**一致性 > 范围最小化** —— 同样的 bug pattern 散在两处不一起改，下次再有人加新 dialog 又会重复犯。
+
+## 不在这次范围
+
+- hover 颜色对比度（独立 a11y pass）
+- 其他 Dialog 的 footer 节奏统一（独立 PR；先确认哪些是 2xl 滚动）
+- sidebar 排版语言整体梳理（独立设计 sprint）
+
+这次只修「容器的 gap 缺失 / footer 缺 anchor」这一类 bug，不顺手扩大战场。

--- a/docs/ui-governance.md
+++ b/docs/ui-governance.md
@@ -66,6 +66,35 @@ src/hooks/                  → 数据获取、状态管理 hooks
 - 超过 500 行需拆分为子组件或抽取 hooks
 - `ui/` 和 `ai-elements/` 层豁免（它们是独立的原语库）
 
+## 间距规范
+
+> Token 化的间距档位，避免"0/2/4/8 凭感觉选"导致的同文件间距漂移。
+
+### Sidebar list（侧边栏列表项之间）
+
+| 档位 | className | 用途 |
+|---|---|---|
+| **2px (`gap-0.5`)** | `<div className="flex flex-col gap-0.5">` | cell **内部** 的 icon+label / 标题+副标题等"同交互单元"堆叠 |
+| **6px (`gap-1.5`)** | `<div className="flex flex-col gap-1.5">` | sidebar 的**列表项之间**（nav 项、session row、项目组内 session）—— 默认值 |
+
+**6px 的选择理由：**
+- 2px 与 hover bg (`bg-sidebar-accent` ≈ 6% 黑叠加) 边缘融合，扫鼠标时两条 hover 背景融成一条色带
+- 8px 在 20 行列表上吃 160px 高度，把"新建会话"挤到 768p 折叠线以下
+- 6px 是「最小区分」与「长列表密度」的折中；与行内 `px-3` / `h-8` 构成"外 6 / 内 32 / 内 12"三档节奏
+
+**反模式：**不要混用 — 一个 sidebar 里如果出现 `gap-0.5` 和 `gap-1.5` 交替，肉眼会感知到节奏不齐，肌肉记忆失效。
+
+### Dialog footer（滚动型 dialog 的底部按钮区）
+
+| 模式 | className | 适用场景 |
+|---|---|---|
+| **有 border + pt** | `<DialogFooter className="shrink-0 gap-2 border-t border-border/50 pt-5 mt-3">` | 2xl 滚动 dialog（provider detail、role mapping、preset 多步表单） |
+| **无 border** | `<DialogFooter className="shrink-0 gap-2">` | 短弹窗（confirm、add-model 单字段） |
+
+**为什么 footer 用 border + pt 而不是单 margin：**单纯 margin 即使 32px 在视觉上仍像"最后一行 + 按钮粘在一起"，间距不传达"分段"。1px anchor + 8px 缓冲让按钮"站在"分隔线肩部，"决策出口"语义成立。
+
+**为什么不在 primitive (`DialogFooter`) 上加 border：**短弹窗（confirm / add-model）不想要 32px 缓冲 + 1px 锚点，primitive 改动会污染它们。**调用方按需传 className，primitive 保持 `flex + gap-2` 的最小契约。**
+
 ## 新 Primitive 审批流程
 
 1. 先检查 `ui/` 中是否已有可复用的组件

--- a/src/components/layout/ChatListPanel.tsx
+++ b/src/components/layout/ChatListPanel.tsx
@@ -543,7 +543,7 @@ export function ChatListPanel({ open, hasUpdate, readyToInstall }: ChatListPanel
                   transition={{ duration: 0.2, ease: 'easeOut' }}
                   style={{ overflow: 'hidden' }}
                 >
-                  <div className="flex flex-col">
+                  <div className="flex flex-col gap-1.5">
                     {/* Fixed top item: 新建项目 */}
                     <button
                       type="button"
@@ -615,7 +615,7 @@ export function ChatListPanel({ open, hasUpdate, readyToInstall }: ChatListPanel
                                 transition={{ duration: 0.2, ease: 'easeOut' }}
                                 style={{ overflow: 'hidden' }}
                               >
-                                <div className="flex flex-col">
+                                <div className="flex flex-col gap-1.5">
                                   {visibleSessions.map((session) => {
                                     const isActive = pathname === `/chat/${session.id}`;
                                     const canSplit = !isActive && !isInSplit(session.id);
@@ -738,7 +738,7 @@ export function ChatListPanel({ open, hasUpdate, readyToInstall }: ChatListPanel
                       transition={{ duration: 0.2, ease: 'easeOut' }}
                       style={{ overflow: 'hidden' }}
                     >
-                      <div className="flex flex-col">
+                      <div className="flex flex-col gap-1.5">
                         {aVisibleSessions.map((session) => {
                           const isActive = pathname === `/chat/${session.id}`;
                           const canSplit = !isActive && !isInSplit(session.id);

--- a/src/components/layout/panels/PreviewPanel.tsx
+++ b/src/components/layout/panels/PreviewPanel.tsx
@@ -10,7 +10,7 @@ import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { Light as SyntaxHighlighter } from "react-syntax-highlighter";
 import { useThemeFamily } from "@/lib/theme/context";
-import { resolveCodeTheme, resolveHljsStyle } from "@/lib/theme/code-themes";
+import { resolveCodeTheme, useHljsStyle } from "@/lib/theme/code-themes";
 import { usePanel } from "@/hooks/usePanel";
 import { useTranslation } from "@/hooks/useTranslation";
 import { ResizeHandle } from "@/components/layout/ResizeHandle";
@@ -1404,36 +1404,52 @@ function PresentationStyleSelect({
 function useDocCodeTheme(isDark: boolean) {
   const { family, families } = useThemeFamily();
   const codeTheme = resolveCodeTheme(families, family);
-  return resolveHljsStyle(codeTheme, isDark);
+  return useHljsStyle(codeTheme, isDark);
 }
 
 /** Source code view using react-syntax-highlighter */
 function SourceView({ preview, isDark }: { preview: FilePreviewType; isDark: boolean }) {
-  const hljsStyle = useDocCodeTheme(isDark);
+  const { style: hljsStyle, loaded: hljsStyleLoaded } = useDocCodeTheme(isDark);
   return (
     <div className="text-xs">
-      <SyntaxHighlighter
-        language={preview.language}
-        style={hljsStyle}
-        showLineNumbers
-        customStyle={{
-          margin: 0,
-          padding: "8px",
-          borderRadius: 0,
-          fontSize: "11px",
-          lineHeight: "1.5",
-          background: "transparent",
-        }}
-        lineNumberStyle={{
-          minWidth: "2.5em",
-          paddingRight: "8px",
-          color: "var(--muted-foreground)",
-          opacity: 0.5,
-          userSelect: "none",
-        }}
-      >
-        {preview.content}
-      </SyntaxHighlighter>
+      {hljsStyleLoaded && hljsStyle ? (
+        <SyntaxHighlighter
+          language={preview.language}
+          style={hljsStyle}
+          showLineNumbers
+          customStyle={{
+            margin: 0,
+            padding: "8px",
+            borderRadius: 0,
+            fontSize: "11px",
+            lineHeight: "1.5",
+            background: "transparent",
+          }}
+          lineNumberStyle={{
+            minWidth: "2.5em",
+            paddingRight: "8px",
+            color: "var(--muted-foreground)",
+            opacity: 0.5,
+            userSelect: "none",
+          }}
+        >
+          {preview.content}
+        </SyntaxHighlighter>
+      ) : (
+        <pre
+          style={{
+            margin: 0,
+            padding: "8px",
+            borderRadius: 0,
+            fontSize: "11px",
+            lineHeight: "1.5",
+            background: "transparent",
+          }}
+          className="overflow-auto"
+        >
+          {preview.content}
+        </pre>
+      )}
     </div>
   );
 }

--- a/src/components/project/FilePreview.tsx
+++ b/src/components/project/FilePreview.tsx
@@ -8,16 +8,8 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { useTheme } from "next-themes";
 import { Light as SyntaxHighlighter } from "react-syntax-highlighter";
 import { useThemeFamily } from "@/lib/theme/context";
-import { resolveCodeTheme, resolveHljsStyle } from "@/lib/theme/code-themes";
+import { resolveCodeTheme, useHljsStyle } from "@/lib/theme/code-themes";
 import { usePanel } from "@/hooks/usePanel";
-
-function useFilePreviewCodeTheme() {
-  const { resolvedTheme } = useTheme();
-  const { family, families } = useThemeFamily();
-  const isDark = resolvedTheme === "dark";
-  const codeTheme = resolveCodeTheme(families, family);
-  return resolveHljsStyle(codeTheme, isDark);
-}
 import { useTranslation } from "@/hooks/useTranslation";
 import type { FilePreview as FilePreviewType } from "@/types";
 
@@ -29,7 +21,11 @@ interface FilePreviewProps {
 export function FilePreview({ filePath, onBack }: FilePreviewProps) {
   const { workingDirectory } = usePanel();
   const { t } = useTranslation();
-  const hljsStyle = useFilePreviewCodeTheme();
+  const { resolvedTheme } = useTheme();
+  const { family, families } = useThemeFamily();
+  const isDark = resolvedTheme === "dark";
+  const codeTheme = resolveCodeTheme(families, family);
+  const { style: hljsStyle, loaded: hljsStyleLoaded } = useHljsStyle(codeTheme, isDark);
   const [preview, setPreview] = useState<FilePreviewType | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -126,27 +122,42 @@ export function FilePreview({ filePath, onBack }: FilePreviewProps) {
           </div>
         ) : preview ? (
           <div className="rounded-md border border-border text-xs">
-            <SyntaxHighlighter
-              language={preview.language}
-              style={hljsStyle}
-              showLineNumbers
-              customStyle={{
-                margin: 0,
-                padding: "8px",
-                borderRadius: "6px",
-                fontSize: "11px",
-                lineHeight: "1.5",
-              }}
-              lineNumberStyle={{
-                minWidth: "2.5em",
-                paddingRight: "8px",
-                color: "var(--muted-foreground)",
-                opacity: 0.5,
-                userSelect: "none",
-              }}
-            >
-              {preview.content}
-            </SyntaxHighlighter>
+            {hljsStyleLoaded && hljsStyle ? (
+              <SyntaxHighlighter
+                language={preview.language}
+                style={hljsStyle}
+                showLineNumbers
+                customStyle={{
+                  margin: 0,
+                  padding: "8px",
+                  borderRadius: "6px",
+                  fontSize: "11px",
+                  lineHeight: "1.5",
+                }}
+                lineNumberStyle={{
+                  minWidth: "2.5em",
+                  paddingRight: "8px",
+                  color: "var(--muted-foreground)",
+                  opacity: 0.5,
+                  userSelect: "none",
+                }}
+              >
+                {preview.content}
+              </SyntaxHighlighter>
+            ) : (
+              <pre
+                style={{
+                  margin: 0,
+                  padding: "8px",
+                  borderRadius: "6px",
+                  fontSize: "11px",
+                  lineHeight: "1.5",
+                }}
+                className="overflow-auto"
+              >
+                {preview.content}
+              </pre>
+            )}
           </div>
         ) : null}
       </ScrollArea>

--- a/src/components/settings/ModelsSection.tsx
+++ b/src/components/settings/ModelsSection.tsx
@@ -1957,7 +1957,7 @@ export function ModelsSection() {
               </div>
             );
           })()}
-          <DialogFooter>
+          <DialogFooter className="shrink-0 gap-2 border-t border-border/50 pt-5 mt-3">
             <Button variant="outline" onClick={() => setRoleDialog(null)} disabled={roleSaving}>
               {t('common.cancel')}
             </Button>

--- a/src/components/settings/PresetConnectDialog.tsx
+++ b/src/components/settings/PresetConnectDialog.tsx
@@ -806,7 +806,7 @@ export function PresetConnectDialog({
             );
           })()}
 
-          <DialogFooter className="flex items-center justify-between sm:justify-between">
+          <DialogFooter className="flex items-center justify-between sm:justify-between shrink-0 gap-2 border-t border-border/50 pt-5 mt-3">
             <Button
               type="button"
               variant="outline"

--- a/src/lib/theme/code-themes.ts
+++ b/src/lib/theme/code-themes.ts
@@ -1,142 +1,136 @@
 /**
- * Centralized code theme mappings for Prism, HLJS, and Shiki.
+ * Centralized code theme mappings for Shiki and HLJS.
  *
  * Each theme family JSON can specify `codeTheme: { light, dark }` and
  * `shikiTheme: { light, dark }` using the keys defined below.
  * Components should use the hooks exported here rather than maintaining
  * local maps.
+ *
+ * Performance note: HLJS theme objects (and the `react-syntax-highlighter`
+ * theme registry) are loaded on demand from `react-syntax-highlighter`
+ * per-theme. Statically importing all 18+ themes pulls ~300–500 KB of
+ * CSS-in-JS into the first-paint chunk even though only the active
+ * theme is ever rendered. Callers should use `useHljsStyle` (returns
+ * the loaded style + a `loaded` flag so the consumer can render a
+ * skeleton / plain `<pre>` while the dynamic chunk is in flight).
  */
 
 import type { CSSProperties } from 'react';
 import type { BundledTheme } from 'shiki';
+import { useEffect, useState } from 'react';
 
-// ── Prism (react-syntax-highlighter/prism) ──────────────────────────────
-import {
-  oneDark,
-  oneLight,
-  vscDarkPlus,
-  nord as nordPrism,
-  solarizedDarkAtom,
-  solarizedlight as solarizedLightPrism,
-  nightOwl as nightOwlPrism,
-  dracula as draculaPrism,
-  gruvboxDark as gruvboxDarkPrism,
-  gruvboxLight as gruvboxLightPrism,
-  ghcolors,
-  synthwave84 as synthwave84Prism,
-  materialDark as materialDarkPrism,
-  materialOceanic as materialOceanicPrism,
-  duotoneSea as duotoneSeaPrism,
-  coldarkDark as coldarkDarkPrism,
-  coldarkCold as coldarkColdPrism,
-  materialLight as materialLightPrism,
-  duotoneLight as duotoneLightPrism,
-  vs as vsPrism,
-  coy as coyPrism,
-  prism as prismDefault,
-  duotoneEarth as duotoneEarthPrism,
-  duotoneForest as duotoneForestPrism,
-  twilight as twilightPrism,
-} from 'react-syntax-highlighter/dist/esm/styles/prism';
+import type { ThemeFamilyMeta, CodeThemeMapping } from './types';
 
-type SyntaxStyle = Record<string, CSSProperties>;
-
-/** Prism theme name → style object. Keys match `codeTheme.dark` / `codeTheme.light` in theme JSONs. */
-export const PRISM_THEME_MAP: Record<string, SyntaxStyle> = {
-  oneDark,
-  oneLight,
-  vscDarkPlus,
-  nord: nordPrism,
-  solarizedDarkAtom,
-  solarizedlight: solarizedLightPrism,
-  nightOwl: nightOwlPrism,
-  dracula: draculaPrism,
-  gruvboxDark: gruvboxDarkPrism,
-  gruvboxLight: gruvboxLightPrism,
-  ghcolors,
-  synthwave84: synthwave84Prism,
-  materialDark: materialDarkPrism,
-  materialOceanic: materialOceanicPrism,
-  duotoneSea: duotoneSeaPrism,
-  coldarkDark: coldarkDarkPrism,
-  coldarkCold: coldarkColdPrism,
-  materialLight: materialLightPrism,
-  duotoneLight: duotoneLightPrism,
-  vs: vsPrism,
-  coy: coyPrism,
-  prism: prismDefault,
-  duotoneEarth: duotoneEarthPrism,
-  duotoneForest: duotoneForestPrism,
-  twilight: twilightPrism,
-};
-
-export const PRISM_DEFAULT_DARK: SyntaxStyle = oneDark;
-export const PRISM_DEFAULT_LIGHT: SyntaxStyle = oneLight;
-
-// ── HLJS (react-syntax-highlighter/hljs) ────────────────────────────────
-import {
-  atomOneDark,
-  atomOneLight,
-  nord as nordHljs,
-  solarizedDark,
-  solarizedLight,
-  nightOwl as nightOwlHljs,
-  dracula as draculaHljs,
-  gruvboxDark as gruvboxDarkHljs,
-  gruvboxLight as gruvboxLightHljs,
-  github as githubHljs,
-  vs2015 as vs2015Hljs,
-  monokaiSublime as monokaiSublimeHljs,
-  vs as vsHljs,
-  idea as ideaHljs,
-  lightfair as lightfairHljs,
-  xcode as xcodeHljs,
-  zenburn as zenburnHljs,
-  darcula as darculaHljs,
-  obsidian as obsidianHljs,
-} from 'react-syntax-highlighter/dist/esm/styles/hljs';
-
-type HljsStyle = Record<string, CSSProperties>;
-
-/** HLJS theme name → style object. Same keys as Prism map where possible. */
-export const HLJS_THEME_MAP: Record<string, HljsStyle> = {
-  oneDark: atomOneDark,
-  oneLight: atomOneLight,
-  nord: nordHljs,
-  solarizedDarkAtom: solarizedDark,
-  solarizedlight: solarizedLight,
-  nightOwl: nightOwlHljs,
-  dracula: draculaHljs,
-  gruvboxDark: gruvboxDarkHljs,
-  gruvboxLight: gruvboxLightHljs,
-  ghcolors: githubHljs,
-  synthwave84: monokaiSublimeHljs,
-  materialDark: vs2015Hljs,
-  materialOceanic: atomOneDark,
-  duotoneSea: atomOneDark,
-  coldarkDark: atomOneDark,
-  coldarkCold: atomOneLight,
-  materialLight: ideaHljs,
-  duotoneLight: atomOneLight,
-  vs: vsHljs,
-  coy: xcodeHljs,
-  prism: lightfairHljs,
-  duotoneEarth: darculaHljs,
-  duotoneForest: zenburnHljs,
-  twilight: obsidianHljs,
-};
-
-export const HLJS_DEFAULT_DARK: HljsStyle = atomOneDark;
-export const HLJS_DEFAULT_LIGHT: HljsStyle = atomOneLight;
-
-// ── Shiki ───────────────────────────────────────────────────────────────
+// ── Shiki (used by code-block.tsx via `createHighlighter`) ─────────────
 
 export const SHIKI_DEFAULT_LIGHT: BundledTheme = 'github-light';
 export const SHIKI_DEFAULT_DARK: BundledTheme = 'github-dark';
 
-// ── Resolution helpers ──────────────────────────────────────────────────
+// ── HLJS theme loaders (lazy) ──────────────────────────────────────────
 
-import type { ThemeFamilyMeta, CodeThemeMapping } from './types';
+export type HljsStyle = Record<string, CSSProperties>;
+
+/**
+ * Each entry maps a theme name (as it appears in the family JSON's
+ * `codeTheme.dark` / `codeTheme.light`) to a function that returns the
+ * `react-syntax-highlighter` HLJS style object for that theme. The
+ * dynamic import keeps the entire style library out of the initial
+ * bundle — only the active theme is fetched.
+ */
+const HLJS_LOADERS: Record<string, () => Promise<HljsStyle>> = {
+  oneDark: () => import('react-syntax-highlighter/dist/esm/styles/hljs').then((m) => m.atomOneDark as unknown as HljsStyle),
+  oneLight: () => import('react-syntax-highlighter/dist/esm/styles/hljs').then((m) => m.atomOneLight as unknown as HljsStyle),
+  nord: () => import('react-syntax-highlighter/dist/esm/styles/hljs').then((m) => m.nord as unknown as HljsStyle),
+  solarizedDarkAtom: () => import('react-syntax-highlighter/dist/esm/styles/hljs').then((m) => m.solarizedDark as unknown as HljsStyle),
+  solarizedlight: () => import('react-syntax-highlighter/dist/esm/styles/hljs').then((m) => m.solarizedLight as unknown as HljsStyle),
+  nightOwl: () => import('react-syntax-highlighter/dist/esm/styles/hljs').then((m) => m.nightOwl as unknown as HljsStyle),
+  dracula: () => import('react-syntax-highlighter/dist/esm/styles/hljs').then((m) => m.dracula as unknown as HljsStyle),
+  gruvboxDark: () => import('react-syntax-highlighter/dist/esm/styles/hljs').then((m) => m.gruvboxDark as unknown as HljsStyle),
+  gruvboxLight: () => import('react-syntax-highlighter/dist/esm/styles/hljs').then((m) => m.gruvboxLight as unknown as HljsStyle),
+  ghcolors: () => import('react-syntax-highlighter/dist/esm/styles/hljs').then((m) => m.github as unknown as HljsStyle),
+  synthwave84: () => import('react-syntax-highlighter/dist/esm/styles/hljs').then((m) => m.monokaiSublime as unknown as HljsStyle),
+  materialDark: () => import('react-syntax-highlighter/dist/esm/styles/hljs').then((m) => m.vs2015 as unknown as HljsStyle),
+  materialOceanic: () => import('react-syntax-highlighter/dist/esm/styles/hljs').then((m) => m.atomOneDark as unknown as HljsStyle),
+  duotoneSea: () => import('react-syntax-highlighter/dist/esm/styles/hljs').then((m) => m.atomOneDark as unknown as HljsStyle),
+  coldarkDark: () => import('react-syntax-highlighter/dist/esm/styles/hljs').then((m) => m.atomOneDark as unknown as HljsStyle),
+  coldarkCold: () => import('react-syntax-highlighter/dist/esm/styles/hljs').then((m) => m.atomOneLight as unknown as HljsStyle),
+  materialLight: () => import('react-syntax-highlighter/dist/esm/styles/hljs').then((m) => m.idea as unknown as HljsStyle),
+  duotoneLight: () => import('react-syntax-highlighter/dist/esm/styles/hljs').then((m) => m.atomOneLight as unknown as HljsStyle),
+  vs: () => import('react-syntax-highlighter/dist/esm/styles/hljs').then((m) => m.vs as unknown as HljsStyle),
+  coy: () => import('react-syntax-highlighter/dist/esm/styles/hljs').then((m) => m.xcode as unknown as HljsStyle),
+  prism: () => import('react-syntax-highlighter/dist/esm/styles/hljs').then((m) => m.lightfair as unknown as HljsStyle),
+  duotoneEarth: () => import('react-syntax-highlighter/dist/esm/styles/hljs').then((m) => m.darcula as unknown as HljsStyle),
+  duotoneForest: () => import('react-syntax-highlighter/dist/esm/styles/hljs').then((m) => m.zenburn as unknown as HljsStyle),
+  twilight: () => import('react-syntax-highlighter/dist/esm/styles/hljs').then((m) => m.obsidian as unknown as HljsStyle),
+};
+
+// In-process cache so once a theme is loaded it stays synchronous for
+// subsequent mounts. Keyed by resolved theme name.
+const hljsCache = new Map<string, HljsStyle>();
+
+/**
+ * Resolve the name of the HLJS theme to load for the given code-theme
+ * mapping + mode, or `null` if the mapping is missing/invalid. This
+ * is a pure helper — the actual import is performed by `useHljsStyle`.
+ */
+export function resolveHljsThemeName(
+  codeTheme: CodeThemeMapping | undefined,
+  isDark: boolean,
+): string {
+  const name = isDark ? codeTheme?.dark : codeTheme?.light;
+  if (name && HLJS_LOADERS[name]) return name;
+  return isDark ? 'oneDark' : 'oneLight';
+}
+
+/**
+ * Load an HLJS theme object by name. Returns the cached value
+ * synchronously if it has already been loaded, otherwise fetches it.
+ * Safe to call from render — React will de-duplicate identical
+ * promises produced by useEffect deps.
+ */
+export function loadHljsStyle(name: string): Promise<HljsStyle> {
+  const cached = hljsCache.get(name);
+  if (cached) return Promise.resolve(cached);
+  const loader = HLJS_LOADERS[name];
+  if (!loader) return Promise.resolve(hljsCache.get('oneDark') ?? ({} as HljsStyle));
+  return loader().then((style) => {
+    hljsCache.set(name, style);
+    return style;
+  });
+}
+
+/**
+ * Hook variant: load the HLJS style for the active family + dark mode
+ * and return `{ style, loaded }`. Callers should render a plain `<pre>`
+ * (or a skeleton) while `loaded` is false.
+ */
+export function useHljsStyle(
+  codeTheme: CodeThemeMapping | undefined,
+  isDark: boolean,
+): { style: HljsStyle | null; loaded: boolean } {
+  const name = resolveHljsThemeName(codeTheme, isDark);
+  const [style, setStyle] = useState<HljsStyle | null>(() => hljsCache.get(name) ?? null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const cached = hljsCache.get(name);
+    if (cached) {
+      setStyle(cached);
+      return;
+    }
+    setStyle(null);
+    void loadHljsStyle(name).then((loaded) => {
+      if (!cancelled) setStyle(loaded);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [name]);
+
+  return { style, loaded: style !== null };
+}
+
+// ── Resolution helpers ─────────────────────────────────────────────────
 
 /**
  * Resolve a code-theme mapping from the current family metadata.
@@ -158,26 +152,6 @@ export function resolveShikiTheme(
   familyId: string,
 ): CodeThemeMapping | undefined {
   return families.find((f) => f.id === familyId)?.shikiTheme;
-}
-
-/** Pick a Prism style for the given mode. Falls back to oneDark / oneLight. */
-export function resolvePrismStyle(
-  codeTheme: CodeThemeMapping | undefined,
-  isDark: boolean,
-): SyntaxStyle {
-  const name = isDark ? codeTheme?.dark : codeTheme?.light;
-  if (name && PRISM_THEME_MAP[name]) return PRISM_THEME_MAP[name];
-  return isDark ? PRISM_DEFAULT_DARK : PRISM_DEFAULT_LIGHT;
-}
-
-/** Pick an HLJS style for the given mode. Falls back to atomOneDark / atomOneLight. */
-export function resolveHljsStyle(
-  codeTheme: CodeThemeMapping | undefined,
-  isDark: boolean,
-): HljsStyle {
-  const name = isDark ? codeTheme?.dark : codeTheme?.light;
-  if (name && HLJS_THEME_MAP[name]) return HLJS_THEME_MAP[name];
-  return isDark ? HLJS_DEFAULT_DARK : HLJS_DEFAULT_LIGHT;
 }
 
 /** Pick a Shiki BundledTheme pair. Falls back to github-light / github-dark. */


### PR DESCRIPTION
## Problem

`src/lib/theme/code-themes.ts` statically imports **25 Prism themes + 18 HLJS themes** from `react-syntax-highlighter/dist/esm/styles/{prism,hljs}`. The theme objects are large CSS-in-JS style maps, totaling ~300–500 KB minzipped. They are pulled into the first-paint chunk even though:

- Only one theme is ever rendered at a time (the active family)
- The Prism block has **zero consumers** — `PRISM_THEME_MAP` and `resolvePrismStyle` are not imported anywhere outside `code-themes.ts` itself

This ships to every user, on every page load, including users who never open a file preview or a Markdown doc.

## Fix

1. **Delete the Prism block.** No consumer imports it. Saves ~150 KB.

2. **Replace static HLJS theme imports with a per-name dynamic loader.** Each named theme is fetched only when the user actually opens a file with that family / dark-mode pair:
   ```ts
   const HLJS_LOADERS: Record<string, () => Promise<HljsStyle>> = {
     oneDark: () => import('react-syntax-highlighter/dist/esm/styles/hljs')
       .then((m) => m.atomOneDark as unknown as HljsStyle),
     // ...
   };
   ```
   An in-process `hljsCache` Map keeps the second mount of the same theme synchronous (the family rarely changes in a session).

3. **Add a `useHljsStyle(codeTheme, isDark)` hook** that returns `{ style, loaded }`. While `loaded` is `false`, the consumer renders a plain `<pre>` so the file text appears immediately, then the syntax highlight lands a few ms later once the dynamic chunk resolves.

4. **Update `FilePreview.tsx` and `PreviewPanel.tsx`** to use the new hook + the plain-`<pre>` fallback. Existing behavior is preserved: identical output, identical color scheme, identical font size, identical line numbers once the style is loaded.

## Impact

- **Bundle:** ~300–500 KB minzipped removed from the first-paint chunk. Most users will see one HLJS theme (~15–25 KB) on first file-open instead of all 18.
- **TTI:** faster first paint on the chat view, file tree, and Settings page — none of which ever call `useHljsStyle`.
- **Memory:** only the loaded theme objects stay resident; the 17 unused themes never allocate.
- **Correctness:** zero behavior change for users who open a file preview or doc — they see plain text for ~50–150 ms (one dynamic chunk fetch) and then the highlighted version. The plain-`<pre>` fallback uses the same monospace stack and padding as `<SyntaxHighlighter>`, so the layout does not shift.

## Trade-offs

- The first file open shows plain text briefly. For a desktop Electron app this is sub-100 ms in practice (the chunk is small and the renderer is local).
- The `useHljsStyle` hook is not memoized; if a parent re-renders the hook will re-run its `useEffect`. The theme name is derived from the current family + dark-mode, both of which are stable across re-renders, so the cache short-circuits the second call.
