### PR TITLE
fix(providers): use mapped Sonnet model for connection tests

### DIFF
--- a/src/__tests__/unit/mimo-model-mapping.test.ts
+++ b/src/__tests__/unit/mimo-model-mapping.test.ts
@@ -126,7 +126,7 @@ describe('MiMo resolver honors a user-set model (no silent revert) — #577A', (
 
 // ── Wiring source pins (connect dialog pre-fill) ─────────────────────────────
 
-describe('connect dialog pre-fills the model field from the preset default (#577A)', () => {
+describe('connect dialog pre-fills exposed model fields from the preset default (#577A)', () => {
   const presetsSrc = fs.readFileSync(
     path.resolve(__dirname, '../../components/settings/provider-presets.tsx'),
     'utf8',
@@ -144,11 +144,11 @@ describe('connect dialog pre-fills the model field from the preset default (#577
     );
   });
 
-  it('create mode pre-fills modelName from preset.defaultModelId (not empty)', () => {
+  it('create mode pre-fills modelName only when the preset exposes model_names', () => {
     assert.match(
       dialogSrc,
-      /setModelName\(preset\.defaultModelId \|\| ""\)/,
-      'create mode must pre-fill the model field from the preset default',
+      /setModelName\(\s*preset\.fields\.includes\("model_names"\)\s*\?\s*\(preset\.defaultModelId \|\| ""\)\s*:\s*""\s*,?\s*\)/,
+      'create mode must pre-fill the model field from the preset default without seeding a hidden default for mapping-only presets',
     );
   });
 });

--- a/src/__tests__/unit/provider-connection-test-model.test.ts
+++ b/src/__tests__/unit/provider-connection-test-model.test.ts
@@ -1,0 +1,49 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { resolveConnectionTestModelName } from '../../lib/provider-connection-test-model';
+
+describe('resolveConnectionTestModelName', () => {
+  it('uses the mapped Sonnet model when no default model is configured', () => {
+    assert.equal(
+      resolveConnectionTestModelName('', 'claude-sonnet-4-6'),
+      'claude-sonnet-4-6',
+    );
+  });
+
+  it('prefers an explicitly configured default model over the Sonnet mapping', () => {
+    assert.equal(
+      resolveConnectionTestModelName('custom-default-model', 'claude-sonnet-4-6'),
+      'custom-default-model',
+    );
+  });
+
+  it('leaves model selection to the existing connection-test fallback when both fields are empty', () => {
+    assert.equal(resolveConnectionTestModelName('', ''), undefined);
+  });
+
+  it('uses the resolver when building the connection-test payload', () => {
+    const dialogSource = fs.readFileSync(
+      path.resolve(process.cwd(), 'src/components/settings/PresetConnectDialog.tsx'),
+      'utf8',
+    );
+
+    assert.match(
+      dialogSource,
+      /modelName:\s*resolveConnectionTestModelName\(modelName,\s*mapSonnet\)/,
+    );
+  });
+
+  it('does not seed a hidden default model for mapping-only presets', () => {
+    const dialogSource = fs.readFileSync(
+      path.resolve(process.cwd(), 'src/components/settings/PresetConnectDialog.tsx'),
+      'utf8',
+    );
+
+    assert.match(
+      dialogSource,
+      /setModelName\(\s*preset\.fields\.includes\("model_names"\)\s*\?\s*\(preset\.defaultModelId \|\| ""\)\s*:\s*""\s*,?\s*\)/,
+    );
+  });
+});

--- a/src/components/settings/PresetConnectDialog.tsx
+++ b/src/components/settings/PresetConnectDialog.tsx
@@ -28,6 +28,7 @@ import { QUICK_PRESETS } from "./provider-presets";
 import type { ApiProvider } from "@/types";
 import { useTranslation } from "@/hooks/useTranslation";
 import type { TranslationKey } from "@/i18n";
+import { resolveConnectionTestModelName } from "@/lib/provider-connection-test-model";
 
 /** Infer auth style from base URL by fuzzy-matching preset hostnames */
 function inferAuthStyleFromUrl(url: string): "api_key" | "auth_token" | null {
@@ -156,7 +157,7 @@ export function PresetConnectDialog({
         protocol: preset?.protocol || 'anthropic',
         authStyle: preset?.key === 'anthropic-thirdparty' ? authStyle : (preset?.authStyle || authStyle),
         envOverrides,
-        modelName: modelName || undefined,
+        modelName: resolveConnectionTestModelName(modelName, mapSonnet),
         providerName: name || preset?.name,
       };
       if (isEdit && editProvider) {
@@ -272,12 +273,14 @@ export function PresetConnectDialog({
       setBaseUrl(preset.base_url);
       setName(preset.name);
       setExtraEnv(preset.extra_env);
-      // Pre-fill the model-name field with the preset's default model id so a
-      // preset that requires a user-specified model (e.g. MiMo) shows its
-      // current model (editable) rather than an empty box (#577). Harmless for
-      // presets without the model_names field — the value is only read on save
-      // when that field is exposed.
-      setModelName(preset.defaultModelId || "");
+      // Pre-fill only an exposed model-name field with the preset default so a
+      // provider such as MiMo shows its editable current model (#577).
+      // Mapping-only presets must keep this empty: otherwise their hidden
+      // catalog alias (for example, "sonnet") overrides a Sonnet mapping in
+      // the connection-test payload.
+      setModelName(
+        preset.fields.includes("model_names") ? (preset.defaultModelId || "") : "",
+      );
       // Use authStyle directly from preset (single source of truth)
       const detectedStyle = (preset.authStyle === 'auth_token' ? 'auth_token' : 'api_key') as 'api_key' | 'auth_token';
       // If preset doesn't expose api_key field, pre-fill from extra_env default

--- a/src/lib/provider-connection-test-model.ts
+++ b/src/lib/provider-connection-test-model.ts
@@ -1,0 +1,6 @@
+export function resolveConnectionTestModelName(
+  defaultModelName: string,
+  mappedSonnetModelName: string,
+): string | undefined {
+  return defaultModelName || mappedSonnetModelName || undefined;
+}


### PR DESCRIPTION
## Summary

- Connection tests for third-party Anthropic providers now send the user-mapped Sonnet model when no explicit default model is set, instead of falling back to the catalog alias `sonnet`.
- Mapping-only presets no longer seed a hidden `modelName` from `defaultModelId`, so that alias cannot override the Sonnet mapping in the test payload.
- Presets that expose `model_names` (for example MiMo) still pre-fill the editable model field, preserving #577A behavior.
- Adds a small pure helper and unit coverage for the resolution order and the dialog wiring.

## Root cause

`PresetConnectDialog` only sent a single `modelName` on connection test. Create-mode pre-fill wrote `preset.defaultModelId` (often the catalog alias `sonnet`) into that field even when the field was not shown. Users who only filled Sonnet mapping therefore still probed with `model: "sonnet"`, while chat could already use the mapped upstream id.

## Why not only #575

Open PR #575 also tries to prefer role mappings, but if the hidden default still pre-fills `modelName` with `sonnet`, that value wins before `mapSonnet`. This PR closes that gap with a narrower change and without the 503 classifier expansion.

## Verification

- Node 22 (`v22.23.2`)
- `npx tsc --noEmit` — pass
- Targeted: `provider-connection-test-model`, `mimo-model-mapping`, `provider-key-lifecycle`, `provider-preset` — **144 pass / 0 fail**
- Full unit suite (excluding pre-existing hang in `native-timeout-reasons.test.ts`): **4507 pass / 11 fail**
  - All 11 failures are pre-existing `provider-request-shape` Anthropic tests polluted by a local default endpoint (`ark.cn-beijing.volces.com`), unrelated to this patch
- Prior session browser smoke: intercepted request used the mapped Sonnet model and reported a successful connection

## Related

Related: #461