### PR TITLE
docs: add AUR link to Linux download row

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 |---|---|---|
 | macOS | [Apple Silicon (.dmg)](https://github.com/op7418/CodePilot/releases/latest) · [Intel (.dmg)](https://github.com/op7418/CodePilot/releases/latest) | arm64 / x64 |
 | Windows | [Installer (.exe)](https://github.com/op7418/CodePilot/releases/latest) | x64 |
-| Linux | [AppImage / deb / rpm](https://github.com/op7418/CodePilot/releases/latest) | x64 / arm64 |
+| Linux | [AppImage / deb / rpm](https://github.com/op7418/CodePilot/releases/latest) · [AUR](https://aur.archlinux.org/packages/codepilot-appimage) | x64 / arm64 |
 
 Or visit the [Releases](https://github.com/op7418/CodePilot/releases) page for all versions.
 


### PR DESCRIPTION
## Summary

- Adds an AUR link to the Linux row in the Download table (`README.md`)
- Documents the community-maintained [`codepilot-appimage`](https://aur.archlinux.org/packages/codepilot-appimage) package for x86_64 and aarch64

The package is maintained in [missing-aur](https://github.com/Cleboost/missing-aur) and updated automatically from upstream releases.