### PR TITLE
perf(chat): derive upstreamModelId from providerGroups to eliminate duplicate fetch

### DIFF
--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -244,6 +244,7 @@ export function ChatView({ sessionId, initialMessages = [], initialHasMore = fal
     resolvedProviderId,
     resolvedModel,
     providerWasFilteredOut,
+    providerGroups,
   } = useProviderModels(currentProviderId, currentModel, sessionRuntimeParam);
 
   // Phase 2 Step 3b — was: silently set state + PATCH the session row
@@ -382,29 +383,18 @@ export function ChatView({ sessionId, initialMessages = [], initialHasMore = fal
     return () => controller.abort();
   }, [currentProviderId]);
 
-  // Resolve upstream model ID for the current model/provider so the context
-  // indicator can disambiguate alias windows (first-party opus = 1M vs
-  // Bedrock/Vertex opus = 200K). /api/providers/models already returns
-  // upstreamModelId per model on the returned groups.
-  const [currentModelUpstream, setCurrentModelUpstream] = useState<string | undefined>(undefined);
-  useEffect(() => {
+  // Derive upstream model ID from providerGroups (already fetched by
+  // useProviderModels above) instead of making a duplicate network request.
+  // Canonical-aware (tech-debt #37): currentModel may be a canonical id
+  // (`claude-opus-4-7`) while the rows are aliases (`opus`) — match by
+  // either so the context-window indicator gets the right upstream.
+  const currentModelUpstream = useMemo(() => {
     const pid = currentProviderId || 'env';
-    const controller = new AbortController();
-    fetch('/api/providers/models', { signal: controller.signal })
-      .then(r => r.ok ? r.json() : null)
-      .then(data => {
-        if (controller.signal.aborted) return;
-        const group = data?.groups?.find((g: { provider_id: string }) => g.provider_id === pid);
-        // Canonical-aware (tech-debt #37): currentModel may be a canonical id
-        // (`claude-opus-4-7`) while the rows are aliases (`opus`) — match by
-        // either so the context-window indicator gets the right upstream.
-        const models = (group?.models ?? []) as Array<{ value: string; upstreamModelId?: string }>;
-        const model = findModelOption(models, currentModel);
-        setCurrentModelUpstream(model?.upstreamModelId);
-      })
-      .catch(() => {});
-    return () => controller.abort();
-  }, [currentProviderId, currentModel]);
+    const group = providerGroups.find((g) => g.provider_id === pid);
+    if (!group) return undefined;
+    const model = findModelOption(group.models, currentModel);
+    return model?.upstreamModelId;
+  }, [currentProviderId, currentModel, providerGroups]);
   useEffect(() => { if (initialPermissionProfile) setPermissionProfile(initialPermissionProfile); }, [initialPermissionProfile]);
 
   // Restore session-scoped last-generated images from sessionStorage


### PR DESCRIPTION
## Summary

`ChatView` was making a duplicate `fetch('/api/providers/models')` inside a `useEffect` solely to extract `upstreamModelId` for the context-window indicator — even though `useProviderModels` (called 20 lines above) already fetches the same endpoint and returns the full `providerGroups` array with `upstreamModelId` on every model row.

## Change

- Destructure `providerGroups` from the existing `useProviderModels` call
- Replace the `useState` + `useEffect` + `fetch` with a `useMemo` that derives `currentModelUpstream` by scanning `providerGroups` in-memory
- Uses the same `findModelOption` helper for canonical-id matching (preserves tech-debt #37 handling)

## Impact

- **Eliminates 1 network round-trip** on every provider/model change
- **Zero behavioral change** — same lookup logic, same return type
- **~20 lines removed** (net -10)