### PR TITLE
Add MiniMax M3 to global provider preset

### DIFF
--- a/src/lib/provider-catalog.ts
+++ b/src/lib/provider-catalog.ts
@@ -700,7 +700,7 @@ export const VENDOR_PRESETS: VendorPreset[] = [
     descriptionZh: 'MiniMax 编程套餐 — 国际区',
     protocol: 'anthropic',
     authStyle: 'auth_token',
-    baseUrl: 'https://api.minimax.io/anthropic/v1',
+    baseUrl: 'https://api.minimax.io/anthropic',
     defaultEnvOverrides: {
       API_TIMEOUT_MS: '3000000',
       CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1',

--- a/src/lib/provider-catalog.ts
+++ b/src/lib/provider-catalog.ts
@@ -700,13 +700,14 @@ export const VENDOR_PRESETS: VendorPreset[] = [
     descriptionZh: 'MiniMax 编程套餐 — 国际区',
     protocol: 'anthropic',
     authStyle: 'auth_token',
-    baseUrl: 'https://api.minimax.io/anthropic',
+    baseUrl: 'https://api.minimax.io/anthropic/v1',
     defaultEnvOverrides: {
       API_TIMEOUT_MS: '3000000',
       CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1',
     },
     defaultModels: [
       { modelId: 'sonnet', upstreamModelId: 'MiniMax-M2.7', displayName: 'MiniMax-M2.7', role: 'default' },
+      { modelId: 'MiniMax-M3', upstreamModelId: 'MiniMax-M3', displayName: 'MiniMax-M3', capabilities: { contextWindow: 1000000, reasoning: true, toolUse: true, supportsAdaptiveThinking: true } },
     ],
     defaultRoleModels: {
       default: 'MiniMax-M2.7',


### PR DESCRIPTION
Reason: add target provider/model to existing provider registry

## Summary
- Add MiniMax-M3 to the existing MiniMax Global provider catalog.

## Test plan
- `npm install`
- `npm run typecheck`
- Secret scan on `git diff`