### PR TITLE
perf(file-tree): debounce refresh-file-tree event and scope to write tools only

### DIFF
--- a/src/lib/stream-session-manager.ts
+++ b/src/lib/stream-session-manager.ts
@@ -117,6 +117,11 @@ const GC_DELAY_MS = 5 * 60 * 1000; // 5 minutes
 // request's .finally) so a hung /api/chat/interrupt can't strand the stream in
 // 'active' and lock the composer's isStreaming gate (GitHub #578).
 const STREAM_FORCE_ABORT_MS = 2000;
+// Debounce the refresh-file-tree window event so rapid-succession write
+// tool results (e.g. 5 files in one turn) trigger at most one file-tree
+// re-fetch instead of one per file.
+const REFRESH_FILE_TREE_DEBOUNCE_MS = 300;
+let refreshFileTreeTimer: ReturnType<typeof setTimeout> | null = null;
 
 function getStreamsMap(): Map<string, ActiveStream> {
   if (!(globalThis as Record<string, unknown>)[GLOBAL_KEY]) {
@@ -537,8 +542,6 @@ async function runStream(stream: ActiveStream, params: StartStreamParams): Promi
           stream.toolResultsArray = [...stream.toolResultsArray, res];
         }
         emit(stream, 'snapshot-updated');
-        // Refresh file tree after each tool completes
-        window.dispatchEvent(new Event('refresh-file-tree'));
         // Phase 4: dispatch codepilot:file-changed when this tool_result
         // belongs to a write/edit tool and is not an error. Lookup the
         // matching tool_use by id to read the name + input, then resolve
@@ -557,6 +560,15 @@ async function runStream(stream: ActiveStream, params: StartStreamParams): Promi
                 source: 'ai-tool',
               });
             }
+            // Refresh file tree after write tools (debounced) —
+            // non-write tools (read, grep, ls, glob) don't mutate
+            // the filesystem so skipping them avoids wasted re-fetches
+            // during agentic workflows with 10-30 tool calls.
+            if (refreshFileTreeTimer) clearTimeout(refreshFileTreeTimer);
+            refreshFileTreeTimer = setTimeout(() => {
+              refreshFileTreeTimer = null;
+              window.dispatchEvent(new Event('refresh-file-tree'));
+            }, REFRESH_FILE_TREE_DEBOUNCE_MS);
           }
         }
       },


### PR DESCRIPTION
## Summary

The stream session manager was dispatching a `refresh-file-tree` window event on **every** tool result — not just write/edit tools. During agentic workflows with 10-30 tool calls (grep, read, ls, glob...) completing in rapid succession, `FileTree` was re-fetching the entire directory listing for each result, causing wasted filesystem I/O and React re-renders.

## Changes

1. **Scope to write tools only** — Move the `refresh-file-tree` dispatch inside the existing `isWriteTool` guard. Non-mutating tools (read, grep, ls, glob) don't change the filesystem, so the file tree doesn't need to re-fetch.

2. **Add 300ms trailing-edge debounce** — When multiple write tools complete in rapid succession (e.g. editing 5 files in one turn), only one file-tree re-fetch fires, 300ms after the last write result lands.

## Impact

- Agentic workflows with many read-only tools: **zero unnecessary file-tree re-fetches** (was 1 per tool)
- Multi-file edits: **1 re-fetch instead of N** (N = number of files written)
- No behavioral change — the file tree still refreshes after writes, just more efficiently