### PR TITLE
fix(cli-tools): forward abortSignal to execAsync so a fired timeout actually kills the command

### DIFF
--- a/src/__tests__/unit/cli-tools-abort-signal.test.ts
+++ b/src/__tests__/unit/cli-tools-abort-signal.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Regression test: codepilot_cli_tools_install / codepilot_cli_tools_update
+ * must actually terminate their underlying shell command when the AI SDK
+ * fires the tool's abortSignal, instead of leaving the real process running
+ * in the background after the agent loop has already moved on.
+ *
+ * Background: native-timeout.ts documents that "ai@7 merely passes the
+ * abort signal INTO execute() and still awaits its promise" — the SDK's own
+ * timeout/cancellation machinery unblocks the *consumer* loop
+ * (timeoutCtl.guardStream), but does nothing to the real OS process unless
+ * execute() itself forwards the signal into the command it runs. Before this
+ * fix, execAsync() in cli-tools.ts's install/update handlers was never given
+ * a `signal` option, so a fired budget (or an aborted run) never actually
+ * killed the shell command — only stopped the loop from waiting on it.
+ *
+ * Run with: node scripts/run-node-tests.mjs unit
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { exec } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execAsync = promisify(exec);
+
+// Cross-platform long-running command: invokes the same `node` binary the
+// test itself runs under, so it needs no OS-specific flags (no `ping -n`
+// vs `ping -c`, no `sleep` vs `timeout`).
+const LONG_RUNNING_COMMAND = `node -e "setTimeout(() => {}, 10000)"`;
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe('cli-tools abortSignal wiring', () => {
+  it('exec() actually kills the child process once the passed signal aborts', async () => {
+    const controller = new AbortController();
+    const promise = execAsync(LONG_RUNNING_COMMAND, { timeout: 300_000, signal: controller.signal });
+    promise.catch(() => {}); // observed below; avoid an unhandled-rejection warning from the race
+
+    setTimeout(() => controller.abort(), 300);
+
+    const outcome = await Promise.race([
+      promise.then(() => 'completed' as const).catch(() => 'aborted' as const),
+      delay(4000).then(() => 'still-running' as const),
+    ]);
+
+    assert.equal(
+      outcome,
+      'aborted',
+      'exec() with a signal option must reject (process killed) once that signal aborts, not keep running',
+    );
+  });
+
+  it('control: exec() WITHOUT a signal option does not stop on its own AbortController firing (proves the bug this test guards against)', async () => {
+    // This mirrors the pre-fix call shape: an AbortController exists and
+    // fires, but nothing was ever wired to `exec()`, so the child process
+    // has no way to learn about it and keeps running.
+    const controller = new AbortController();
+    const promise = execAsync(LONG_RUNNING_COMMAND, { timeout: 300_000 }); // no `signal` here, intentionally
+    promise.catch(() => {});
+
+    setTimeout(() => controller.abort(), 300);
+
+    const outcome = await Promise.race([
+      promise.then(() => 'completed' as const).catch(() => 'aborted' as const),
+      delay(1500).then(() => 'still-running' as const),
+    ]);
+
+    assert.equal(
+      outcome,
+      'still-running',
+      'this control case demonstrates the exact orphaned-process bug: without `signal`, an aborted controller has no effect on the running command',
+    );
+  });
+});

--- a/src/lib/builtin-tools/cli-tools.ts
+++ b/src/lib/builtin-tools/cli-tools.ts
@@ -256,7 +256,7 @@ export function createCliToolsTools() {
         command: z.string().describe('The install command to execute, e.g. "brew install ffmpeg"'),
         name: z.string().optional().describe('Display name for the tool. If omitted, extracted from the command.'),
       }),
