### PR TITLE
perf(chat): wrap MessageInput with React.memo to skip re-renders during streaming

### DIFF
--- a/src/components/chat/MessageInput.tsx
+++ b/src/components/chat/MessageInput.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRef, useState, useCallback, useEffect, useMemo, type KeyboardEvent, type FormEvent } from 'react';
+import { memo, useRef, useState, useCallback, useEffect, useMemo, type KeyboardEvent, type FormEvent } from 'react';
 import { CodePilotIcon } from "@/components/ui/semantic-icon";
 import { useTranslation } from '@/hooks/useTranslation';
 import type { TranslationKey } from '@/i18n';
@@ -158,7 +158,7 @@ async function fileResponseToAttachment(
   };
 }
 
-export function MessageInput({
+export const MessageInput = memo(function MessageInput({
   onSend,
   onCommand,
   onStop,
@@ -1136,4 +1136,4 @@ export function MessageInput({
 
     </div>
   );
-}
+});


### PR DESCRIPTION
MessageInput is a 1133-line component with 24 props, 10+ hooks, and 8 child components. It was not wrapped in React.memo, so every ~100ms streaming text chunk caused the entire function body to re-run. All props are already reference-stable during streaming (callbacks are useCallback'd, primitives don't change, arrays are useMemo'd). With React.memo, the shallow prop comparison skips the re-render — only the MessageList items need to re-render in response to new text.