### PR TITLE
fix: Feishu duplicate message processing

### DIFF
--- a/src/lib/bridge/bridge-manager.ts
+++ b/src/lib/bridge/bridge-manager.ts
@@ -203,6 +203,8 @@ interface BridgeManagerState {
   adapters: Map<string, BaseChannelAdapter>;
   adapterMeta: Map<string, AdapterMeta>;
   running: boolean;
+  /** Guard against concurrent start() calls — set immediately on entry, cleared on completion or error */
+  starting: boolean;
   startedAt: string | null;
   loopAborts: Map<string, AbortController>;
   activeTasks: Map<string, AbortController>;
@@ -218,6 +220,7 @@ function getState(): BridgeManagerState {
       adapters: new Map(),
       adapterMeta: new Map(),
       running: false,
+      starting: false,
       startedAt: null,
       loopAborts: new Map(),
       activeTasks: new Map(),
@@ -263,6 +266,10 @@ export interface StartResult {
 export async function start(): Promise<StartResult> {
   const state = getState();
   if (state.running) return { started: true };
+  if (state.starting) return { started: false, reason: 'starting_in_progress' };
+
+  // Set starting flag immediately to prevent concurrent start() calls
+  state.starting = true;
 
   const bridgeEnabled = getSetting('remote_bridge_enabled') === 'true';
   if (!bridgeEnabled) {
@@ -311,6 +318,7 @@ export async function start(): Promise<StartResult> {
     console.warn('[bridge-manager] No adapters started successfully, bridge not activated');
     state.adapters.clear();
     state.adapterMeta.clear();
+    state.starting = false;
     const reason = configErrors.length > 0
       ? `adapter_config_invalid: ${configErrors.join('; ')}`
       : 'no_adapters_started';
@@ -320,6 +328,7 @@ export async function start(): Promise<StartResult> {
   // Mark running BEFORE starting consumer loops — runAdapterLoop checks
   // state.running in its while-condition, so it must be true first.
   state.running = true;
+  state.starting = false;
   state.startedAt = new Date().toISOString();
 
   // Suppress notification bot polling to avoid conflicts
@@ -344,6 +353,7 @@ export async function stop(): Promise<void> {
   if (!state.running) return;
 
   state.running = false;
+  state.starting = false;
 
   // Abort all active tool/stream tasks so in-flight Claude sessions stop
   // writing to DB and release session locks cleanly. Without this, `/stop`

--- a/src/lib/channels/feishu/index.ts
+++ b/src/lib/channels/feishu/index.ts
@@ -31,6 +31,14 @@ import { loadFeishuConfig, validateFeishuConfig } from './config';
 
 /** Max number of message IDs to keep for dedup. */
 const DEDUP_MAX = 1000;
+
+/**
+ * Max age for inbound messages in milliseconds.
+ * Messages older than this are dropped as stale — they are likely historical
+ * events replayed by the Lark SDK after a WSClient reconnect or bridge restart.
+ * Default: 5 minutes.
+ */
+const STALE_MESSAGE_MAX_AGE_MS = 5 * 60 * 1000;
 import { FeishuGateway } from './gateway';
 import { parseMessageWithResources } from './inbound';
 import { getBotInfo } from './identity';
@@ -391,6 +399,17 @@ export class FeishuChannelPlugin implements ChannelPlugin<FeishuConfig> {
   }
 
   private enqueueMessage(msg: InboundMessage): void {
+    // Stale message filter: drop messages older than STALE_MESSAGE_MAX_AGE_MS.
+    // The Lark SDK replays unprocessed historical events on WSClient reconnect,
+    // which can cause the bot to respond to messages from hours or days ago.
+    if (msg.timestamp && !msg.callbackData) {
+      const age = Date.now() - msg.timestamp;
+      if (age > STALE_MESSAGE_MAX_AGE_MS) {
+        console.log('[feishu/plugin]', `Stale message dropped (${Math.round(age / 1000)}s old):`, msg.messageId);
+        return;
+      }
+    }
+
     // Dedup: skip messages already seen (prevents duplicates from WS reconnect/retry)
     if (msg.messageId && !msg.callbackData) {
       if (this.seenMessageIds.has(msg.messageId)) {

--- a/src/lib/channels/feishu/index.ts
+++ b/src/lib/channels/feishu/index.ts
@@ -28,6 +28,9 @@ interface CardActionEvent {
   open_message_id?: string;
 }
 import { loadFeishuConfig, validateFeishuConfig } from './config';
+
+/** Max number of message IDs to keep for dedup. */
+const DEDUP_MAX = 1000;
 import { FeishuGateway } from './gateway';
 import { parseMessageWithResources } from './inbound';
 import { getBotInfo } from './identity';
@@ -60,6 +63,8 @@ export class FeishuChannelPlugin implements ChannelPlugin<FeishuConfig> {
    * scheduling new timers.
    */
   private identityGeneration = 0;
+  /** Dedup: set of recently seen message IDs to prevent duplicate processing. */
+  private seenMessageIds = new Set<string>();
 
   loadConfig(): FeishuConfig | null {
     this.config = loadFeishuConfig();
@@ -347,6 +352,11 @@ export class FeishuChannelPlugin implements ChannelPlugin<FeishuConfig> {
       this.waitResolve(null);
       this.waitResolve = null;
     }
+    // NOTE: Do NOT clear seenMessageIds here.
+    // After gateway.stop() closes the WSClient, in-flight events from the old
+    // connection may still arrive briefly. Keeping the dedup set prevents them
+    // from being re-processed if a new gateway starts immediately after.
+    // The set is bounded by DEDUP_MAX and will naturally age out.
   }
 
   isRunning(): boolean {
@@ -381,10 +391,29 @@ export class FeishuChannelPlugin implements ChannelPlugin<FeishuConfig> {
   }
 
   private enqueueMessage(msg: InboundMessage): void {
-    // Track messageId for reaction acknowledgment (skip callback messages)
+    // Dedup: skip messages already seen (prevents duplicates from WS reconnect/retry)
     if (msg.messageId && !msg.callbackData) {
+      if (this.seenMessageIds.has(msg.messageId)) {
+        console.log('[feishu/plugin]', 'Duplicate message skipped:', msg.messageId);
+        return;
+      }
+      this.seenMessageIds.add(msg.messageId);
+
+      // Track messageId for reaction acknowledgment
       this.lastMessageIdByChat.set(msg.address.chatId, msg.messageId);
+
+      // Prune dedup set when it exceeds capacity
+      if (this.seenMessageIds.size > DEDUP_MAX) {
+        const excess = this.seenMessageIds.size - DEDUP_MAX;
+        let removed = 0;
+        for (const id of this.seenMessageIds) {
+          if (removed >= excess) break;
+          this.seenMessageIds.delete(id);
+          removed++;
+        }
+      }
     }
+
     if (this.waitResolve) {
       const resolve = this.waitResolve;
       this.waitResolve = null;


### PR DESCRIPTION
## 问题

飞书桥接存在两个严重问题：
1. **重复回复** — 用户在同一会话中收到多条相同回复
2. **回复历史消息** — bot 在凌晨自动回复了用户很久以前发的消息

## 根因分析

### 问题 1：重复回复（3 个独立原因）

#### 1a. Feishu 插件无消息去重
enqueueMessage() 直接入队无检查 messageId，Lark SDK 重连时重复推送事件。

#### 1b. WSClient 未真正关闭
Gateway.stop() 只置空引用没有调用 SDK close()，旧连接继续存活导致 restart 时双 WSClient 同时运行。

#### 1c. bridge-manager 并发竞态
start() 没有防止并发调用，Electron auto-start + UI 手动 Start 可能同时触发。

### 问题 2：回复历史消息
Lark SDK 在 WSClient 重连时会重放所有未确认的历史事件，Feishu adapter 没有过期消息过滤。

## 修复内容

- FeishuChannelPlugin: 添加 seenMessageIds Set 去重
- FeishuGateway.stop(): 调用 wsClient.close(force:true) 真正关闭
- FeishuChannelPlugin.enqueueMessage(): 添加 5 分钟过期消息过滤
- FeishuChannelPlugin.stop(): 不再清空去重集合
- bridge-manager.start(): 添加 starting 标志位防止并发调用

全部 590 测试通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