-      execute: async ({ command, name }) => {
+      execute: async ({ command, name }, { abortSignal }) => {
         try {
           const expandedPath = getExpandedPath();
           const installMethod = extractInstallMethod(command);
@@ -265,6 +265,7 @@ export function createCliToolsTools() {
           const { stdout, stderr } = await execAsync(command, {
             timeout: 300_000,
             env: { ...process.env, PATH: expandedPath },
+            signal: abortSignal,
           });
 
           const output = (stdout + '\n' + stderr).trim();
@@ -629,7 +630,7 @@ export function createCliToolsTools() {
         toolId: z.string().optional().describe('The tool ID to update (e.g. "ffmpeg", "custom-mytool")'),
         name: z.string().optional().describe('The tool name or binary name to update (used if toolId not provided)'),
       }),
-      execute: async ({ toolId, name: toolName }) => {
+      execute: async ({ toolId, name: toolName }, { abortSignal }) => {
         try {
           const expandedPath = getExpandedPath();
           const env = { ...process.env, PATH: expandedPath };
@@ -700,6 +701,7 @@ export function createCliToolsTools() {
           const { stdout, stderr } = await execAsync(updateCmd, {
             timeout: 300_000,
             env,
+            signal: abortSignal,
           });
 
           const output = (stdout + '\n' + stderr).trim();


### PR DESCRIPTION
## Problem

`codepilot_cli_tools_install` and `codepilot_cli_tools_update` run their real
shell command via `execAsync(command, { timeout: 300_000, env })` — no
`signal` option.

`native-timeout.ts` already documents why this is a gap, in its own words:

> Because ai@7 merely passes the abort signal INTO `execute()` and still
> awaits its promise, firing this budget must not rely on the SDK ending the
> stream — the consumer loop must iterate via `guardStream` (below) to escape
> a tool that ignores the signal.

`guardStream` solves the *consumer loop* getting stuck. It does nothing for
the *real process*: `execute()` never destructured the SDK's `abortSignal`,
and nothing was ever passed to `child_process.exec`. So once a
`tool-execution` (or any other) budget fires — or a run is aborted for any
other reason — the agent loop moves on and reports the run as timed out /
aborted, while the actual install or update command keeps running,
unsupervised, in the background.

## Reproduction

Not just theoretical — minimal, deterministic repro:

```ts
const controller = new AbortController();
const p = execAsync('node -e "setTimeout(() => {}, 10000)"', { timeout: 300_000 /* no signal */ });
setTimeout(() => controller.abort(), 400);
// 3+ seconds later, the process is still running — abort() had no effect.
```

```ts
const controller = new AbortController();
const p = execAsync('node -e "setTimeout(() => {}, 10000)"', { timeout: 300_000, signal: controller.signal });
setTimeout(() => controller.abort(), 400);
// ~50ms later, p rejects with ABORT_ERR — the process is actually killed.
```

Both cases are in the new test file, as the "aborted" case and an explicit
control case reproducing the current (pre-fix) behavior.

## Fix

Destructure `abortSignal` from `execute()`'s second parameter (the AI SDK's
`ToolCallOptions`, confirmed from `node_modules/ai`'s own `.d.ts`:
`abortSignal?: AbortSignal` on `ToolExecutionOptions`) and pass it through as
`signal` to `execAsync()` in both tools. `child_process.exec` has supported
an `AbortSignal`-based `signal` option since Node 15/16 — this wires an
already-existing signal through; it adds no new cancellation machinery.

When no timeout budget is configured, `native-timeout.ts`'s own documented
contract is "the controller arms no timers" — so `abortSignal` is simply
`undefined` in that case and `execAsync` behaves exactly as it does today.
Zero behavior change for the default, unconfigured path.

## Scope

Only the two `execAsync` call sites with a real, potentially long-running,
side-effecting command (install, update) are touched — 4 lines, 2 files.
The shorter read-only `exec`/`execFile` calls elsewhere in this file
(`--version` checks, `which`, `brew`/`npm outdated`, all capped 5-30s) are
intentionally left alone to keep this patch minimal and focused on the exact
bug class it fixes.

`cli-tools-mcp.ts` (the SDK Runtime's separate implementation — the two
files currently maintain independent `execAsync` call sites, despite this
file's own header comment describing itself as the "single source of
truth") has the same gap but is intentionally **not** touched here, same
scoping precedent #676 used for Native-Runtime-only changes.

**This is unrelated to #676** (deferred-execution-integrity — whether
`execute()` should run at all based on the surrounding stream's terminal
state). This fixes a different question: once `execute()` has legitimately
started, does aborting it actually stop the real side effect, or does it
just orphan it in the background. Both can land independently.

## Testing

- `src/__tests__/unit/cli-tools-abort-signal.test.ts` (new): 2/2 passing —
  `node --test src/__tests__/unit/cli-tools-abort-signal.test.ts`
  - `exec()` with a wired `signal` actually kills the process on abort
  - control case: `exec()` **without** a `signal` (today's behavior) — an
    aborted `AbortController` has no effect on the running command
- No existing test imports `builtin-tools/cli-tools.ts` directly (checked
  before writing this patch), so there's no prior coverage of this file to
  regress.
- Type verified directly against the installed `ai` package's `.d.ts`
  (`abortSignal?: AbortSignal` on `ToolExecutionOptions`) rather than
  assumed.
- `npx tsc --noEmit` (full project): clean, 0 errors. (This took a long
  first-run pass in my sandbox — took long enough that I initially posted
  this PR before it finished and said so; it has since completed cleanly,
  updating that note now rather than leaving a stale caveat in place.)

No unrelated changes.

