### PR TITLE
Refresh MiniMax model capabilities and endpoints

### DIFF
--- a/src/__tests__/unit/provider-preset.test.ts
+++ b/src/__tests__/unit/provider-preset.test.ts
@@ -85,6 +85,29 @@ describe('Preset Schema Validation', () => {
     assert.notEqual(p!.sdkProxyOnly, true, 'openai-compatible uses the AI SDK path, not the Claude Code subprocess');
     assert.notEqual(p!.meta?.claudeCodeVerified, true, 'claudeCodeVerified is only meaningful for anthropic presets');
   });
+
+  it('MiniMax regional presets expose current model metadata and OpenAI endpoints', () => {
+    const expected = [
+      ['minimax-cn', 'https://api.minimaxi.com/v1', 'https://platform.minimaxi.com/docs'],
+      ['minimax-global', 'https://api.minimax.io/v1', 'https://platform.minimax.io/docs'],
+    ] as const;
+    for (const [key, openaiBaseUrl, docsUrl] of expected) {
+      const preset = VENDOR_PRESETS.find(v => v.key === key)!;
+      const m27 = preset.defaultModels.find(model => model.upstreamModelId === 'MiniMax-M2.7')!;
+      const m3 = preset.defaultModels.find(model => model.modelId === 'MiniMax-M3')!;
+      assert.equal(m27.capabilities?.contextWindow, 204_800);
+      assert.equal(m27.capabilities?.thinkingMode, 'always');
+      assert.deepEqual(m27.capabilities?.inputModalities, ['text']);
+      assert.equal(m3.capabilities?.contextWindow, 1_000_000);
+      assert.equal(m3.capabilities?.supportsAdaptiveThinking, true);
+      assert.deepEqual(m3.capabilities?.inputModalities, ['text', 'image', 'video']);
+      assert.deepEqual(preset.wireCapabilities?.codexResponses, {
+        baseUrl: openaiBaseUrl,
+        modelIds: ['MiniMax-M3', 'MiniMax-M2.7'],
+      });
+      assert.equal(preset.meta?.docsUrl, docsUrl);
+    }
+  });
 });
 
 describe('toClaudeCodeEnv: env shape after CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST removal', () => {

--- a/src/lib/provider-catalog.ts
+++ b/src/lib/provider-catalog.ts
@@ -81,6 +81,15 @@ export interface CatalogModel {
     supportsAdaptiveThinking?: boolean;
     /** Vendor-documented thinking mode when it is not user-switchable. */
     thinkingMode?: 'always' | 'adaptive';
+    /** Input modalities accepted by the model's upstream endpoint. */
+    inputModalities?: ('text' | 'image' | 'video')[];
+    /** Vendor list pricing, in USD per million tokens. */
+    pricingUsdPerMillionTokens?: {
+      input: number;
+      output: number;
+      cacheRead: number;
+      cacheWrite?: number | null;
+    };
     /** Vendor default effort when the user leaves the selector on Auto. */
     defaultEffortLevel?: ProviderEffortLevel;
     /** Vendor sampling defaults/limits that must be represented honestly. */
@@ -289,6 +298,13 @@ export const PresetSchema = z.object({
       effortNoteKey: z.string().optional(),
       supportsAdaptiveThinking: z.boolean().optional(),
       thinkingMode: z.enum(['always', 'adaptive']).optional(),
+      inputModalities: z.array(z.enum(['text', 'image', 'video'])).optional(),
+      pricingUsdPerMillionTokens: z.object({
+        input: z.number(),
+        output: z.number(),
+        cacheRead: z.number(),
+        cacheWrite: z.number().nullable().optional(),
+      }).optional(),
       defaultEffortLevel: z.enum(['low', 'medium', 'high', 'xhigh', 'max']).optional(),
       thinkingTemperatureDefault: z.number().optional(),
       thinkingTemperatureMin: z.number().optional(),
@@ -1005,7 +1021,44 @@ export const VENDOR_PRESETS: VendorPreset[] = [
       CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1',
     },
     defaultModels: [
-      { modelId: 'sonnet', upstreamModelId: 'MiniMax-M2.7', displayName: 'MiniMax-M2.7', role: 'default' },
+      {
+        modelId: 'sonnet',
+        upstreamModelId: 'MiniMax-M2.7',
+        displayName: 'MiniMax-M2.7',
+        role: 'default',
+        capabilities: {
+          reasoning: true,
+          toolUse: true,
+          contextWindow: 204_800,
+          thinkingMode: 'always',
+          inputModalities: ['text'],
+          pricingUsdPerMillionTokens: {
+            input: 0.3,
+            output: 1.2,
+            cacheRead: 0.06,
+            cacheWrite: 0.375,
+          },
+        },
+      },
+      {
+        modelId: 'MiniMax-M3',
+        upstreamModelId: 'MiniMax-M3',
+        displayName: 'MiniMax-M3',
+        capabilities: {
+          reasoning: true,
+          toolUse: true,
+          vision: true,
+          contextWindow: 1_000_000,
+          supportsAdaptiveThinking: true,
+          inputModalities: ['text', 'image', 'video'],
+          pricingUsdPerMillionTokens: {
+            input: 0.6,
+            output: 2.4,
+            cacheRead: 0.12,
+            cacheWrite: null,
+          },
+        },
+      },
     ],
     defaultRoleModels: {
       default: 'MiniMax-M2.7',
@@ -1016,9 +1069,15 @@ export const VENDOR_PRESETS: VendorPreset[] = [
     fields: ['api_key'],
     iconKey: 'minimax',
     sdkProxyOnly: true,
+    wireCapabilities: {
+      codexResponses: {
+        baseUrl: 'https://api.minimaxi.com/v1',
+        modelIds: ['MiniMax-M3', 'MiniMax-M2.7'],
+      },
+    },
     meta: {
       apiKeyUrl: 'https://platform.minimaxi.com/user-center/payment/token-plan',
-      docsUrl: 'https://platform.minimaxi.com/docs/token-plan/claude-code',
+      docsUrl: 'https://platform.minimaxi.com/docs',
       billingModel: 'token_plan',
       claudeCodeVerified: true,
     },
@@ -1038,7 +1097,44 @@ export const VENDOR_PRESETS: VendorPreset[] = [
       CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1',
     },
     defaultModels: [
-      { modelId: 'sonnet', upstreamModelId: 'MiniMax-M2.7', displayName: 'MiniMax-M2.7', role: 'default' },
+      {
+        modelId: 'sonnet',
+        upstreamModelId: 'MiniMax-M2.7',
+        displayName: 'MiniMax-M2.7',
+        role: 'default',
+        capabilities: {
+          reasoning: true,
+          toolUse: true,
+          contextWindow: 204_800,
+          thinkingMode: 'always',
+          inputModalities: ['text'],
+          pricingUsdPerMillionTokens: {
+            input: 0.3,
+            output: 1.2,
+            cacheRead: 0.06,
+            cacheWrite: 0.375,
+          },
+        },
+      },
+      {
+        modelId: 'MiniMax-M3',
+        upstreamModelId: 'MiniMax-M3',
+        displayName: 'MiniMax-M3',
+        capabilities: {
+          reasoning: true,
+          toolUse: true,
+          vision: true,
+          contextWindow: 1_000_000,
+          supportsAdaptiveThinking: true,
+          inputModalities: ['text', 'image', 'video'],
+          pricingUsdPerMillionTokens: {
+            input: 0.6,
+            output: 2.4,
+            cacheRead: 0.12,
+            cacheWrite: null,
+          },
+        },
+      },
     ],
     defaultRoleModels: {
       default: 'MiniMax-M2.7',
@@ -1049,9 +1145,15 @@ export const VENDOR_PRESETS: VendorPreset[] = [
     fields: ['api_key'],
     iconKey: 'minimax',
     sdkProxyOnly: true,
+    wireCapabilities: {
+      codexResponses: {
+        baseUrl: 'https://api.minimax.io/v1',
+        modelIds: ['MiniMax-M3', 'MiniMax-M2.7'],
+      },
+    },
     meta: {
       apiKeyUrl: 'https://platform.minimax.io/user-center/payment/token-plan',
-      docsUrl: 'https://platform.minimax.io/docs/token-plan/opencode',
+      docsUrl: 'https://platform.minimax.io/docs',
       billingModel: 'token_plan',
       claudeCodeVerified: true,
     },


### PR DESCRIPTION
Reason: Refresh MiniMax model capability metadata and regional endpoint configuration.

Updated both regional MiniMax presets with current M2.7 and M3 context, pricing, thinking, and input modality metadata. Added regional OpenAI-compatible endpoint declarations and aligned documentation links with the official documentation roots. Added regression coverage for the catalog metadata and endpoint declarations.

Checks:
- `npm run typecheck`
- `node node_modules/tsx/dist/cli.mjs --test --import ./src/__tests__/db-isolation.setup.ts src/__tests__/unit/provider-preset.test.ts`
